### PR TITLE
Added the Devolo MT2756 flood sensor

### DIFF
--- a/ESH-INF/thing/devolo_mt2756_0_0.xml
+++ b/ESH-INF/thing/devolo_mt2756_0_0.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zwave"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+  xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0
+                      http://eclipse.org/smarthome/schemas/thing-description/v1.0.0">
+
+  <thing-type id="devolo_mt2756_00_000" listed="false">
+    <label>MT2756 Flood Sensor</label>
+    <description>Flood Sensor</description>
+
+    <!-- CHANNEL DEFINITIONS -->
+    <channels>
+      <channel id="sensor_binary" typeId="sensor_binary">
+        <label>Binary Sensor</label>
+        <properties>
+          <property name="binding:*:OnOffType">SENSOR_BINARY</property>
+        </properties>
+      </channel>
+      <channel id="alarm_flood" typeId="alarm_flood">
+        <label>Alarm (flood)</label>
+        <properties>
+          <property name="binding:*:OnOffType">ALARM;type=FLOOD</property>
+        </properties>
+      </channel>
+      <channel id="alarm_burglar" typeId="alarm_burglar">
+        <label>Alarm (burglar)</label>
+        <properties>
+          <property name="binding:*:OnOffType">ALARM;type=BURGLAR</property>
+        </properties>
+      </channel>
+      <channel id="battery-level" typeId="system.battery-level">
+        <properties>
+          <property name="binding:*:PercentType">BATTERY</property>
+        </properties>
+      </channel>
+    </channels>
+
+    <!-- DEVICE PROPERTY DEFINITIONS -->
+    <properties>
+      <property name="vendor">Devolo</property>
+      <property name="modelId">MT2756</property>
+      <property name="manufacturerId">0175</property>
+      <property name="manufacturerRef">0002:0021</property>
+      <property name="versionMin">1.11</property>
+      <property name="versionMax">1.11</property>
+      <property name="dbReference">178</property>
+      <property name="defaultAssociations">1</property>
+    </properties>
+
+    <!-- CONFIGURATION DESCRIPTIONS -->
+    <config-description>
+
+      <!-- PARAMETER DEFINITIONS -->
+      <parameter-group name="configuration">
+        <context>setup</context>
+        <label>Configuration Parameters</label>
+      </parameter-group>
+
+      <parameter name="config_1_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>1: Basic Set OFF Level</label>
+        <description><![CDATA[
+Setting the BASIC command value<br /><ul><li>When the flood trigger off(0x00), send the BASIC CC to the group 2</li></ul>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_2_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>2: Basic Set ON Level</label>
+        <description><![CDATA[
+Setting the BASIC command value<br /><ul><li>When the flood trigger on(0xFF), send the BASIC CC to the group 2</li></ul>
+        ]]></description>
+        <default>255</default>
+      </parameter>
+
+      <parameter name="config_5_1" type="integer" groupName="configuration">
+        <label>5: Disable the Flood function</label>
+        <description><![CDATA[
+Operation mode<br /><ul><li>0: Flood function is enabled</li> <li>1: Flood function is disabled</li></ul>
+        ]]></description>
+        <default>0</default>
+        <options>
+          <option value="0">Flood function is enabled</option>
+          <option value="1">Flood function is disabled</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_7_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>7: Customer Function</label>
+        <description><![CDATA[
+Parameter to set the sensor functions<br /><ul><li>Bit 0: Reserve</li> <li>Bit 1: Reserve</li> <li>Bit 2: Reserve</li> <li>Bit 3: Disable send out BASIC OFF after the flood event cleared </li></ul>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_10_1" type="integer" groupName="configuration"
+                 min="0" max="127">
+        <label>10: Auto Report Battery Time</label>
+        <description><![CDATA[
+The interval time for auto reporting the battery level<br /><ul><li>0 = Turn off auto report battery.</li> <li>1-127 = Number of ticks. The default value is 12. The tick time can be set by configuration No. 20.</li></ul>
+        ]]></description>
+        <default>12</default>
+      </parameter>
+
+      <parameter name="config_15_1" type="integer" groupName="configuration"
+                 min="0" max="127">
+        <label>15: Auto Report Flood Time</label>
+        <description><![CDATA[
+The interval time for auto report the flood state<br /><ul><li>0 = Turn off auto report</li> <li>1-127 = Number of ticks. The default value is 12. The tick time can be set by configuration No. 20.</li></ul>
+        ]]></description>
+        <default>12</default>
+      </parameter>
+
+      <parameter name="config_20_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>20: Auto Report Tick Interval</label>
+        <description><![CDATA[
+The interval time for auto reporting each tick.<br /><ul><li>0 = Turn off all auto report function.</li> <li>1-255 = Number of ticks. Setting this configuration will effect configuration Nr. 10 and No. 15.</li></ul>
+        ]]></description>
+        <default>30</default>
+      </parameter>
+
+      <!-- ASSOCIATION DEFINITIONS -->
+      <parameter-group name="association">
+        <context>link</context>
+        <label>Association Groups</label>
+      </parameter-group>
+
+      <parameter name="group_1" type="text" groupName="association" multiple="true">
+        <label>1: Reports</label>
+        <multipleLimit>8</multipleLimit>
+      </parameter>
+
+      <parameter name="group_2" type="text" groupName="association" multiple="true">
+        <label>2: Light Control</label>
+        <multipleLimit>8</multipleLimit>
+      </parameter>
+
+    </config-description>
+
+  </thing-type>
+
+</thing:thing-descriptions>


### PR DESCRIPTION
Dear Chris,

I've tried to add the MT2756 flood sensor as discussed in this thread:

https://community.openhab.org/t/devolo-flood-sensor-doesnt-seem-to-be-in-the-z-wave-database/18638/5

I hope I got it about right, I haven't been sure what to put in the "dbReference" reference field (so I left it the way it was for the PAT02c).

Thanks again for your help :-)!

Greetings,
Julian