### PR TITLE
removed (wrong) state options for binary switches and fixed category

### DIFF
--- a/ESH-INF/thing/_channels.xml
+++ b/ESH-INF/thing/_channels.xml
@@ -645,14 +645,8 @@
     <channel-type id="switch_binary">
         <item-type>Switch</item-type>
         <label>Switch</label>
-        <description>Switch the light on and off</description>
-        <category>Light</category>
-        <state>
-            <options>
-                <option value="On">On</option>
-                <option value="Off">Off</option>
-            </options>
-        </state>
+        <description>Switch the power on and off</description>
+        <category>Switch</category>
     </channel-type>
 
     <!-- Brightness (Dimmer) Channel -->


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>