### PR TITLE
removed bridgeHandlerInitialized method as it has been removed in the ESH API

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -410,13 +410,6 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
     }
 
     @Override
-    public void bridgeHandlerInitialized(ThingHandler thingHandler, Bridge bridge) {
-        logger.debug("NODE {}: Controller initialised.", nodeId);
-
-        bridgeStatusChanged(bridge.getStatusInfo());
-    }
-
-    @Override
     public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
         logger.debug("NODE {}: Controller status changed to {}.", nodeId, bridgeStatusInfo.getStatus());
 


### PR DESCRIPTION
See https://github.com/eclipse/smarthome/pull/2087 and https://github.com/openhab/openhab2-addons/pull/1394

Signed-off-by: Kai Kreuzer <kai@openhab.org>