### PR TITLE
Zipato MINI KEYPAD RFiD/ZWAVE: change alarm_access to notification_ac…

### DIFF
--- a/ESH-INF/thing/wintop_wtrfid_0_0.xml
+++ b/ESH-INF/thing/wintop_wtrfid_0_0.xml
@@ -23,10 +23,10 @@
           <property name="binding:*:OnOffType">ALARM;type=BURGLAR</property>
         </properties>
       </channel>
-      <channel id="alarm_access" typeId="alarm_access">
+      <channel id="notification_access_control" typeId="notification_access_control">
         <label>Alarm (access)</label>
         <properties>
-          <property name="binding:*:OnOffType">ALARM;type=ACCESS_CONTROL</property>
+          <property name="binding:*:DecimalType">type=ACCESS_CONTROL</property>
         </properties>
       </channel>
       <channel id="battery-level" typeId="system.battery-level">


### PR DESCRIPTION
Hi Chris, as discussed here: https://community.openhab.org/t/wtrfid-mini-keypad-rfid-z-wave/19014/27 
I changed the channel and tested it locally, the channel is updated properly when pressing the buttons.

Regards, Christian