### PR TITLE
Improve serial port tolerance to corrupted frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ There is no binding level configuration required for the Z-Wave binding. All con
 
 #### Controller Is Master
 
+When *Controller Is Master* is true, the binding expects to be the main Z-Wave controller in the system. This is not related to the type of controller (*Primary* or *Secondary*), but is related to how devices will be configured.  This will instruct the binding to perform configuration of the device to send network related information such as device wakeup to the binding.
+
+Many functions in Z-Wave only allow a single node to be set, and this is normally reserved for the main system controller. For example, battery device *Wakeup Node*, and *Lifeline* association groups usually only allow a single device to be set.
+
+For most systems, this should be set to *true* - the only time when it would be *false* is if you normally control your Z-Wave network through a different system.
+
 #### Controller Is SUC
 
 #### Heal Time
@@ -47,6 +53,20 @@ There is no binding level configuration required for the Z-Wave binding. All con
 
 
 ## Channels
+
+### Controller Channels
+
+| Channel    | Description                                            |
+|------------|--------------------------------------------------------|
+| serial_sof | Counts number of frames started                        |
+| serial_ack | Counts number of frames acknowledged by the controller |
+| serial_nak | Counts number of frame rejected by the controller      |
+| serial_can | Counts number of frames cancelled by the controller    |
+| serial_oof | Counts number of bytes received out of frame flow      |
+| serial_cse | Counts number of frames received with checksum error   |
+
+### Device Channels
+
 
 ## Initialisation
 

--- a/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
+++ b/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
@@ -84,6 +84,7 @@ public class ZWaveBindingConstants {
     public final static String CHANNEL_SERIAL_NAK = "serial_nak";
     public final static String CHANNEL_SERIAL_CAN = "serial_can";
     public final static String CHANNEL_SERIAL_OOF = "serial_oof";
+    public final static String CHANNEL_SERIAL_CSE = "serial_cse";
 
     public final static String CHANNEL_CFG_BINDING = "binding";
     public final static String CHANNEL_CFG_COMMANDCLASS = "commandClass";

--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveSerialHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveSerialHandler.java
@@ -53,8 +53,9 @@ public class ZWaveSerialHandler extends ZWaveControllerHandler {
     private int NAKCount = 0;
     private int ACKCount = 0;
     private int OOFCount = 0;
+    private int CSECount = 0;
 
-    private static final int ZWAVE_RECEIVE_TIMEOUT = 1000;
+    private static final int SERIAL_RECEIVE_TIMEOUT = 250;
 
     private ZWaveReceiveThread receiveThread;
 
@@ -82,7 +83,7 @@ public class ZWaveSerialHandler extends ZWaveControllerHandler {
             serialPort.setSerialPortParams(115200, SerialPort.DATABITS_8, SerialPort.STOPBITS_1,
                     SerialPort.PARITY_NONE);
             serialPort.enableReceiveThreshold(1);
-            serialPort.enableReceiveTimeout(ZWAVE_RECEIVE_TIMEOUT);
+            serialPort.enableReceiveTimeout(SERIAL_RECEIVE_TIMEOUT);
             logger.debug("Starting receive thread");
             receiveThread = new ZWaveReceiveThread();
             receiveThread.start();
@@ -145,6 +146,15 @@ public class ZWaveSerialHandler extends ZWaveControllerHandler {
      */
     private class ZWaveReceiveThread extends Thread implements SerialPortEventListener {
 
+        private final int SEARCH_SOF = 0;
+        private final int SEARCH_LEN = 1;
+        private final int SEARCH_DAT = 2;
+
+        private int rxState = SEARCH_SOF;
+        private int messageLength;
+        private int rxLength;
+        private byte[] rxBuffer;
+
         private static final int SOF = 0x01;
         private static final int ACK = 0x06;
         private static final int NAK = 0x15;
@@ -199,7 +209,13 @@ public class ZWaveSerialHandler extends ZWaveControllerHandler {
                     try {
                         nextByte = serialPort.getInputStream().read();
 
+                        // If byte value is -1, this is a timeout
                         if (nextByte == -1) {
+                            if (rxState != SEARCH_SOF) {
+                                // If we're not searching for a new frame when we get a timeout, something bad happened
+                                logger.debug("Receive Timeout - Sending NAK");
+                                rxState = SEARCH_SOF;
+                            }
                             continue;
                         }
                     } catch (IOException e) {
@@ -207,91 +223,104 @@ public class ZWaveSerialHandler extends ZWaveControllerHandler {
                         break;
                     }
 
-                    switch (nextByte) {
-                        case SOF:
-                            // Keep track of statistics
-                            SOFCount++;
-                            updateState(new ChannelUID(getThing().getUID(), CHANNEL_SERIAL_SOF),
-                                    new DecimalType(SOFCount));
+                    switch (rxState) {
+                        case SEARCH_SOF:
+                            switch (nextByte) {
+                                case SOF:
+                                    logger.trace("Received SOF");
 
-                            int messageLength;
-                            try {
-                                messageLength = serialPort.getInputStream().read();
-                            } catch (IOException e) {
-                                logger.error("Got I/O exception {} during receiving. exiting thread.",
-                                        e.getLocalizedMessage());
+                                    // Keep track of statistics
+                                    SOFCount++;
+                                    updateState(new ChannelUID(getThing().getUID(), CHANNEL_SERIAL_SOF),
+                                            new DecimalType(SOFCount));
+                                    rxState = SEARCH_LEN;
+                                    break;
+
+                                case ACK:
+                                    // Keep track of statistics
+                                    ACKCount++;
+                                    updateState(new ChannelUID(getThing().getUID(), CHANNEL_SERIAL_ACK),
+                                            new DecimalType(ACKCount));
+                                    logger.trace("Received ACK");
+                                    break;
+
+                                case NAK:
+                                    // A NAK means the CRC was incorrectly received by the controller
+                                    NAKCount++;
+                                    updateState(new ChannelUID(getThing().getUID(), CHANNEL_SERIAL_NAK),
+                                            new DecimalType(NAKCount));
+                                    logger.debug("Protocol error (NAK), discarding");
+
+                                    // TODO: Add NAK processing
+                                    break;
+
+                                case CAN:
+                                    // The CAN means that the controller dropped the frame
+                                    CANCount++;
+                                    updateState(new ChannelUID(getThing().getUID(), CHANNEL_SERIAL_CAN),
+                                            new DecimalType(CANCount));
+                                    logger.debug("Protocol error (CAN), resending");
+
+                                    // TODO: Add CAN processing (Resend?)
+                                    break;
+
+                                default:
+                                    OOFCount++;
+                                    updateState(new ChannelUID(getThing().getUID(), CHANNEL_SERIAL_OOF),
+                                            new DecimalType(OOFCount));
+                                    logger.warn(String.format("Protocol error (OOF). Got 0x%02X.", nextByte));
+                                    // Let the timeout deal with sending the NAK
+                                    break;
+                            }
+                            break;
+
+                        case SEARCH_LEN:
+                            // Sanity check the frame length
+                            if (nextByte < 4 || nextByte > 64) {
+                                logger.debug("Frame length is out of limits ({})", nextByte);
 
                                 break;
                             }
+                            messageLength = (nextByte & 0xff) + 2;
 
-                            byte[] buffer = new byte[messageLength + 2];
-                            buffer[0] = SOF;
-                            buffer[1] = (byte) messageLength;
-                            int total = 0;
+                            rxBuffer = new byte[messageLength];
+                            rxBuffer[0] = SOF;
+                            rxBuffer[1] = (byte) nextByte;
+                            rxLength = 2;
+                            rxState = SEARCH_DAT;
+                            break;
 
-                            while (total < messageLength) {
-                                try {
-                                    int read = serialPort.getInputStream().read(buffer, total + 2,
-                                            messageLength - total);
-                                    total += (read > 0 ? read : 0);
-                                } catch (IOException e) {
-                                    logger.error("Got I/O exception {} during receiving. exiting thread.",
-                                            e.getLocalizedMessage());
-                                    return;
-                                }
+                        case SEARCH_DAT:
+                            rxBuffer[rxLength] = (byte) nextByte;
+                            rxLength++;
+
+                            if (rxLength < messageLength) {
+                                break;
                             }
 
-                            logger.debug("Receive Message = {}", SerialMessage.bb2hex(buffer));
-                            SerialMessage recvMessage = new SerialMessage(buffer);
+                            logger.debug("Receive Message = {}", SerialMessage.bb2hex(rxBuffer));
+                            SerialMessage recvMessage = new SerialMessage(rxBuffer);
                             if (recvMessage.isValid) {
                                 logger.trace("Message is valid, sending ACK");
                                 sendResponse(ACK);
 
                                 incomingMessage(recvMessage);
                             } else {
-                                logger.error("Message is invalid, discarding");
+                                CSECount++;
+                                updateState(new ChannelUID(getThing().getUID(), CHANNEL_SERIAL_CSE),
+                                        new DecimalType(CSECount));
+
+                                logger.debug("Message is invalid, discarding");
                                 sendResponse(NAK);
                             }
-                            break;
-                        case ACK:
-                            // Keep track of statistics
-                            ACKCount++;
-                            updateState(new ChannelUID(getThing().getUID(), CHANNEL_SERIAL_ACK),
-                                    new DecimalType(ACKCount));
-                            logger.trace("Received ACK");
-                            break;
-                        case NAK:
-                            NAKCount++;
-                            updateState(new ChannelUID(getThing().getUID(), CHANNEL_SERIAL_NAK),
-                                    new DecimalType(NAKCount));
-                            logger.error("Protocol error (NAK), discarding");
 
-                            // TODO: Add NAK processing
-                            break;
-                        case CAN:
-                            CANCount++;
-                            updateState(new ChannelUID(getThing().getUID(), CHANNEL_SERIAL_CAN),
-                                    new DecimalType(CANCount));
-                            logger.error("Protocol error (CAN), resending");
-                            try {
-                                Thread.sleep(100);
-                            } catch (InterruptedException e) {
-                                break;
-                            }
-
-                            // TODO: Add CAN processing (Resend?)
-                            break;
-                        default:
-                            OOFCount++;
-                            updateState(new ChannelUID(getThing().getUID(), CHANNEL_SERIAL_OOF),
-                                    new DecimalType(OOFCount));
-                            logger.warn(String.format("Protocol error (OOF). Got 0x%02X. Sending NAK.", nextByte));
-                            sendResponse(NAK);
+                            rxState = SEARCH_SOF;
                             break;
                     }
+
                 }
             } catch (Exception e) {
-                logger.error("Exception during ZWave thread: Receive {}", e);
+                logger.error("Exception during ZWave thread: Receive {}", e.getMessage());
             }
             logger.debug("Stopped ZWave thread: Receive");
 


### PR DESCRIPTION
This adds a state machine to the serial receive thread to avoid an endless wait if a byte is lost. This allows timeouts to be detected quickly and a NAK sent to the controller to get communications moving again.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>