### PR TITLE
Fibaro gen five model update

### DIFF
--- a/ESH-INF/thing/fibaro_fgfs101_3_2.xml
+++ b/ESH-INF/thing/fibaro_fgfs101_3_2.xml
@@ -59,7 +59,7 @@
       <property name="vendor">Fibargroup</property>
       <property name="modelId">FGFS101</property>
       <property name="manufacturerId">010F</property>
-      <property name="manufacturerRef">0B00:1001,0B01:1002</property>
+      <property name="manufacturerRef">0B00:1001,0B01:1002,0B01:2002</property>
       <property name="versionMin">3.2</property>
       <property name="versionMax">25.0</property>
       <property name="dbReference">392</property>

--- a/ESH-INF/thing/fibaro_fgpb101_0_0.xml
+++ b/ESH-INF/thing/fibaro_fgpb101_0_0.xml
@@ -35,7 +35,7 @@
       <property name="vendor">Fibargroup</property>
       <property name="modelId">FGPB101</property>
       <property name="manufacturerId">010F</property>
-      <property name="manufacturerRef">0F01:1000,FB10:1014</property>
+      <property name="manufacturerRef">0F01:1000,0F01:2000,FB10:1014</property>
       <property name="dbReference">436</property>
       <property name="defaultAssociations">1</property>
     </properties>


### PR DESCRIPTION
Added the gen five ProductId to the Fibaro FGFS101 and FGPB101.

Fixes #250
Signed-off-by: Andy Lintner <dev@beowulfe.com> (github: beowulfe)