### PR TITLE
Add method to clear all nodes from an association group

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -654,6 +654,12 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
                     }
                 }
 
+                // If there are no known associations in the group, then let's clear the group completely
+                // This ensures we don't end up with strange ghost associations
+                if (node.getAssociationGroup(groupIndex).getAssociationCnt() == 0) {
+                    controllerHandler.sendData(node.clearAssociation(groupIndex));
+                }
+
                 // Request an update to the association group
                 controllerHandler.sendData(node.getAssociation(groupIndex));
                 pendingCfg.put(configurationParameter.getKey(), valueObject);

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -1053,6 +1053,22 @@ public class ZWaveNode {
         return null;
     }
 
+    public SerialMessage clearAssociation(Integer groupId) {
+        ZWaveMultiAssociationCommandClass multiAssociationCommandClass = (ZWaveMultiAssociationCommandClass) getCommandClass(
+                CommandClass.MULTI_INSTANCE_ASSOCIATION);
+        if (multiAssociationCommandClass != null) {
+            return multiAssociationCommandClass.clearAssociationMessage(groupId);
+        }
+
+        ZWaveAssociationCommandClass associationCommandClass = (ZWaveAssociationCommandClass) getCommandClass(
+                CommandClass.ASSOCIATION);
+        if (associationCommandClass != null) {
+            return associationCommandClass.clearAssociationMessage(groupId);
+        }
+
+        return null;
+    }
+
     // public void setFactoryId(String deviceFactoryId) {
     // this.deviceFactoryId = deviceFactoryId;
     // }

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAssociationCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAssociationCommandClass.java
@@ -40,6 +40,8 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass implements Z
     @XStreamOmitField
     private static final Logger logger = LoggerFactory.getLogger(ZWaveAssociationCommandClass.class);
 
+    private static final int MAX_SUPPORTED_VERSION = 2;
+
     private static final int ASSOCIATIONCMD_SET = 1;
     private static final int ASSOCIATIONCMD_GET = 2;
     private static final int ASSOCIATIONCMD_REPORT = 3;
@@ -71,6 +73,7 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass implements Z
      */
     public ZWaveAssociationCommandClass(ZWaveNode node, ZWaveController controller, ZWaveEndpoint endpoint) {
         super(node, controller, endpoint);
+        versionMax = MAX_SUPPORTED_VERSION;
     }
 
     /**
@@ -274,6 +277,32 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass implements Z
         outputData.write(ASSOCIATIONCMD_REMOVE);
         outputData.write(group);
         outputData.write(node);
+
+        result.setMessagePayload(outputData.toByteArray());
+        return result;
+    }
+
+    /**
+     * Gets a SerialMessage with the ASSOCIATIONCMD_REMOVE command
+     *
+     * @param group
+     *            the association group
+     * @param node
+     *            the node to add to the specified group
+     * @return the serial message
+     */
+    public SerialMessage clearAssociationMessage(int group) {
+        logger.debug("NODE {}: Creating new message for application command ASSOCIATIONCMD_REMOVE group={}, node=all",
+                getNode().getNodeId(), group);
+        SerialMessage result = new SerialMessage(getNode().getNodeId(), SerialMessageClass.SendData,
+                SerialMessageType.Request, SerialMessageClass.SendData, SerialMessagePriority.Config);
+
+        ByteArrayOutputStream outputData = new ByteArrayOutputStream();
+        outputData.write(getNode().getNodeId());
+        outputData.write(3);
+        outputData.write(getCommandClass().getKey());
+        outputData.write(ASSOCIATIONCMD_REMOVE);
+        outputData.write(group);
 
         result.setMessagePayload(outputData.toByteArray());
         return result;

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveAssociationCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveAssociationCommandClassTest.java
@@ -59,6 +59,17 @@ public class ZWaveAssociationCommandClassTest extends ZWaveCommandClassTest {
     }
 
     @Test
+    public void clearAssociationMessage() {
+        ZWaveAssociationCommandClass cls = (ZWaveAssociationCommandClass) getCommandClass(CommandClass.ASSOCIATION);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 10, 0, 19, 99, 3, -123, 4, 1, 0, 0, 6 };
+        cls.setVersion(1);
+        msg = cls.clearAssociationMessage(1);
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
     public void setAssociationMessage() {
         ZWaveAssociationCommandClass cls = (ZWaveAssociationCommandClass) getCommandClass(CommandClass.ASSOCIATION);
         SerialMessage msg;

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveMultiAssociationCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveMultiAssociationCommandClassTest.java
@@ -73,7 +73,35 @@ public class ZWaveMultiAssociationCommandClassTest extends ZWaveCommandClassTest
     }
 
     @Test
-    public void setAssociationMessage() {
+    public void clearAssociationMessage() {
+        ZWaveMultiAssociationCommandClass cls = (ZWaveMultiAssociationCommandClass) getCommandClass(
+                CommandClass.MULTI_INSTANCE_ASSOCIATION);
+        SerialMessage msg;
+
+        byte[] expectedResponseV1 = { 1, 10, 0, 19, 99, 3, -114, 4, 1, 0, 0, 13 };
+        cls.setVersion(1);
+        msg = cls.clearAssociationMessage(1);
+        byte[] x = msg.getMessageBuffer();
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void setAssociationMessageV2() {
+        ZWaveMultiAssociationCommandClass cls = (ZWaveMultiAssociationCommandClass) getCommandClass(
+                CommandClass.MULTI_INSTANCE_ASSOCIATION);
+        SerialMessage msg;
+
+        // Version 2 doesn't allow endpoint 0 to be set
+        byte[] expectedResponse2 = { 1, 11, 0, 19, 99, 4, -114, 1, 1, 2, 0, 4, 8 };
+
+        cls.setVersion(1);
+        msg = cls.setAssociationMessage(1, 2, 0);
+        msg.setCallbackId(4);
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponse2));
+    }
+
+    @Test
+    public void setAssociationMessageV3() {
         ZWaveMultiAssociationCommandClass cls = (ZWaveMultiAssociationCommandClass) getCommandClass(
                 CommandClass.MULTI_INSTANCE_ASSOCIATION);
         SerialMessage msg;
@@ -81,7 +109,7 @@ public class ZWaveMultiAssociationCommandClassTest extends ZWaveCommandClassTest
         byte[] expectedResponse1 = { 1, 13, 0, 19, 99, 6, -114, 1, 1, 0, 2, 0, 0, 4, 12 };
         byte[] expectedResponse2 = { 1, 13, 0, 19, 99, 6, -114, 1, 1, 0, 2, 3, 0, 4, 15 };
 
-        cls.setVersion(1);
+        cls.setVersion(3);
         msg = cls.setAssociationMessage(1, 2, 0);
         msg.setCallbackId(4);
         assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponse1));


### PR DESCRIPTION
Adds method to clear all nodes/endpoints from association groups - to remove those stubborn nodes!
Signed-off-by: Chris Jackson <chris@cd-jackson.com>