### PR TITLE
updated to recent dependencies to make gnu.io package available again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <!-- openHAB dependencies p2 repository -->
         <repository>
             <id>p2-openhab-deps-repo</id>
-            <url>https://dl.bintray.com/openhab/p2/openhab-deps-repo/1.0.6</url>
+            <url>https://dl.bintray.com/openhab/p2/openhab-deps-repo/1.0.10</url>
             <layout>p2</layout>
         </repository>
     </repositories>


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>