### PR TITLE
Support for Gateway Controllers

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveDeviceClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveDeviceClass.java
@@ -379,7 +379,7 @@ public class ZWaveDeviceClass {
         SET_TOP_BOX_CONTROLLER(4, Generic.STATIC_CONTROLLER, "Set-Top Box Controller"),
         SUB_SYSTEM_CONTROLLER(4, Generic.STATIC_CONTROLLER, "Sub-System Controller"),
         TV_CONTROLLER(6, Generic.STATIC_CONTROLLER, "TV Controller"),
-        GATEWAY_CONTROLLER(7, Generic.STATIC_CONTROLLER, "Gateway Controller"),
+        SPECIFIC_TYPE_GATEWAY(7, Generic.STATIC_CONTROLLER, "Gateway"),
 
         SATELLITE_RECEIVER(4, Generic.AV_CONTROL_POINT, "Satellite Receiver"),
         SATELLITE_RECEIVER_V2(17, Generic.AV_CONTROL_POINT, "Satellite Receiver V2"),
@@ -615,7 +615,7 @@ public class ZWaveDeviceClass {
                     return new CommandClass[] { CommandClass.SECURITY, CommandClass.MANUFACTURER_SPECIFIC,
                             CommandClass.DOOR_LOCK, CommandClass.USER_CODE, CommandClass.VERSION };
 
-                case GATEWAY_CONTROLLER:
+                case SPECIFIC_TYPE_GATEWAY:
                     return new CommandClass[] { CommandClass.VERSION, CommandClass.MANUFACTURER_SPECIFIC,
                                                 CommandClass.SECURITY };
                 default:

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveDeviceClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveDeviceClass.java
@@ -379,6 +379,7 @@ public class ZWaveDeviceClass {
         SET_TOP_BOX_CONTROLLER(4, Generic.STATIC_CONTROLLER, "Set-Top Box Controller"),
         SUB_SYSTEM_CONTROLLER(4, Generic.STATIC_CONTROLLER, "Sub-System Controller"),
         TV_CONTROLLER(6, Generic.STATIC_CONTROLLER, "TV Controller"),
+        GATEWAY_CONTROLLER(7, Generic.STATIC_CONTROLLER, "Gateway Controller"),
 
         SATELLITE_RECEIVER(4, Generic.AV_CONTROL_POINT, "Satellite Receiver"),
         SATELLITE_RECEIVER_V2(17, Generic.AV_CONTROL_POINT, "Satellite Receiver V2"),
@@ -614,6 +615,9 @@ public class ZWaveDeviceClass {
                     return new CommandClass[] { CommandClass.SECURITY, CommandClass.MANUFACTURER_SPECIFIC,
                             CommandClass.DOOR_LOCK, CommandClass.USER_CODE, CommandClass.VERSION };
 
+                case GATEWAY_CONTROLLER:
+                    return new CommandClass[] { CommandClass.VERSION, CommandClass.MANUFACTURER_SPECIFIC,
+                                                CommandClass.SECURITY };
                 default:
                     return new CommandClass[0];
             }


### PR DESCRIPTION
This pull request adds support for static controller type 0x7, "Gateway Controller".  That's what my Wink Hub reports itself as; without this addition, OpenHAB wouldn't even communicate with the Wink Hub.

Signed-off-by: Phil! Gold <phil_g@pobox.com> (github: asciiphil)