### PR TITLE
Update multi_instance_association to ensure src and dst endpoint aren't both 0

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -648,8 +648,9 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
                     // Is the new association still in the currentMembers list?
                     if (currentMembers.isAssociated(member.getNode(), member.getEndpoint()) == false) {
                         // No - so it needs to be added
-                        controllerHandler
-                                .sendData(node.setAssociation(groupIndex, member.getNode(), member.getEndpoint()));
+                        // TODO: This needs to handle the sending endpoint not being root.
+                        controllerHandler.sendData(
+                                node.setAssociation(null, groupIndex, member.getNode(), member.getEndpoint()));
                     }
                 }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -1006,10 +1006,25 @@ public class ZWaveNode {
         return null;
     }
 
-    public SerialMessage setAssociation(int groupId, int nodeId, int endpointId) {
+    /**
+     * Sets an association.
+     * This method chooses the appropriate association command class to use for the device
+     * and the endpoint.
+     *
+     * The ZWave spec requires that source and destination endpoints can't be 0, therefore
+     * if the device endpoint is the root node, and the receive endpoint is 0, we use the
+     * single instance command class, otherwise we use the multi instance class if it exists.
+     *
+     * @param endpoint the endpoint required to semd the reports
+     * @param groupId the group to be set
+     * @param nodeId the node to be set to report to (receive)
+     * @param endpointId the endpoint to be set to report to (receive)
+     * @return
+     */
+    public SerialMessage setAssociation(ZWaveEndpoint endpoint, int groupId, int nodeId, int endpointId) {
         ZWaveMultiAssociationCommandClass multiAssociationCommandClass = (ZWaveMultiAssociationCommandClass) getCommandClass(
                 CommandClass.MULTI_INSTANCE_ASSOCIATION);
-        if (multiAssociationCommandClass != null) {
+        if (endpoint == null && endpointId != 0 && multiAssociationCommandClass != null) {
             return multiAssociationCommandClass.setAssociationMessage(groupId, nodeId, endpointId);
         }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -906,7 +906,7 @@ public class ZWaveNodeInitStageAdvancer implements ZWaveEventListener {
                             logger.debug("NODE {}: Node advancer: SET_ASSOCIATION - Adding ASSOCIATION to group {}",
                                     node.getNodeId(), groupId);
                             // Set the association, and request the update so we confirm if it's set
-                            addToQueue(node.setAssociation(groupId, controller.getOwnNodeId(), 0));
+                            addToQueue(node.setAssociation(null, groupId, controller.getOwnNodeId(), 0));
                             addToQueue(node.getAssociation(groupId));
                         }
                     }

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/ZWaveNodeTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/ZWaveNodeTest.java
@@ -1,0 +1,43 @@
+package org.openhab.binding.zwave.test.internal.protocol;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
+import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAssociationCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiAssociationCommandClass;
+
+/**
+ * Test for {@link ZWaveNode}
+ *
+ * @author Chris Jackson - Initial contribution
+ *
+ */
+public class ZWaveNodeTest {
+    @Test
+    public void setAssociation() {
+        ZWaveController controller = null;
+        ZWaveEndpoint endpoint = null;
+        ZWaveNode node = new ZWaveNode(1, 2, controller);
+        node.addCommandClass(new ZWaveAssociationCommandClass(node, controller, endpoint));
+        node.addCommandClass(new ZWaveMultiAssociationCommandClass(node, controller, endpoint));
+
+        SerialMessage msg;
+        byte[] expectedResponse;
+
+        // Setting device endpoint null and receive endpoint 0 should use single instance
+        expectedResponse = new byte[] { 1, 11, 0, 19, 2, 4, -123, 1, 0, 5, 0, 0, 96 };
+        msg = node.setAssociation(null, 0, 5, 0);
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponse));
+
+        // Setting device endpoint null and receive endpoint 1 should use multi instance
+        expectedResponse = new byte[] { 1, 13, 0, 19, 2, 6, -114, 1, 0, 0, 5, 1, 0, 0, 110 };
+        msg = node.setAssociation(null, 0, 5, 1);
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponse));
+    }
+}

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveAssociationCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveAssociationCommandClassTest.java
@@ -33,7 +33,6 @@ public class ZWaveAssociationCommandClassTest extends ZWaveCommandClassTest {
         byte[] expectedResponseV1 = { 1, 10, 0, 19, 99, 3, -123, 2, 1, 0, 0, 0 };
         cls.setVersion(1);
         msg = cls.getAssociationMessage(1);
-        byte[] x = msg.getMessageBuffer();
         assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
     }
 
@@ -45,7 +44,6 @@ public class ZWaveAssociationCommandClassTest extends ZWaveCommandClassTest {
         byte[] expectedResponseV1 = { 1, 9, 0, 19, 99, 2, -123, 5, 0, 0, 4 };
         cls.setVersion(1);
         msg = cls.getGroupingsMessage();
-        byte[] x = msg.getMessageBuffer();
         assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
     }
 
@@ -57,7 +55,6 @@ public class ZWaveAssociationCommandClassTest extends ZWaveCommandClassTest {
         byte[] expectedResponseV1 = { 1, 11, 0, 19, 99, 4, -123, 4, 1, 1, 0, 0, 1 };
         cls.setVersion(1);
         msg = cls.removeAssociationMessage(1, 1);
-        byte[] x = msg.getMessageBuffer();
         assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
     }
 
@@ -69,7 +66,6 @@ public class ZWaveAssociationCommandClassTest extends ZWaveCommandClassTest {
         byte[] expectedResponseV1 = { 1, 11, 0, 19, 99, 4, -123, 1, 1, 1, 0, 0, 4 };
         cls.setVersion(1);
         msg = cls.setAssociationMessage(1, 1);
-        byte[] x = msg.getMessageBuffer();
         assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
     }
 }


### PR DESCRIPTION
Having both src and dest endpoints as 0 violates the protocol. It also probably causes devices that don't support multi_instance command class to send multi_instance messages with src and dest endpoint set to 0.

https://community.openhab.org/t/fibaro-wall-plug-switch-fgwpx102-101-power-reports-not-working/14398

Signed-off-by: Chris Jackson <chris@cd-jackson.com>