### PR TITLE
Add support to statically set METER supported scales.

### DIFF
--- a/ESH-INF/thing/qubino_zmnhba_0_0.xml
+++ b/ESH-INF/thing/qubino_zmnhba_0_0.xml
@@ -14,7 +14,7 @@
       <channel id="switch_binary" typeId="switch_binary">
         <label>Switch</label>
         <properties>
-          <property name="binding:*:OnOffType">SWITCH_BINARY</property>
+          <property name="binding:*:OnOffType">SWITCH_BINARY,BASIC</property>
         </properties>
       </channel>
       <channel id="sensor_temperature" typeId="sensor_temperature">
@@ -80,6 +80,9 @@
       <property name="manufacturerId">0159</property>
       <property name="manufacturerRef">0002:0001</property>
       <property name="dbReference">208</property>
+      <property name="commandClass:METER">meterType=ELECTRIC,meterScale=E_W;E_KWh</property>
+      <property name="commandClass:METER:1">meterType=ELECTRIC,meterScale=E_W;E_KWh</property>
+      <property name="commandClass:METER:2">meterType=ELECTRIC,meterScale=E_W;E_KWh</property>
       <property name="defaultAssociations">3</property>
     </properties>
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMeterCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMeterCommandClass.java
@@ -238,7 +238,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
             meterType = MeterType.valueOf(options.get("meterType"));
             logger.debug("NODE {}: Set meter type {}", getNode().getNodeId(), meterType.getLabel());
 
-            List<String> scaleList = Arrays.asList(options.get("meterScale").split(","));
+            List<String> scaleList = Arrays.asList(options.get("meterScale").split(";"));
             for (String name : scaleList) {
                 MeterScale scale = MeterScale.valueOf(name);
                 logger.debug("NODE {}: Meter Scale {} = {}", getNode().getNodeId(), meterType.getLabel(),

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMeterCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMeterCommandClass.java
@@ -49,12 +49,14 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
     private static final Logger logger = LoggerFactory.getLogger(ZWaveMeterCommandClass.class);
     private static final int MAX_SUPPORTED_VERSION = 3;
 
-    private static final int METER_GET = 0x01;
-    private static final int METER_REPORT = 0x02;
+    // Version 1
+    private static final int METER_GET = 1;
+    private static final int METER_REPORT = 2;
+
     // Version 2 and 3
-    private static final int METER_SUPPORTED_GET = 0x03;
-    private static final int METER_SUPPORTED_REPORT = 0x04;
-    private static final int METER_RESET = 0x05;
+    private static final int METER_SUPPORTED_GET = 3;
+    private static final int METER_SUPPORTED_REPORT = 4;
+    private static final int METER_RESET = 5;
 
     private MeterType meterType = null;
     private final Set<MeterScale> meterScales = new HashSet<MeterScale>();

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -690,16 +690,23 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
                         if ("commandClass".equals(cmds[0]) == false) {
                             continue;
                         }
-                        String args[] = value.split("=");
 
-                        if ("ccRemove".equals(args[0])) {
+                        String options[] = value.split(",");
+
+                        Map<String, String> optionMap = new HashMap<String, String>(1);
+                        for (String option : options) {
+                            String args[] = option.split("=");
+                            optionMap.put(args[0], args[1]);
+                        }
+
+                        if (optionMap.containsKey("ccRemove")) {
                             // If we want to remove the class, then remove it!
 
                             // TODO: This will only remove the root nodes and ignores endpoint
                             // TODO: Do we need to search into multi_instance?
                             node.removeCommandClass(CommandClass.getCommandClass(cmds[1]));
                             logger.debug("NODE {}: Node advancer: UPDATE_DATABASE - removing {}", node.getNodeId(),
-                                    CommandClass.getCommandClass(args[0]).getLabel());
+                                    CommandClass.getCommandClass(optionMap.get("ccRemove")).getLabel());
                             continue;
                         }
 
@@ -710,20 +717,18 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
 
                         // If we found the command class, then set its options
                         if (zwaveClass != null) {
-                            Map<String, String> option = new HashMap<String, String>(1);
-                            option.put(args[0], args[1]);
-                            zwaveClass.setOptions(option);
+                            zwaveClass.setOptions(optionMap);
                             continue;
                         }
 
                         // Command class isn't found! Do we want to add it?
                         // TODO: Does this need to account for multiple endpoints!?!
-                        if ("ccAdd".equals(args[0])) {
-                            ZWaveCommandClass commandClass = ZWaveCommandClass
-                                    .getInstance(CommandClass.getCommandClass(args[0]).getKey(), node, controller);
+                        if (optionMap.containsKey("ccAdd")) {
+                            ZWaveCommandClass commandClass = ZWaveCommandClass.getInstance(
+                                    CommandClass.getCommandClass(optionMap.get("ccAdd")).getKey(), node, controller);
                             if (commandClass != null) {
                                 logger.debug("NODE {}: Node advancer: UPDATE_DATABASE - adding {}", node.getNodeId(),
-                                        CommandClass.getCommandClass(args[0]).getLabel());
+                                        CommandClass.getCommandClass(optionMap.get("ccAdd")).getLabel());
                                 node.addCommandClass(commandClass);
                             }
                         }

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveMeterCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveMeterCommandClassTest.java
@@ -91,7 +91,6 @@ public class ZWaveMeterCommandClassTest extends ZWaveCommandClassTest {
         options.put("meterCanReset", "true");
         cls.setOptions(options);
         msg = cls.getResetMessage();
-        byte[] x = msg.getMessageBuffer();
         assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
     }
 
@@ -115,5 +114,25 @@ public class ZWaveMeterCommandClassTest extends ZWaveCommandClassTest {
         cls.setVersion(1);
         msg = cls.getMessage(MeterScale.E_KWh);
         assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void setOptions() {
+        ZWaveMeterCommandClass cls = (ZWaveMeterCommandClass) getCommandClass(CommandClass.METER);
+
+        // Not supported in V1
+        assertEquals(0, cls.initialize(true).size());
+
+        // Get supported in V2
+        cls.setVersion(2);
+        assertEquals(1, cls.initialize(true).size());
+
+        Map<String, String> options = new HashMap<String, String>(2);
+        options.put("meterType", "ELECTRIC");
+        options.put("meterScale", "E_W");
+        cls.setOptions(options);
+
+        // Don't request if we've set the type and scale
+        assertEquals(0, cls.initialize(true).size());
     }
 }


### PR DESCRIPTION
Manually defining the meter type and scales will also prevent the binding from requesting the supported types since some devices don't appear to respond to it.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>