### PR TITLE
Update polling

### DIFF
--- a/ESH-INF/thing/act_zrm230_0_0.xml
+++ b/ESH-INF/thing/act_zrm230_0_0.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zwave"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+  xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0
+                      http://eclipse.org/smarthome/schemas/thing-description/v1.0.0">
+
+  <thing-type id="act_zrm230_00_000" listed="false">
+    <label>ZRM230 Wall Switch/Transmitter (2-gang)</label>
+    <description><![CDATA[
+Wall Switch/Transmitter (2-gang)<br /><h1>Overview</h1><p>Radio Frequency Controlled, 6A, 230 VAC, European Wall Mounted 3-Way Switch, Dual Switch, Release 1.1  </p> <p>The ZRM230 Wall Mounted 3-Way Switch is a component of the HomePro lighting control system. This Wall Mounted Switch is designed to work with other Z-Wave enabled devices. Z-Wave nodes of other types can be added to the system and will also act as repeaters if they support this function of repeating the signal received to other modules in the system.  </p> <br /><h2>Inclusion Information</h2><p>Including to the Network (Must be installed in permanent location, not on test bench).<br />1. Setup the controller you are using to include a device into network.<br />2. Tap either the top or bottom of the left switch once  </p> <br /><h2>Exclusion Information</h2><p>1. Setup the controller you are using to exclude a device from the network.<br />2. Tap either the top or the bottom of the left switch once.  </p>
+    ]]></description>
+
+    <!-- CHANNEL DEFINITIONS -->
+    <channels>
+    </channels>
+
+    <!-- DEVICE PROPERTY DEFINITIONS -->
+    <properties>
+      <property name="vendor">ACT - Advanced Control Technologies</property>
+      <property name="modelId">ZRM230</property>
+      <property name="manufacturerId">0001</property>
+      <property name="manufacturerRef">524D:3330</property>
+      <property name="dbReference">188</property>
+      <property name="defaultAssociations">4</property>
+    </properties>
+
+    <!-- CONFIGURATION DESCRIPTIONS -->
+    <config-description>
+
+      <!-- PARAMETER DEFINITIONS -->
+      <parameter-group name="configuration">
+        <context>setup</context>
+        <label>Configuration Parameters</label>
+      </parameter-group>
+
+      <parameter name="config_1_1" type="integer" groupName="configuration">
+        <label>1: Ignore start level</label>
+        <description><![CDATA[
+Set ignore start level bit when transmitting dim commands.<br /><h1>Overview</h1><p>The ZRM230 can send Dim commands to Z-Wave enabled dimmers. The Dim command has a start level embedded in it. A dimmer receiving this command will start dimming from that start level. However, the command also has a bit that indicates whether the dimmer should ignore the start level. If the bit is set to 1, the dimmer will ignore the start level and instead start dimming from its current level. If this bit is set to 0, the dimmer will ignore the start level.</p>
+        ]]></description>
+        <default>1</default>
+        <options>
+          <option value="0">Ignore start level</option>
+          <option value="1">Do not ignore start level</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_2_1" type="integer" groupName="configuration">
+        <label>2: Suspend Group 4</label>
+        <description><![CDATA[
+Disable transmitting commands to group 4 devices.<br /><h1>Overview</h1><p>You may wish to disable transmitting commands to Z-Wave devices that are in Group 4 without “disassociating” those devices from the group. Setting parameter 2 to the value of 1 will stop the ZRM230 from transmitting todevices that are “associated” into Group 4.</p>
+        ]]></description>
+        <default>0</default>
+        <options>
+          <option value="0">Transmit to group 4 devices</option>
+          <option value="1">Stop transmit to group 4 devices</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_3_1" type="integer" groupName="configuration">
+        <label>3: Night Light</label>
+        <description><![CDATA[
+LED behaviour of the ZRM230.<br /><h1>Overview</h1><p>The LED on the ZRM230 will by default, turn ON when the load attached is turned ON. To make the LED turn ON when the load attached is turned OFF instead, set parameter 3 to a value of 1.</p>
+        ]]></description>
+        <default>0</default>
+        <options>
+          <option value="0">Led when load on</option>
+          <option value="1">Led when load off</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_4_1" type="integer" groupName="configuration">
+        <label>4: Invert Switch</label>
+        <description><![CDATA[
+Switch (paddle) behaviour.<br /><h1>Overview</h1><p>To change the top of the switch to OFF and the bottom of the switch ON , set parameter 4 to 1. Note: If you invert the switches and also install the product upside down, remember the load will now be controlled by the right, not the left switch.</p>
+        ]]></description>
+        <default>0</default>
+        <options>
+          <option value="0">Invert off</option>
+          <option value="1">Invert on</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_14_1" type="integer" groupName="configuration"
+                 min="0" max="1">
+        <label>14: Enable Shade Control Group 2</label>
+        <description><![CDATA[
+Operate shade control devices on group 2.<br /><h1>Overview</h1><p>The ZRM230 can operate shade control devices via its group 2 if this configuration parameter is set to 1. </p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_15_1" type="integer" groupName="configuration"
+                 min="0" max="1">
+        <label>15: Enable Shade Control Group 3</label>
+        <description><![CDATA[
+Operate shade control devices on group 3.<br /><h1>Overview</h1><p>The ZRM230 can operate shade control devices via its group 3 if this configuration parameter is set to 1. </p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_19_1" type="integer" groupName="configuration">
+        <label>19: LED Transmission Indication</label>
+        <description><![CDATA[
+Z-Wave transmission LED settings.<br /><h1>Overview</h1><p>The ZRM230 will flicker its LED when it is transmitting to any of its 4 groups. This flickering can be set to notflicker at all (set to 0), to flicker the entire time it is transmitting (set to 1), or to flicker for only 1 second when it begins transmitting (set to 2). By default, the ZRM230 is set to flicker for only 1 second.  </p>
+        ]]></description>
+        <default>2</default>
+        <options>
+          <option value="0">No flicker</option>
+          <option value="1">Flicker for 1 second</option>
+          <option value="2">Flicker for 2 second</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_20_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>20: Poll Group 2 Interval</label>
+        <description><![CDATA[
+Poll Group 2 interval (minutes).<br /><h1>Overview</h1><p>Poll Group 2 Interval (minutes), valid values = 1 through 255 (Default value is 2).</p>
+        ]]></description>
+        <default>2</default>
+      </parameter>
+
+      <parameter name="config_22_1" type="integer" groupName="configuration"
+                 min="0" max="1">
+        <label>22: Poll Group 2</label>
+        <description><![CDATA[
+Group 2 poll control.<br /><h1>Overview</h1><p>Poll Group 2, if value is 1, the ZRM230 will poll group 2 at the interval set in configuration Parameter 20.</p>
+        ]]></description>
+        <default>1</default>
+      </parameter>
+
+      <!-- ASSOCIATION DEFINITIONS -->
+      <parameter-group name="association">
+        <context>link</context>
+        <label>Association Groups</label>
+      </parameter-group>
+
+      <parameter name="group_1" type="text" groupName="association" multiple="true">
+        <label>1: Left paddle (relais)</label>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+      <parameter name="group_2" type="text" groupName="association" multiple="true">
+        <label>2: Right paddle</label>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+      <parameter name="group_3" type="text" groupName="association" multiple="true">
+        <label>3: Right double click paddle</label>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+      <parameter name="group_4" type="text" groupName="association" multiple="true">
+        <label>4: Controller updates</label>
+        <description>Group used to inform devices about the updates of the status of the device.</description>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+    </config-description>
+
+  </thing-type>
+
+</thing:thing-descriptions>

--- a/ESH-INF/thing/act_ztm230_0_0.xml
+++ b/ESH-INF/thing/act_ztm230_0_0.xml
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zwave"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+  xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0
+                      http://eclipse.org/smarthome/schemas/thing-description/v1.0.0">
+
+  <thing-type id="act_ztm230_00_000" listed="false">
+    <label>ZTM230 Dual paddle wall mounted transmitter</label>
+    <description><![CDATA[
+Dual paddle wall mounted transmitter<br /><h1>Overview</h1><p>The ZTM230 Wall Mounted Transmitter is a component of the HomePro lighting control system. Wire the Transmitter anywhere power is available according to the diagram above and program from the Wireless Controller to operate loads. Inclusion of the ZTM230 Wall Mounted Transmitter on the ZTH200 Wireless Controller menu allows remote ON/OFF control and dimming of lights controlled by associated modules, as it does not control any electrical load directly.</p> <p>This Wall Mounted Transmitter is designed to work with other Z-Wave enabled devices. Z-Wave nodes of other types can be Included in the network and will also act as repeaters to increase the range of the network.  </p> <br /><h2>Inclusion Information</h2><p>Including to the Network (Must be installed in its permanent location, not on test bench)<br />1. Setup the controller you are using to include the device into the network.<br />2. Tap the top or bottom of the left switch once  </p> <br /><h2>Exclusion Information</h2><p>1. Setup the controller you are using to exclude a device from the network.<br />2. Tap the top or the bottom of the left switch once.  </p>
+    ]]></description>
+
+    <!-- CHANNEL DEFINITIONS -->
+    <channels>
+      <channel id="switch_binary" typeId="switch_binary">
+        <label>Switch</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_SWITCH_BINARY</property>
+        </properties>
+      </channel>
+      <channel id="switch_dimmer" typeId="switch_dimmer">
+        <label>Dimmer</label>
+        <properties>
+          <property name="binding:*:PercentType">COMMAND_CLASS_SWITCH_MULTILEVEL</property>
+          <property name="binding:Command:OnOffType">COMMAND_CLASS_SWITCH_MULTILEVEL</property>
+        </properties>
+      </channel>
+    </channels>
+
+    <!-- DEVICE PROPERTY DEFINITIONS -->
+    <properties>
+      <property name="vendor">ACT - Advanced Control Technologies</property>
+      <property name="modelId">ZTM230</property>
+      <property name="manufacturerId">0001</property>
+      <property name="manufacturerRef">544D:3330</property>
+      <property name="dbReference">524</property>
+    </properties>
+
+    <!-- CONFIGURATION DESCRIPTIONS -->
+    <config-description>
+
+      <!-- PARAMETER DEFINITIONS -->
+      <parameter-group name="configuration">
+        <context>setup</context>
+        <label>Configuration Parameters</label>
+      </parameter-group>
+
+      <parameter name="config_1_1" type="integer" groupName="configuration">
+        <label>1: Ignore Start Level Bit</label>
+        <description><![CDATA[
+Set Ignore Start Level Bit When Transmitting Dim Commands<br /><h1>Overview</h1><p>The ZTM230 can send Dim commands to Z-Wave enabled dimmers. The Dim command has a start level embedded in it. A dimmer receiving this command will start dimming from that start level. However, the command can be sent so that the dimmer ignores the start level and instead start dimming from its current level. By default, the ZTM230 sends the command so that the dimmer will start dimming from its current dim level rather then the start level embedded in the command. To change this, simply set the configuration parameter above to 0.  </p>
+        ]]></description>
+        <default>1</default>
+        <options>
+          <option value="0">Do not ignore start level</option>
+          <option value="1">Ignore start level</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_2_1" type="integer" groupName="configuration"
+                 min="0" max="1">
+        <label>2: Suspend Group 4</label>
+        <description><![CDATA[
+Disable transmitting commands to group 4 devices.<br /><h1>Overview</h1><p>You may wish to disable transmitting commands to Z-Wave devices that are in Group 4 without “disassociating” those devices from the group.<br />Setting parameter 2 to the value of 1 will stop the ZTM230 from transmitting to devices that are “associated” into Group 4  </p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_3_1" type="integer" groupName="configuration"
+                 min="0" max="1">
+        <label>3: Night Light</label>
+        <description><![CDATA[
+LED behaviour of the ZTM230.<br /><h1>Overview</h1><p>The LED on the ZTM230, will by default, turn ON when the status of the devices in Group 1 is ON. To make the LED turn ON when the status of Group 1 is OFF set this parameter to a value of 1.  </p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_4_1" type="integer" groupName="configuration"
+                 min="0" max="1">
+        <label>4: Invert Switch</label>
+        <description><![CDATA[
+Switch paddle behaviour<br /><h1>Overview</h1><p>To change the top of the transmitter to OFF and the bottom of the transmitter to ON, set parameter 4 to 1. To change back to original settings, set this parameter to the value of 0.  </p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_5_1" type="integer" groupName="configuration"
+                 min="0" max="1">
+        <label>5: Ignore Start Level Bit</label>
+        <description><![CDATA[
+Ignore Start Level When Receiving Dim Commands<br /><h1>Overview</h1><p>The ZTM230 can send Dim commands to Z-Wave enabled dimmers. The Dim command has a start level embedded in it. A dimmer receiving this command will start dimming from that start level. However, the command can be sent so that the dimmer ignores the start level and instead start dimming from its current level. By default, the ZTM230 sends the command so that the dimmer will start dimming from its current dim level rather then the start level embedded in the command. To change this, simply set the configuration parameter above to 0</p> <p><strong>Note that this only affects a level that is reported or possibly sent by the ZTM230 since the ZTM230 does not control a load.</strong></p>
+        ]]></description>
+        <default>1</default>
+      </parameter>
+
+      <parameter name="config_7_1" type="integer" groupName="configuration"
+                 min="1" max="99">
+        <label>7: On/Off Command dim step</label>
+        <description><![CDATA[
+Dim step parameter<br /><h1>Overview</h1><p>Dim step (dim rate) parameter. It can be set to a value of 1 to 99. This value indicates how many levels the dimmer will change when the timer (discussed below) expires.</p>
+        ]]></description>
+        <default>3</default>
+      </parameter>
+
+      <parameter name="config_8_1" type="integer" groupName="configuration"
+                 min="1" max="255">
+        <label>8: On/Off Command dim timer</label>
+        <description><![CDATA[
+Dim timer parameter<br /><h1>Overview</h1><p>Dim timer parameter (how fast the dim rate) parameter. It can be set to a value of 1 to 255. This value indicates in 10 millisecond resolution, how often the dim level will change. For example, if you set this parameter to 1, then the dim level will change every 10mS. If you set it to 255, then the dim level will change every 2.55 seconds.  </p>
+        ]]></description>
+        <default>10</default>
+      </parameter>
+
+      <parameter name="config_9_1" type="integer" groupName="configuration"
+                 min="1" max="99">
+        <label>9: Local Control dim rate</label>
+        <description><![CDATA[
+Dim step Parameter<br /><h1>Overview</h1><p>Local Control dim rate. </p>
+        ]]></description>
+        <default>3</default>
+      </parameter>
+
+      <parameter name="config_10_1" type="integer" groupName="configuration"
+                 min="1" max="255">
+        <label>10: Dim timer Parameter</label>
+        <description><![CDATA[
+Dim timer Parameter<br /><h1>Overview</h1><p>Dim timer Parameter. </p>
+        ]]></description>
+        <default>10</default>
+      </parameter>
+
+      <parameter name="config_11_1" type="integer" groupName="configuration"
+                 min="1" max="99">
+        <label>11: ALL ON/ALL OFF dim step</label>
+        <description><![CDATA[
+ALL ON/ALL OFF dim step<br /><h1>Overview</h1><p>ALL ON/ALL OFF dim rate step parameter. </p>
+        ]]></description>
+        <default>3</default>
+      </parameter>
+
+      <parameter name="config_12_1" type="integer" groupName="configuration"
+                 min="1" max="255">
+        <label>12: ALL ON/ALL OFF dim rate</label>
+        <description><![CDATA[
+Dim timer Parameter<br /><h1>Overview</h1><p>ALL ON/ALL OFF dim rate timer Parameter.</p>
+        ]]></description>
+        <default>10</default>
+      </parameter>
+
+      <parameter name="config_13_1" type="integer" groupName="configuration"
+                 min="0" max="1">
+        <label>13: Disable group 4 during dim command</label>
+        <description><![CDATA[
+Disable group 4 during dim command<br /><h1>Overview</h1><p>Note that this only affects a level that is reported or possibly sent by the ZTM230 since the ZTM230 does not control a load.<br /><br />After the ZTM230 is commanded to stop dimming when it has been dimming because of the DIM START command, it will then command the Z-Wave devices that are in Group 4 to its new level. To prevent the ZTM230 from commanding the Z-Wave devices in Group 4 during this particular occurrence, set Parameter 13 to the value of 1.</p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_14_1" type="integer" groupName="configuration"
+                 min="0" max="1">
+        <label>14: Enable shade control group 2</label>
+        <description><![CDATA[
+Enable shade control group 2<br /><h1>Overview</h1><p>The ZTM230 can control shade control devices via its group 2 if this configuration parameter is set to 1. </p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_15_1" type="integer" groupName="configuration"
+                 min="0" max="1">
+        <label>15: Enable shade control group 3</label>
+        <description><![CDATA[
+Enable shade control group 3<br /><h1>Overview</h1><p>The ZTM230 can control shade control devices via its group 3 if this configuration parameter is set to 1. </p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_16_1" type="integer" groupName="configuration"
+                 min="0" max="1">
+        <label>16: Enable shade control group 1</label>
+        <description><![CDATA[
+Enable shade control group 1<br /><h1>Overview</h1><p>The ZTM230 can control shade control devices via its group 1 if this configuration parameter is set to 1. </p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_19_1" type="integer" groupName="configuration"
+                 min="0" max="2">
+        <label>19: Transmission LED</label>
+        <description><![CDATA[
+Transmission LED behaviour<br /><h1>Overview</h1><p>The ZTM230 will flicker its LED when it is transmitting to any of its 4 groups. This flickering can be set to not flicker at all (set to 0), to flicker the entire time it is transmitting (set to 1), or to flicker for only 1 second when it begins transmitting (set to 2). By default, the ZTM230 is set to flicker for only 1 second.</p>
+        ]]></description>
+        <default>2</default>
+      </parameter>
+
+      <parameter name="config_20_1" type="integer" groupName="configuration"
+                 min="1" max="255">
+        <label>20: Poll group 1 interval</label>
+        <description><![CDATA[
+Group 1 poll interval<br /><h1>Overview</h1><p>How often it will poll Group 1 is configured using this parameter 20. The default poll rate is 2. Note that the poll interval starts timing again upon successful transmission of the poll request. Also note that the polling interval is not “exact” and that you may see some slight drift occur. Also the poll interval is reset upon switch being pressed. In addition, on power up, the ZTM230 will randomly poll based upon it’s node ID within 2 minutes of power being applied.  </p>
+        ]]></description>
+        <default>2</default>
+      </parameter>
+
+      <parameter name="config_21_1" type="integer" groupName="configuration"
+                 min="0" max="1">
+        <label>21: Poll group 1</label>
+        <description><![CDATA[
+Poll group 1<br /><h1>Overview</h1><p>The ZTM230 will poll the first node in Group 1 in order to keep itself synchronized with the group if this configuration parameter is set to 1. How often it will poll is configured using parameter 20.  </p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_22_1" type="integer" groupName="configuration"
+                 min="0" max="1">
+        <label>22: Poll Group 2</label>
+        <description><![CDATA[
+Poll Group 2 interval (minutes).<br /><h1>Overview</h1><p>The ZTM230 will poll the first node in Group 2 in order to keep itself synchronized with the group if this configuration parameter is set to 1. How often it will poll is configured using parameter 20.  </p>
+        ]]></description>
+        <default>1</default>
+      </parameter>
+
+      <!-- ASSOCIATION DEFINITIONS -->
+      <parameter-group name="association">
+        <context>link</context>
+        <label>Association Groups</label>
+      </parameter-group>
+
+      <parameter name="group_1" type="text" groupName="association" multiple="true">
+        <label>1: Group 1</label>
+        <description><![CDATA[
+Group 1 left paddle<br /><h1>Overview</h1><p>Nodes in this group are turned ON and OFF by tapping the top or bottom of the left switch.<br />Nodes associated into this group are dimmed by pressing and holding the bottom of the left switch until the desired dim level is reached.  </p>
+        ]]></description>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+      <parameter name="group_2" type="text" groupName="association" multiple="true">
+        <label>2: Group 2</label>
+        <description><![CDATA[
+Group 2 right paddle<br /><h1>Overview</h1><p>Nodes in this group are turned ON and OFF by tapping the right switch.<br />Nodes associated into this group are dimmed by pressing and holding the bottom of the right switch until the desired dim level is reached. The LED on the right switch will indicate the status of group 2. Group 2 will be polled at a specific interval and the status of group 2 will be indicated via the LED. The polling interval can be configured.</p>
+        ]]></description>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+      <parameter name="group_3" type="text" groupName="association" multiple="true">
+        <label>3: Group 3</label>
+        <description><![CDATA[
+Group 3 double tap right paddle<br /><h1>Overview</h1><p>Nodes in this group are turned ON and OFF by tapping the right switch twice. Nodes associated into this group are dimmed by tapping the bottom of the switch once and then pressing and holding the bottom of the switch until the desired dim level is reached.<br /></p> <p>note that associating nodes into group 3 will cause a very slight delay before the command is transmitted to group 2.  </p>
+        ]]></description>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+      <parameter name="group_4" type="text" groupName="association" multiple="true">
+        <label>4: Group 4</label>
+        <description><![CDATA[
+Group 4 <br /><h1>Overview</h1><p>Nodes in this group are turned ON or OFF or set to a specific dim level when the ZTM230 is controlled remotely. You can place up to 5 nodes in each group.<br />If controlling dimmers, for best results, associate the dimmers into the group first.  </p>
+        ]]></description>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+    </config-description>
+
+  </thing-type>
+
+</thing:thing-descriptions>

--- a/ESH-INF/thing/aeon_zw056_0_0.xml
+++ b/ESH-INF/thing/aeon_zw056_0_0.xml
@@ -94,6 +94,7 @@ Alert for low battery<br /><h1>Overview</h1><p>0x00:  normal battery level</p> 
         ]]></description>
         <default>0</default>
         <options>
+          <option value="-1">Unknown Battery Level</option>
           <option value="0">Battery Level Good</option>
           <option value="255">Low Battery</option>
         </options>

--- a/ESH-INF/thing/benext_doorsensor_0_0.xml
+++ b/ESH-INF/thing/benext_doorsensor_0_0.xml
@@ -41,7 +41,7 @@
       <property name="vendor">BeNext</property>
       <property name="modelId">doorSensor</property>
       <property name="manufacturerId">008A</property>
-      <property name="manufacturerRef">0004:0100</property>
+      <property name="manufacturerRef">0004:0100,0004:0101</property>
       <property name="dbReference">223</property>
       <property name="defaultAssociations">1</property>
     </properties>

--- a/ESH-INF/thing/cloud_a803n_0_0.xml
+++ b/ESH-INF/thing/cloud_a803n_0_0.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zwave"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+  xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0
+                      http://eclipse.org/smarthome/schemas/thing-description/v1.0.0">
+
+  <thing-type id="cloud_a803n_00_000" listed="false">
+    <label>A803N Motion Sensor</label>
+    <description>Motion Sensor</description>
+
+    <!-- CHANNEL DEFINITIONS -->
+    <channels>
+      <channel id="sensor_binary" typeId="sensor_binary">
+        <label>Binary Sensor</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_SENSOR_BINARY</property>
+        </properties>
+      </channel>
+      <channel id="sensor_luminance" typeId="sensor_luminance">
+        <label>Sensor (luminance)</label>
+        <properties>
+          <property name="binding:*:DecimalType">COMMAND_CLASS_SENSOR_MULTILEVEL;type=LUMINANCE</property>
+        </properties>
+      </channel>
+      <channel id="alarm_general" typeId="alarm_general">
+        <label>Alarm (general)</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_ALARM;type=GENERAL</property>
+        </properties>
+      </channel>
+      <channel id="battery-level" typeId="system.battery-level">
+        <properties>
+          <property name="binding:*:PercentType">COMMAND_CLASS_BATTERY</property>
+        </properties>
+      </channel>
+    </channels>
+
+    <!-- DEVICE PROPERTY DEFINITIONS -->
+    <properties>
+      <property name="vendor">Cloud Media</property>
+      <property name="modelId">A803N</property>
+      <property name="manufacturerId">0200</property>
+      <property name="manufacturerRef">0003:0002</property>
+      <property name="dbReference">521</property>
+      <property name="defaultAssociations">1,2,3,4</property>
+    </properties>
+
+    <!-- CONFIGURATION DESCRIPTIONS -->
+    <config-description>
+
+      <!-- PARAMETER DEFINITIONS -->
+      <parameter-group name="configuration">
+        <context>setup</context>
+        <label>Configuration Parameters</label>
+      </parameter-group>
+
+      <parameter name="config_1_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>1: Param 1</label>
+        <description>Param 1</description>
+        <default>12</default>
+      </parameter>
+
+      <parameter name="config_2_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>2: Param 2</label>
+        <description>Param 2</description>
+        <default>3</default>
+      </parameter>
+
+      <parameter name="config_3_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>3: Param 3</label>
+        <description>Param 3</description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_4_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>4: Param 4</label>
+        <description>Param 4</description>
+        <default>15</default>
+      </parameter>
+
+      <parameter name="config_5_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>5: Param 5</label>
+        <description>Param 5</description>
+        <default>1</default>
+      </parameter>
+
+      <parameter name="config_6_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>6: Param 6</label>
+        <description>Param 6</description>
+        <default>1</default>
+      </parameter>
+
+      <parameter name="config_7_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>7: Param 7</label>
+        <description>Param 7</description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_8_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>8: Param 8</label>
+        <description>Param 8</description>
+        <default>255</default>
+      </parameter>
+
+      <parameter name="config_9_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>9: Param 9</label>
+        <description>Param 9</description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_10_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>10: Param 10</label>
+        <description>Param 10</description>
+        <default>50</default>
+      </parameter>
+
+      <parameter name="config_11_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>11: Param 11</label>
+        <description>Param 11</description>
+        <default>100</default>
+      </parameter>
+
+      <parameter name="config_12_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>12: Param 12</label>
+        <description>Param 12</description>
+        <default>3</default>
+      </parameter>
+
+      <!-- ASSOCIATION DEFINITIONS -->
+      <parameter-group name="association">
+        <context>link</context>
+        <label>Association Groups</label>
+      </parameter-group>
+
+      <parameter name="group_1" type="text" groupName="association">
+        <label>1: Group 1</label>
+      </parameter>
+
+      <parameter name="group_2" type="text" groupName="association" multiple="true">
+        <label>2: Group 2</label>
+        <multipleLimit>4</multipleLimit>
+      </parameter>
+
+      <parameter name="group_3" type="text" groupName="association" multiple="true">
+        <label>3: Group 3</label>
+        <multipleLimit>4</multipleLimit>
+      </parameter>
+
+      <parameter name="group_4" type="text" groupName="association" multiple="true">
+        <label>4: Group 4</label>
+        <multipleLimit>4</multipleLimit>
+      </parameter>
+
+    </config-description>
+
+  </thing-type>
+
+</thing:thing-descriptions>

--- a/ESH-INF/thing/devolo_phpse02_0_0.xml
+++ b/ESH-INF/thing/devolo_phpse02_0_0.xml
@@ -19,11 +19,9 @@ Multisound indoor siren (Zipato/Devolo)<br /><h1>Overview</h1><p><strong>### NOT
           <property name="binding:*:OnOffType">COMMAND_CLASS_SWITCH_BINARY,COMMAND_CLASS_BASIC</property>
         </properties>
       </channel>
-      <channel id="switch_dimmer" typeId="switch_dimmer">
+      <channel id="notification_send" typeId="notification_send">
         <label>Sounds</label>
         <properties>
-          <property name="binding:*:PercentType">COMMAND_CLASS_SWITCH_MULTILEVEL</property>
-          <property name="binding:Command:OnOffType">COMMAND_CLASS_SWITCH_MULTILEVEL</property>
         </properties>
       </channel>
       <channel id="sensor_binary" typeId="sensor_binary">
@@ -42,6 +40,12 @@ Multisound indoor siren (Zipato/Devolo)<br /><h1>Overview</h1><p><strong>### NOT
         <label>Alarm (general)</label>
         <properties>
           <property name="binding:*:OnOffType">COMMAND_CLASS_ALARM;type=GENERAL</property>
+        </properties>
+      </channel>
+      <channel id="notification_send" typeId="notification_send">
+        <label>Start Sound</label>
+        <properties>
+          <property name="binding:*:DecimalType">COMMAND_CLASS_ALARM;event1=SMOKE:1,event2=ACCESS_CONTROL:22,event3=BURGLAR:1,event4=EMERGENCY:1,event5=EMERGENCY:2,event6=EMERGENCY:3,event7=ACCESS_CONTROL:3,event8=ACCESS_CONTROL:4,event9=EMERGENCY:254</property>
         </properties>
       </channel>
     </channels>

--- a/ESH-INF/thing/fakro_arz_0_0.xml
+++ b/ESH-INF/thing/fakro_arz_0_0.xml
@@ -17,11 +17,12 @@
           <property name="binding:*:OnOffType">COMMAND_CLASS_SWITCH_BINARY</property>
         </properties>
       </channel>
-      <channel id="switch_dimmer" typeId="switch_dimmer">
-        <label>Dimmer</label>
+      <channel id="blinds_control" typeId="blinds_control">
+        <label>Blinds control</label>
         <properties>
           <property name="binding:*:PercentType">COMMAND_CLASS_SWITCH_MULTILEVEL,COMMAND_CLASS_BASIC</property>
-          <property name="binding:Command:OnOffType">COMMAND_CLASS_SWITCH_MULTILEVEL,COMMAND_CLASS_BASIC</property>
+          <property name="binding:Command:StopMoveType">COMMAND_CLASS_SWITCH_MULTILEVEL,COMMAND_CLASS_BASIC</property>
+          <property name="binding:Command:UpDownType">COMMAND_CLASS_SWITCH_MULTILEVEL,COMMAND_CLASS_BASIC</property>
         </properties>
       </channel>
     </channels>

--- a/ESH-INF/thing/idlock_idl101_1_0.xml
+++ b/ESH-INF/thing/idlock_idl101_1_0.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zwave"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+  xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0
+                      http://eclipse.org/smarthome/schemas/thing-description/v1.0.0">
+
+  <thing-type id="idlock_idl101_01_000" listed="false">
+    <label>IDL-101 Z-Wave Lock</label>
+    <description><![CDATA[
+Z-Wave Lock<br /><h1>Overview</h1><p>http://idlock.no/</p> <br /><h2>Inclusion Information</h2><ol><li>Bring the controller as close as possible to the lock unit</li> <li>Set the controller to inclusion mode</li> <li>Push and hold KEY button on the inside panel on the lock until all keys on the outside light up and a audible signal is given.</li> <li>Release the KEY button on the inside panel</li> <li>Press the key 8 on the outside panel</li> <li>The LED flashes blue when inclusion is in progress</li> <li>The inclusion may take some time as security is required</li> </ol><br /><h2>Exclusion Information</h2><ol><li>Set the controller to exclusion mode</li> <li>Push and hold KEY button on the inside panel on the lock until all keys on the outside light up and a audible signal is given.</li> <li>Release the KEY button on the inside panel</li> <li>Press the key 8 on the outside panel</li> <li>The LED flashes blue when exclusion is done</li> </ol><br /><h2>Wakeup Information</h2><p>This is a frequently listening device (FLIRS) which supports beaming. This means that the lock will check regularly for incoming commands, and respond quickly without the need for any user specification of wakeup intervals or physical wakeup procedures.</p>
+    ]]></description>
+
+    <!-- CHANNEL DEFINITIONS -->
+    <channels>
+      <channel id="lock_door" typeId="lock_door">
+        <label>Door Lock</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_DOOR_LOCK</property>
+        </properties>
+      </channel>
+      <channel id="alarm_access" typeId="alarm_access">
+        <label>Alarm (access)</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_ALARM;type=ACCESS_CONTROL</property>
+        </properties>
+      </channel>
+      <channel id="alarm_burglar" typeId="alarm_burglar">
+        <label>Alarm (burglar)</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_ALARM;type=BURGLAR</property>
+        </properties>
+      </channel>
+      <channel id="alarm_general" typeId="alarm_general">
+        <label>Alarm (emergency)</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_ALARM;type=EMERGENCY</property>
+        </properties>
+      </channel>
+      <channel id="battery-level" typeId="system.battery-level">
+        <properties>
+          <property name="binding:*:PercentType">COMMAND_CLASS_BATTERY</property>
+        </properties>
+      </channel>
+    </channels>
+
+    <!-- DEVICE PROPERTY DEFINITIONS -->
+    <properties>
+      <property name="vendor">Alphonsus Tech</property>
+      <property name="modelId">IDL-101</property>
+      <property name="manufacturerId">0230</property>
+      <property name="manufacturerRef">0003:0001</property>
+      <property name="versionMin">1.0</property>
+      <property name="versionMax">1.0</property>
+      <property name="dbReference">384</property>
+      <property name="defaultAssociations">1</property>
+    </properties>
+
+    <!-- CONFIGURATION DESCRIPTIONS -->
+    <config-description>
+
+      <!-- PARAMETER DEFINITIONS -->
+      <parameter-group name="configuration">
+        <context>setup</context>
+        <label>Configuration Parameters</label>
+      </parameter-group>
+
+      <parameter name="config_1_1" type="integer" groupName="configuration">
+        <label>1: Door Lock Mode</label>
+        <description><![CDATA[
+Sets the door lock mode<br /><h1>Overview</h1><p>No details in manual, will update when the meaning of this parameter is uncovered.</p>
+        ]]></description>
+        <default>1</default>
+        <options>
+          <option value="0">Disable Away Manual Lock</option>
+          <option value="1">Disable Away Auto Lock</option>
+          <option value="2">Enable Away Manual Lock</option>
+          <option value="3">Enable Away Auto Lock</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_2_2" type="integer" groupName="configuration"
+                 min="0" max="65535">
+        <label>2: RFID Register Mode</label>
+        <description>Sets the RFID registration mode</description>
+        <default>0</default>
+      </parameter>
+
+      <!-- ASSOCIATION DEFINITIONS -->
+      <parameter-group name="association">
+        <context>link</context>
+        <label>Association Groups</label>
+      </parameter-group>
+
+      <parameter name="group_1" type="text" groupName="association" multiple="true">
+        <label>1: Lifeline</label>
+        <description>Notification reports are sent out to devices included in this association group</description>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+    </config-description>
+
+  </thing-type>
+
+</thing:thing-descriptions>

--- a/ESH-INF/thing/leviton_dz15s_0_0.xml
+++ b/ESH-INF/thing/leviton_dz15s_0_0.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zwave"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+  xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0
+                      http://eclipse.org/smarthome/schemas/thing-description/v1.0.0">
+
+  <thing-type id="leviton_dz15s_00_000" listed="false">
+    <label>DZ15S Scene Capable Push On/Off</label>
+    <description>Scene Capable Push On/Off</description>
+
+    <!-- CHANNEL DEFINITIONS -->
+    <channels>
+      <channel id="switch_binary" typeId="switch_binary">
+        <label>Switch</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_SWITCH_BINARY,COMMAND_CLASS_BASIC</property>
+        </properties>
+      </channel>
+      <channel id="scene_number" typeId="scene_number">
+        <label>Scene Number</label>
+        <properties>
+          <property name="binding:*:DecimalType">COMMAND_CLASS_SCENE_ACTIVATION</property>
+        </properties>
+      </channel>
+    </channels>
+
+    <!-- DEVICE PROPERTY DEFINITIONS -->
+    <properties>
+      <property name="vendor">Leviton</property>
+      <property name="modelId">DZ15S</property>
+      <property name="manufacturerId">001D</property>
+      <property name="manufacturerRef">3401:0001</property>
+      <property name="dbReference">523</property>
+    </properties>
+
+  </thing-type>
+
+</thing:thing-descriptions>

--- a/ESH-INF/thing/logic_zhc5010_1_4.xml
+++ b/ESH-INF/thing/logic_zhc5010_1_4.xml
@@ -8,7 +8,7 @@
   <thing-type id="logic_zhc5010_01_004" listed="false">
     <label>ZHC5010 FUGA Wall 4-way Switch with LED + Relay</label>
     <description><![CDATA[
-FUGA Wall 4-way Switch with LED + Relay<br /><h1>Overview</h1><p>ZHC5010 is a wall switch module with Z-Wave communication. The module contains four buttons, four LEDs, a built-in relay switch and is designed to fit into a standard LK FUGA® wall box (one-module format). The ZHC5010 Wall Switch allows you to control the local load as well as Z-Wave connected devices in up to four additional Z-Wave groups.</p> <p>Please note that for simplicity reasons, this configuration set does not include;</p> <ul><li>Multi Level support</li> <li>House Clean Mode support</li> <li>Control of association groups</li> </ul><p>Support for this could be added to the profile later as per description in the manual.</p> <br /><h2>Inclusion Information</h2><p>Place your primary controller in Adding Mode by following the manufacturer's instructions, then activate the add mode on the device by triple-clicking the upper left button on the module, or by triple-clicking the little button in the middle of the module (hidden behind the small plastic cover). Adding Mode is indicated by blinking of upper left LED until the timeout occurs after 10 seconds or the module has been added in the network. </p> <br /><h2>Exclusion Information</h2><p>Follow the inclusion procedures; the device is removed in the same manner, when the controller is in Removing Mode.</p> <p>Factory reset:<br />ZHC5010 can be factory reset by pressing the small button in the middle of the module (normally covered by small plastic cover) for at least 10 seconds. Remove the middle plastic cover by means of a small screwdriver, and press the small button for at least 10 seconds, until all the LEDs lights up. Please use this procedure only when the network primary controller is missing or otherwise inoperable.</p>
+FUGA Wall 4-way Switch with LED + Relay<br /><h1>Overview</h1><p>ZHC5010 is a wall switch module with Z-Wave communication. The module contains four buttons, four LEDs, a built-in relay switch and is designed to fit into a standard LK FUGA® wall box (one-module format). The ZHC5010 Wall Switch allows you to control the local load as well as Z-Wave connected devices in up to four additional Z-Wave groups.</p> <p>Please note, this configuration set does not yet include;</p> <ul><li>Multi Level support</li> <li>Control of association groups</li> </ul><p>Support for this could be added to the profile later as per description in the manual.</p> <br /><h2>Inclusion Information</h2><p>Place your primary controller in Adding Mode by following the manufacturer's instructions, then activate the add mode on the device by triple-clicking the upper left button on the module, or by triple-clicking the little button in the middle of the module (hidden behind the small plastic cover). Adding Mode is indicated by blinking of upper left LED until the timeout occurs after 10 seconds or the module has been added in the network. </p> <br /><h2>Exclusion Information</h2><p>Follow the inclusion procedures; the device is removed in the same manner, when the controller is in Removing Mode.</p> <p>Factory reset:<br />ZHC5010 can be factory reset by pressing the small button in the middle of the module (normally covered by small plastic cover) for at least 10 seconds. Remove the middle plastic cover by means of a small screwdriver, and press the small button for at least 10 seconds, until all the LEDs lights up. Please use this procedure only when the network primary controller is missing or otherwise inoperable.</p>
     ]]></description>
 
     <!-- CHANNEL DEFINITIONS -->
@@ -16,7 +16,7 @@ FUGA Wall 4-way Switch with LED + Relay<br /><h1>Overview</h1><p>ZHC5010 is a wa
       <channel id="switch_binary" typeId="switch_binary">
         <label>Switch</label>
         <properties>
-          <property name="binding:*:OnOffType">COMMAND_CLASS_SWITCH_BINARY</property>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_SWITCH_BINARY,COMMAND_CLASS_BASIC</property>
         </properties>
       </channel>
       <channel id="switch_dimmer" typeId="switch_dimmer">
@@ -35,7 +35,7 @@ FUGA Wall 4-way Switch with LED + Relay<br /><h1>Overview</h1><p>ZHC5010 is a wa
       <channel id="switch_binary1" typeId="switch_binary">
         <label>Switch 1</label>
         <properties>
-          <property name="binding:*:OnOffType">COMMAND_CLASS_SWITCH_BINARY:1</property>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_SWITCH_BINARY:1,COMMAND_CLASS_BASIC:1</property>
         </properties>
       </channel>
       <channel id="switch_dimmer1" typeId="switch_dimmer">
@@ -263,6 +263,146 @@ How built-in relay is controlled<br /><h1>Overview</h1><p>This parameter configu
           <option value="3">Relay is controlled by button #3</option>
           <option value="4">Relay is controlled by button #4</option>
           <option value="5">Relay is activated for one second</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_16_1" type="integer" groupName="configuration">
+        <label>16: Indicator mode.</label>
+        <description><![CDATA[
+set the current light level for the actual LED or the level value can be stored<br /><h1>Overview</h1><p>When ZHC5010 receives an Indicator Set message, then the received value can be used only to set the current light level for the actual LED or the level value can be stored and will then be used for subsequent internal activations. </p>
+        ]]></description>
+        <default>1</default>
+        <options>
+          <option value="0">Indicator Set level used to control the LED.</option>
+          <option value="1">Indicator Set level values and internal LED activations.</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_17_1" type="integer" groupName="configuration">
+        <label>17: Scene notification offset.</label>
+        <description><![CDATA[
+Scene sequence numbers transmitted by Central Scene notifications.<br /><h1>Overview</h1><p>Configure the scene sequence numbers that will be transmitted by Central Scene notifications.</p> <p>Button #1 will send scene [value], button #2 will send scene [value] + 1, button #3 will send scene [value] + 2, button #4 will send scene [value] + 3. (Default = 1)</p>
+        ]]></description>
+        <default>1</default>
+        <options>
+          <option value="0">Scene notifications are turned off.</option>
+          <option value="1">Send scene value for button #</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_18_1" type="integer" groupName="configuration">
+        <label>18: Disable House Cleaning.</label>
+        <description><![CDATA[
+Disable House Cleaning Mode.<br /><h1>Overview</h1><p>This parameter is able to enable or disable the so-called “House Cleaning Mode”, where ZHC5010 is able send a dimming command in order to set the level of the lights to 100%.</p>
+        ]]></description>
+        <default>0</default>
+        <options>
+          <option value="0">House Cleaning Mode is enabled</option>
+          <option value="1">1 House Cleaning Mode is disabled.</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_19_4_00000001" type="integer" groupName="configuration">
+        <label>19: Multilevel Switch (button #1) Disabled/Enabled</label>
+        <description>Multilevel Switch on single press for device 1 (button #1)</description>
+        <default>1</default>
+        <options>
+          <option value="0">Disabled</option>
+          <option value="1">Enabled</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_19_4_0000FF00" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>19: Multilevel Switch - Upper switch value</label>
+        <description><![CDATA[
+<br /><h1>Overview</h1><p>When single pressing the button for ON, a Multilevel Switch Set with this value will be send to devices in association group 6. (Default = 255)</p>
+        ]]></description>
+        <default>255</default>
+      </parameter>
+
+      <parameter name="config_19_4_00FF0000" type="integer" groupName="configuration"
+                 min="0" max="99">
+        <label>19: Multilevel Switch - Lower switch value</label>
+        <description><![CDATA[
+<br /><h1>Overview</h1><p>When single pressing the button for OFF, a Multilevel Switch Set with this value will be send to devices in association group 6. (Default = 0)</p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_20_4_00000001" type="integer" groupName="configuration">
+        <label>20: Multilevel Switch (button #2) Disabled/Enabled</label>
+        <description>Multilevel Switch on single press for device 2 (button #2)</description>
+        <default>1</default>
+        <options>
+          <option value="0">Disabled</option>
+          <option value="1">Enabled</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_20_4_0000FF00" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>20: Multilevel Switch - Upper switch value</label>
+        <description><![CDATA[
+<br /><h1>Overview</h1><p>When single pressing the button for ON, a Multilevel Switch Set with this value will be send to devices in association group 6. (Default = 255)</p>
+        ]]></description>
+        <default>255</default>
+      </parameter>
+
+      <parameter name="config_20_4_00FF0000" type="integer" groupName="configuration"
+                 min="0" max="99">
+        <label>20: Multilevel Switch - Lower switch value</label>
+        <description><![CDATA[
+<br /><h1>Overview</h1><p>When single pressing the button for OFF, a Multilevel Switch Set with this value will be send to devices in association group 6. (Default = 0)</p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_23_1" type="integer" groupName="configuration">
+        <label>23: Control of association groups (button #1).</label>
+        <description><![CDATA[
+Control of association groups for device 1 (button #1).<br /><h1>Overview</h1><p>Enable or disable if received commands are relayed to the nodes in the association groups.</p>
+        ]]></description>
+        <default>1</default>
+        <options>
+          <option value="0">Association groups will not be switched.</option>
+          <option value="1">Association groups will be switched,</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_24_1" type="integer" groupName="configuration">
+        <label>24: Control of association groups (button #2).</label>
+        <description><![CDATA[
+Control of association groups for device 2 (button #2).<br /><h1>Overview</h1><p>Enable or disable if received commands are relayed to the nodes in the association groups.</p>
+        ]]></description>
+        <default>1</default>
+        <options>
+          <option value="0">Association groups will not be switched.</option>
+          <option value="1">Association groups will be switched,</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_25_1" type="integer" groupName="configuration">
+        <label>25: Control of association groups (button #3).</label>
+        <description><![CDATA[
+Control of association groups for device 3 (button #3).<br /><h1>Overview</h1><p>Enable or disable if received commands are relayed to the nodes in the association groups.</p>
+        ]]></description>
+        <default>1</default>
+        <options>
+          <option value="0">Association groups will not be switched.</option>
+          <option value="1">Association groups will be switched,</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_26_1" type="integer" groupName="configuration">
+        <label>26: Control of association groups (button #4).</label>
+        <description><![CDATA[
+Control of association groups for device 4 (button #4).<br /><h1>Overview</h1><p>Enable or disable if received commands are relayed to the nodes in the association groups.</p>
+        ]]></description>
+        <default>1</default>
+        <options>
+          <option value="0">Association groups will not be switched.</option>
+          <option value="1">Association groups will be switched,</option>
         </options>
       </parameter>
 

--- a/ESH-INF/thing/merten_507601_0_0.xml
+++ b/ESH-INF/thing/merten_507601_0_0.xml
@@ -11,6 +11,12 @@
 
     <!-- CHANNEL DEFINITIONS -->
     <channels>
+      <channel id="switch_binary" typeId="switch_binary">
+        <label>Switch</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_SWITCH_BINARY,COMMAND_CLASS_BASIC</property>
+        </properties>
+      </channel>
     </channels>
 
     <!-- DEVICE PROPERTY DEFINITIONS -->

--- a/ESH-INF/thing/philio_pan08_0_0.xml
+++ b/ESH-INF/thing/philio_pan08_0_0.xml
@@ -74,7 +74,7 @@
       <property name="vendor">Philio Technology Corp</property>
       <property name="modelId">PAN08</property>
       <property name="manufacturerId">013C</property>
-      <property name="manufacturerRef">0001:0006</property>
+      <property name="manufacturerRef">0001:0006,0001:0015</property>
       <property name="dbReference">175</property>
     </properties>
 

--- a/ESH-INF/thing/qubino_zmnhld_0_0.xml
+++ b/ESH-INF/thing/qubino_zmnhld_0_0.xml
@@ -1,0 +1,503 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zwave"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+  xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0
+                      http://eclipse.org/smarthome/schemas/thing-description/v1.0.0">
+
+  <thing-type id="qubino_zmnhld_00_000" listed="false">
+    <label>ZMNHLD Flush PWM Thermostat</label>
+    <description><![CDATA[
+Flush PWM Thermostat<br /><h1>Overview</h1><p>This Z-Wave module is used to regulate temperature.</p> <p>Regulation is done using full wave PWM technology. The module can be controlled either through Z-wave network or through the wall switch.</p> <p>The module is designed to be mounted inside a "flush mounting box" and is hidden behind a traditional wall switch.<br />Module measures power consumtion of connected device.</p> <p>It is designed to act as repeater in order to improve range and stability of Z-wave network.</p> <br /><h2>Inclusion Information</h2><p>WARNING: Service button S <strong>must NOT be used</strong> when module is connected to 110-230V power supply.</p> <ul><li>Connect module to power supply (with temperature sensor connected - if purchased),</li> <li>Enable add/remove mode on main controller</li> <li>Auto-inclusion (works for about 2 minutesafter connected to power supply) or</li> <li><strong>110V-230V power supply: </strong>Press push button I1 three times within 3 seconds (3 times change switch state within 3 seconds)</li> <li><strong>24V SELV: </strong>Press service button <strong>S</strong> for more than 2 seconds.</li> </ul><p><strong>NOTE1:</strong> For auto-inclusion procedure, first set main controller into inclusion mode and then connect module to power supply.</p> <p><strong>NOTE2:</strong> When connecting temperature sensor to module that has already been included, you have to exclude module first. Switch off power supply,connect the sensor and re-include the module.</p> <br /><h2>Exclusion Information</h2><p>WARNING: Service button S <strong>must NOT be used</strong> when module is connected to 110-230V power supply.</p> <ul><li>Connect module to power supply</li> <li>Bring module within maximum 1 meter (3 feet) of the main controller</li> <li>Enable add/remove mode on main controller</li> <li><strong>110V-230V power supply:</strong> Press push button <strong>I1</strong> five times within 3 seconds (5 times change switch state within 3 seconds) in the first 60 seconds after the module is connected to the power supply</li> <li><strong>24V SELV:</strong> Press ervice button <strong>S</strong> for more than 6 seconds.</li> </ul><p>By this function all parameters of the module are set to default values and own ID is deleted. If push button I1 is pressed three times within 3 seconds (or service button S is pressed more than 2 and less than 6 seconds) module is excluded, but configuration parameters are not set to default values.</p> <p>NOTE: If the module is included with parameters 100 or 101 with values different to default and module reset is done, wait at least 30s before next inclusion.</p>
+    ]]></description>
+
+    <!-- CHANNEL DEFINITIONS -->
+    <channels>
+      <channel id="sensor_temperature1" typeId="sensor_temperature">
+        <label>Sensor (temperature)</label>
+        <properties>
+          <property name="binding:*:DecimalType">COMMAND_CLASS_SENSOR_MULTILEVEL:1;type=TEMPERATURE</property>
+        </properties>
+      </channel>
+    </channels>
+
+    <!-- DEVICE PROPERTY DEFINITIONS -->
+    <properties>
+      <property name="vendor">Goap</property>
+      <property name="modelId">ZMNHLD</property>
+      <property name="manufacturerId">0159</property>
+      <property name="manufacturerRef">0005:0053</property>
+      <property name="dbReference">498</property>
+      <property name="defaultAssociations">1</property>
+    </properties>
+
+    <!-- CONFIGURATION DESCRIPTIONS -->
+    <config-description>
+
+      <!-- PARAMETER DEFINITIONS -->
+      <parameter-group name="configuration">
+        <context>setup</context>
+        <label>Configuration Parameters</label>
+      </parameter-group>
+
+      <parameter name="config_1_1" type="integer" groupName="configuration">
+        <label>1: Input I1 switch type</label>
+        <description>Input I1 switch type</description>
+        <default>1</default>
+        <options>
+          <option value="0">mono-stable switch type</option>
+          <option value="1">bi-stable switch type</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_2_1" type="integer" groupName="configuration">
+        <label>2: Input I2 switch type</label>
+        <description>Input I2 switch type</description>
+        <default>1</default>
+        <options>
+          <option value="0">mono-stable switch type</option>
+          <option value="1">bi-stable switch type</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_3_1" type="integer" groupName="configuration">
+        <label>3: Input I3 switch type</label>
+        <description>Input I3 switch type</description>
+        <default>1</default>
+        <options>
+          <option value="0">mono-stable switch type</option>
+          <option value="1">bi-stable switch type</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_4_1" type="integer" groupName="configuration">
+        <label>4: Input 1 contact type</label>
+        <description><![CDATA[
+Input 1 contact type<br /><h1>Overview</h1><p>This parameter has influence only when parameter no. 11 is set to value "2"<br />After setting the parameter switch the sensor once, so tha the module could determine the input state</p>
+        ]]></description>
+        <default>0</default>
+        <options>
+          <option value="0">normally open</option>
+          <option value="1">normally closed</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_5_1" type="integer" groupName="configuration">
+        <label>5: Input 2 contact type</label>
+        <description><![CDATA[
+Input 2 contact type<br /><h1>Overview</h1><p>This parameter has influence only when parameter no. 12 is set to value "2000"<br />After setting the parameter switch the sensor once, so tha the module could determine the input state</p>
+        ]]></description>
+        <default>0</default>
+        <options>
+          <option value="0">normally open</option>
+          <option value="1">normally closed</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_6_1" type="integer" groupName="configuration">
+        <label>6: Input 3 contact type</label>
+        <description><![CDATA[
+Input 3 contact type<br /><h1>Overview</h1><p>This parameter has influence only when parameter no. 13 is set to value "2"<br />After setting the parameter switch the sensor once, so tha the module could determine the input state</p>
+        ]]></description>
+        <default>0</default>
+        <options>
+          <option value="0">normally open</option>
+          <option value="1">normally closed</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_10_2" type="integer" groupName="configuration">
+        <label>10: Activate / deactivate ALL ON/ALL OFF</label>
+        <description><![CDATA[
+Activate / deactivate ALL ON/ALL OFF<br /><h1>Overview</h1><p>Flush PWM thermostat module responds to commands ALL ON / ALL OFF that may be sent by the main controller or by other controllers belonging to the system.</p>
+        ]]></description>
+        <default>255</default>
+        <options>
+          <option value="0">ALL ON is not active / ALL OFF is not active</option>
+          <option value="1">ALL ON is not active / ALL OFF is active</option>
+          <option value="2">ALL ON is active / ALL OFF is not active</option>
+          <option value="255">ALL ON is active / ALL OFF is active</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_11_2" type="integer" groupName="configuration">
+        <label>11: I1 Functionality selection</label>
+        <description>I1 Functionality selection</description>
+        <default>0</default>
+        <options>
+          <option value="1">Input I1 changes the mode between Off and Heat/Cool</option>
+          <option value="2">Input I1 influences the heating/cooling valves</option>
+          <option value="32767">Input I1 doesnt influence on the Heat/Cool process</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_12_2" type="integer" groupName="configuration">
+        <label>12: I2 Functionality selection</label>
+        <description><![CDATA[
+I2 Functionality selection<br /><h1>Overview</h1><p>0-990 - Temperature setpoint from 0,0 to 99,0 °C<br />1001-1150 - Temperature setpoint -0.1 to -15°C<br />2000 - Input I2 influences on the cooling value according to the status of condense sensor.</p>
+        ]]></description>
+        <default>32767</default>
+        <options>
+          <option value="2000">Input I2 influences the cooling value with condense sensor</option>
+          <option value="32767">Input I2 doesnt influence on the Heat/Cool process</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_13_2" type="integer" groupName="configuration">
+        <label>13: I3 Functionality selection</label>
+        <description>I3 Functionality selection</description>
+        <default>32767</default>
+        <options>
+          <option value="1">Input I3 changes the mode between Heat and Cool</option>
+          <option value="2">Input I3 influences the heating/cooling valves</option>
+          <option value="32767">Input I3 doesnt influence on the Heat/Cool process</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_40_1" type="integer" groupName="configuration"
+                 min="0" max="100">
+        <label>40: Power reporting in Watts on power change</label>
+        <description><![CDATA[
+Power reporting in Watts on power change<br /><h1>Overview</h1><p>0 - reporting disabled<br />1-100 = 1%-100% Reporting enabled<br />Power report is send only when actual power in Watts in real time changes for more then that set percentage</p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_42_2" type="integer" groupName="configuration"
+                 min="0" max="32767">
+        <label>42: Power reporting in Watts by time interval</label>
+        <description><![CDATA[
+Power reporting in Watts by time interval<br /><h1>Overview</h1><p>0 - report disabled<br />1-32767 = 1 second - 32767 seconds interval. Reporting enabled with time interval</p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_45_2" type="integer" groupName="configuration"
+                 min="0" max="1127">
+        <label>45: Antifreeze</label>
+        <description><![CDATA[
+Antifreeze<br /><h1>Overview</h1><p>Set value means at which temperature the thermostat will be turned on even if the thermostat was manually set off<br />0-127 = 0..12.7°C<br />1001-1127 = -0.1..-12.6°C<br />255 = Antifreeze is disabled</p>
+        ]]></description>
+        <default>50</default>
+      </parameter>
+
+      <parameter name="config_50_1" type="integer" groupName="configuration"
+                 min="2" max="100">
+        <label>50: PWM maximum value</label>
+        <description><![CDATA[
+PWM maximum value<br /><h1>Overview</h1><p>2..100 = 2..100% Maximum PWM is set by entered value</p>
+        ]]></description>
+        <default>100</default>
+      </parameter>
+
+      <parameter name="config_51_1" type="integer" groupName="configuration"
+                 min="0" max="99">
+        <label>51: PWM minimum value</label>
+        <description><![CDATA[
+PWM minimum value<br /><h1>Overview</h1><p>0..99 = 0..99% Minimum PWM is set by entered value</p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_52_1" type="integer" groupName="configuration"
+                 min="5" max="127">
+        <label>52: PWM cycle duration</label>
+        <description><![CDATA[
+PWM cycle duration<br /><h1>Overview</h1><p>5..127 = 5-125 seconds. PWM cycle duration is set by entered value</p>
+        ]]></description>
+        <default>10</default>
+      </parameter>
+
+      <parameter name="config_53_1" type="integer" groupName="configuration"
+                 min="0" max="127">
+        <label>53: PID value inside deadband</label>
+        <description><![CDATA[
+PID value inside deadband<br /><h1>Overview</h1><p>0 - PID value equals PWM minimum cycle<br />1 - PID value set to LAST VALUE</p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_54_1" type="integer" groupName="configuration"
+                 min="0" max="127">
+        <label>54: PID deadband</label>
+        <description><![CDATA[
+PID deadband<br /><h1>Overview</h1><p>0..127 = 0..12.7 °C <br />This parameter defines the zone where PID is not active.</p>
+        ]]></description>
+        <default>5</default>
+      </parameter>
+
+      <parameter name="config_55_1" type="integer" groupName="configuration"
+                 min="0" max="127">
+        <label>55: Integral sampling time</label>
+        <description><![CDATA[
+Integral sampling time<br /><h1>Overview</h1><p>0..127 = 0..127 seconds.<br />Parameter defines the time between samples.</p>
+        ]]></description>
+        <default>5</default>
+      </parameter>
+
+      <parameter name="config_56_2" type="integer" groupName="configuration"
+                 min="0" max="1000">
+        <label>56: P parameter</label>
+        <description>P parameter</description>
+        <default>100</default>
+      </parameter>
+
+      <parameter name="config_57_2" type="integer" groupName="configuration"
+                 min="0" max="1000">
+        <label>57: I parameter</label>
+        <description>I parameter</description>
+        <default>1</default>
+      </parameter>
+
+      <parameter name="config_58_2" type="integer" groupName="configuration"
+                 min="0" max="1000">
+        <label>58: D parameter</label>
+        <description>D parameter</description>
+        <default>1</default>
+      </parameter>
+
+      <parameter name="config_59_1" type="integer" groupName="configuration">
+        <label>59: Thermostat mode</label>
+        <description>Thermostat mode</description>
+        <default>0</default>
+        <options>
+          <option value="0">Heat mode</option>
+          <option value="1">Cool mode</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_60_2" type="integer" groupName="configuration"
+                 min="1" max="1150">
+        <label>60: Too low temperature limit</label>
+        <description><![CDATA[
+Too low temperature limit<br /><h1>Overview</h1><p>0..1000 = 0.1-100.0°C<br />1001..1150 = -0.1..-15.0°C</p>
+        ]]></description>
+        <default>50</default>
+      </parameter>
+
+      <parameter name="config_61_2" type="integer" groupName="configuration"
+                 min="1" max="1000">
+        <label>61: Too high temperature limit</label>
+        <description><![CDATA[
+Too high temperature limit<br /><h1>Overview</h1><p>1..1000 = 0.1..100.0°C</p>
+        ]]></description>
+        <default>700</default>
+      </parameter>
+
+      <parameter name="config_63_1" type="integer" groupName="configuration">
+        <label>63: Output switch selection</label>
+        <description><![CDATA[
+Output switch selection<br /><h1>Overview</h1><p>Set value means the type of the device that is connected to the PWM output.</p>
+        ]]></description>
+        <default>0</default>
+        <options>
+          <option value="0">When the device is turned off the output is 0V</option>
+          <option value="1">When the system is turned off the output is 230V</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_70_2" type="integer" groupName="configuration"
+                 min="0" max="32000">
+        <label>70: Input I1 status on delay</label>
+        <description><![CDATA[
+Input I1 status on delay<br /><h1>Overview</h1><p>If the value of the parameter is different to 0 means that the influence of this input to heating or cooling will react after inserted time.</p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_71_2" type="integer" groupName="configuration"
+                 min="0" max="32000">
+        <label>71: Input I1 status off delay</label>
+        <description><![CDATA[
+Input I1 status off delay<br /><h1>Overview</h1><p>If the value of the parameter is different to 0 means that the influence of this input to heating or cooling will react after inserted time.</p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_72_2" type="integer" groupName="configuration"
+                 min="0" max="32000">
+        <label>72: Input I2 status on delay</label>
+        <description><![CDATA[
+Input I2 status on delay<br /><h1>Overview</h1><p>If the value of the parameter is different to 0 means that the influence of this input to heating or cooling will react after inserted time.</p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_73_2" type="integer" groupName="configuration"
+                 min="0" max="32000">
+        <label>73: Input I2 status off delay</label>
+        <description><![CDATA[
+Input I2 status off delay<br /><h1>Overview</h1><p>If the value of the parameter is different to 0 means that the influence of this input to heating or cooling will react after inserted time.</p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_74_2" type="integer" groupName="configuration"
+                 min="0" max="32000">
+        <label>74: Input I3 status on delay</label>
+        <description><![CDATA[
+Input I3 status on delay<br /><h1>Overview</h1><p>If the value of the parameter is different to 0 means that the influence of this input to heating or cooling will react after inserted time.</p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_75_2" type="integer" groupName="configuration"
+                 min="0" max="32000">
+        <label>75: Input I3 status off delay</label>
+        <description><![CDATA[
+Input I3 status off delay<br /><h1>Overview</h1><p>If the value of the parameter is different to 0 means that the influence of this input to heating or cooling will react after inserted time.</p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <parameter name="config_100_1" type="integer" groupName="configuration">
+        <label>100: Enable/Disable Endpoint I1 or select type</label>
+        <description>Enable/Disable Endpoint I1 or select type</description>
+        <default>0</default>
+        <options>
+          <option value="0">disabled</option>
+          <option value="1">Home security, motion detection</option>
+          <option value="2">CO - Carbon monoxid detected</option>
+          <option value="3">CO2 - Carbon dioxid detected</option>
+          <option value="4">Water alarm</option>
+          <option value="5">Heat alarm</option>
+          <option value="6">Smoke alarm</option>
+          <option value="9">Sensor binary</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_101_1" type="integer" groupName="configuration">
+        <label>101: Enable/Disable Endpoint I2 or select type</label>
+        <description>Enable/Disable Endpoint I2 or select type</description>
+        <default>0</default>
+        <options>
+          <option value="0">disabled</option>
+          <option value="1">Home security, motion detection</option>
+          <option value="2">CO - Carbon monoxid detected</option>
+          <option value="3">CO2 - Carbon dioxid detected</option>
+          <option value="4">Water alarm</option>
+          <option value="5">Heat alarm</option>
+          <option value="6">Smoke alarm</option>
+          <option value="9">Sensor binary</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_102_1" type="integer" groupName="configuration">
+        <label>102: Enable/Disable Endpoint I3 or select type</label>
+        <description>Enable/Disable Endpoint I3 or select type</description>
+        <default>0</default>
+        <options>
+          <option value="0">disabled</option>
+          <option value="1">Home security, motion detection</option>
+          <option value="2">CO - Carbon monoxid detected</option>
+          <option value="3">CO2 - Carbon dioxid detected</option>
+          <option value="4">Water alarm</option>
+          <option value="5">Heat alarm</option>
+          <option value="6">Smoke alarm</option>
+          <option value="9">Sensor binary</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_110_2" type="integer" groupName="configuration"
+                 min="0" max="32536">
+        <label>110: Temperature sensor offset settings</label>
+        <description><![CDATA[
+Temperature sensor offset settings<br /><h1>Overview</h1><p>32536 = offset is 0.0°C<br />1..100 = offset is 0.1..10.0°C added to actual measuring value<br />1001..1100 = offset is -0.1..-10.0°C subtracted to actual measuring value</p>
+        ]]></description>
+        <default>32536</default>
+      </parameter>
+
+      <parameter name="config_120_1" type="integer" groupName="configuration"
+                 min="0" max="127">
+        <label>120: Digital temperature sensor reporting</label>
+        <description><![CDATA[
+Digital temperature sensor reporting<br /><h1>Overview</h1><p>If digital teperature sensor is connected, module reports measured temperature on temperture change defined by this parameter</p>
+        ]]></description>
+        <default>5</default>
+      </parameter>
+
+      <parameter name="config_121_1" type="integer" groupName="configuration">
+        <label>121: Digital temperature sensor / setpoint selector</label>
+        <description>Digital temperature sensor / setpoint selector</description>
+        <default>0</default>
+        <options>
+          <option value="0">internal sensor is mounted</option>
+          <option value="1">temperature is grabbed by sensor with assoc 3</option>
+          <option value="2">temperature is grabbed from ext battery sensor</option>
+          <option value="4">setpoint is grabbed by sensor with assoc 5</option>
+          <option value="8">setpoint is grabbed from ext battery sensor</option>
+          <option value="10">temperature an setpoint are grabbed from ext batt sensor</option>
+        </options>
+      </parameter>
+
+      <parameter name="config_122_1" type="integer" groupName="configuration"
+                 min="0" max="254">
+        <label>122: Node Id of external battery powered sensor</label>
+        <description><![CDATA[
+Node Id of external battery powered sensor<br /><h1>Overview</h1><p>0 - disabled</p> <p>1..254 = NodeId of external battery powered room sensor</p>
+        ]]></description>
+        <default>0</default>
+      </parameter>
+
+      <!-- ASSOCIATION DEFINITIONS -->
+      <parameter-group name="association">
+        <context>link</context>
+        <label>Association Groups</label>
+      </parameter-group>
+
+      <parameter name="group_1" type="text" groupName="association">
+        <label>1: Lifeline group</label>
+        <description>reserved for communication with the main controller</description>
+      </parameter>
+
+      <parameter name="group_2" type="text" groupName="association" multiple="true">
+        <label>2: basic on/off (output)</label>
+        <description>Triggered at change of the output</description>
+        <multipleLimit>16</multipleLimit>
+      </parameter>
+
+      <parameter name="group_3" type="text" groupName="association" multiple="true">
+        <label>3: Sensor_multilevel_get</label>
+        <multipleLimit>16</multipleLimit>
+      </parameter>
+
+      <parameter name="group_4" type="text" groupName="association" multiple="true">
+        <label>4: basic on/off (temp limit)</label>
+        <description>triggered by Too high temperature limit</description>
+        <multipleLimit>16</multipleLimit>
+      </parameter>
+
+      <parameter name="group_5" type="text" groupName="association" multiple="true">
+        <label>5: Thermostat setpoint get</label>
+        <multipleLimit>16</multipleLimit>
+      </parameter>
+
+      <parameter name="group_6" type="text" groupName="association" multiple="true">
+        <label>6: basic on/off (window)</label>
+        <description>triggered by change of I1</description>
+        <multipleLimit>16</multipleLimit>
+      </parameter>
+
+      <parameter name="group_7" type="text" groupName="association" multiple="true">
+        <label>7: basic on/off (condense sensor)</label>
+        <description>triggered by change of I2</description>
+        <multipleLimit>16</multipleLimit>
+      </parameter>
+
+      <parameter name="group_8" type="text" groupName="association" multiple="true">
+        <label>8: basic on/off (flood sensor)</label>
+        <description>triggered by change of I3</description>
+        <multipleLimit>16</multipleLimit>
+      </parameter>
+
+      <parameter name="group_9" type="text" groupName="association" multiple="true">
+        <label>9: sensor multilevel report</label>
+        <description>Triggered at change of temperature</description>
+        <multipleLimit>16</multipleLimit>
+      </parameter>
+
+    </config-description>
+
+  </thing-type>
+
+</thing:thing-descriptions>

--- a/ESH-INF/thing/remotec_zrc90_0_0.xml
+++ b/ESH-INF/thing/remotec_zrc90_0_0.xml
@@ -29,7 +29,7 @@
       <property name="vendor">Remotec</property>
       <property name="modelId">ZRC-90</property>
       <property name="manufacturerId">5254</property>
-      <property name="manufacturerRef">0001:8510,0002:8510</property>
+      <property name="manufacturerRef">0000:8510,0001:8510,0002:8510</property>
       <property name="dbReference">361</property>
       <property name="defaultAssociations">1</property>
     </properties>

--- a/ESH-INF/thing/rtc_ct32_0_0.xml
+++ b/ESH-INF/thing/rtc_ct32_0_0.xml
@@ -172,7 +172,7 @@
       <property name="vendor">Radio Thermostat Company of America (RTC)</property>
       <property name="modelId">CT32</property>
       <property name="manufacturerId">0098</property>
-      <property name="manufacturerRef">2002:0100</property>
+      <property name="manufacturerRef">2002:0100,2002:0102,0002:0100</property>
       <property name="dbReference">99</property>
       <property name="defaultAssociations">1</property>
     </properties>
@@ -228,9 +228,9 @@ Enables or Disables the Aux / Emergency Heat.<br /><h1>Overview</h1><p>The Auxil
       </parameter>
 
       <parameter name="config_7_1" type="integer" groupName="configuration">
-        <label>7: Sets the swing threshold before turning on / off HVAC.</label>
+        <label>7: Swing Temperature</label>
         <description><![CDATA[
-<br /><h1>Overview</h1><p>The Thermostat Swing Temperature configuration command sets swing temperature on the thermostat. The swing temperature is applied to the setpoint to determine when the thermostat will turn on the HVAC system.</p>
+Sets the swing threshold before turning on / off HVAC.<br /><h1>Overview</h1><p>The Thermostat Swing Temperature configuration command sets swing temperature on the thermostat. The swing temperature is applied to the setpoint to determine when the thermostat will turn on the HVAC system.</p>
         ]]></description>
         <default>2</default>
         <options>

--- a/ESH-INF/thing/schlage_be369_0_0.xml
+++ b/ESH-INF/thing/schlage_be369_0_0.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zwave"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+  xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0
+                      http://eclipse.org/smarthome/schemas/thing-description/v1.0.0">
+
+  <thing-type id="schlage_be369_00_000" listed="false">
+    <label>BE369 Keypad Deadbolt</label>
+    <description><![CDATA[
+Keypad Deadbolt<br /><h1>Overview</h1><p>Schlage BE369 Keypad Door Lock - </p> <p>Shares same hardware as FE599 lock (lever version).</p> <br /><h2>Inclusion Information</h2><ol><li>When prompted, follow the lock’s enrollment process: <ol><li>Enter your 6-digit programming code</li> <li>Wait for the device to beep three times</li> <li>Press the Schlage button</li> <li>Press 0</li> <li>The Schlage button will blink three times to confirm</li> </ol></li> </ol><br /><h2>Exclusion Information</h2><ol><li>When prompted, follow the lock’s removal process: <ol><li>Enter your 6-digit programming code</li> <li>Wait for the device to beep three times</li> <li>Press the Schlage button</li> <li>Press 0</li> <li>The Schlage button will blink three times to confirm</li> </ol></li> </ol><br /><h2>Wakeup Information</h2><p>Unknown</p>
+    ]]></description>
+
+    <!-- CHANNEL DEFINITIONS -->
+    <channels>
+      <channel id="lock_door" typeId="lock_door">
+        <label>Door Lock</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_DOOR_LOCK</property>
+        </properties>
+      </channel>
+      <channel id="alarm_general" typeId="alarm_general">
+        <label>Alarm</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_ALARM</property>
+        </properties>
+      </channel>
+      <channel id="battery-level" typeId="system.battery-level">
+        <properties>
+          <property name="binding:*:PercentType">COMMAND_CLASS_BATTERY</property>
+        </properties>
+      </channel>
+    </channels>
+
+    <!-- DEVICE PROPERTY DEFINITIONS -->
+    <properties>
+      <property name="vendor">Allegion</property>
+      <property name="modelId">BE369</property>
+      <property name="manufacturerId">003B</property>
+      <property name="manufacturerRef">634B:5044</property>
+      <property name="dbReference">518</property>
+    </properties>
+
+  </thing-type>
+
+</thing:thing-descriptions>

--- a/ESH-INF/thing/shenzhen_sirenalarm_0_0.xml
+++ b/ESH-INF/thing/shenzhen_sirenalarm_0_0.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zwave"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+  xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0
+                      http://eclipse.org/smarthome/schemas/thing-description/v1.0.0">
+
+  <thing-type id="shenzhen_sirenalarm_00_000" listed="false">
+    <label>Siren Alarm Siren Alarm</label>
+    <description>Siren Alarm</description>
+
+    <!-- CHANNEL DEFINITIONS -->
+    <channels>
+      <channel id="switch_binary" typeId="switch_binary">
+        <label>Switch</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_SWITCH_BINARY</property>
+        </properties>
+      </channel>
+      <channel id="alarm_general" typeId="alarm_general">
+        <label>Alarm</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_ALARM</property>
+        </properties>
+      </channel>
+      <channel id="battery-level" typeId="system.battery-level">
+        <properties>
+          <property name="binding:*:PercentType">COMMAND_CLASS_BATTERY</property>
+        </properties>
+      </channel>
+    </channels>
+
+    <!-- DEVICE PROPERTY DEFINITIONS -->
+    <properties>
+      <property name="vendor">Shenzhen Neo Electronics Co., Ltd</property>
+      <property name="modelId">Siren Alarm</property>
+      <property name="manufacturerId">0258</property>
+      <property name="manufacturerRef">0003:1088</property>
+      <property name="dbReference">522</property>
+      <property name="defaultAssociations">1,2,3</property>
+    </properties>
+
+    <!-- CONFIGURATION DESCRIPTIONS -->
+    <config-description>
+
+      <!-- PARAMETER DEFINITIONS -->
+      <parameter-group name="configuration">
+        <context>setup</context>
+        <label>Configuration Parameters</label>
+      </parameter-group>
+
+      <parameter name="config_1_1" type="integer" groupName="configuration"
+                 min="1" max="3">
+        <label>1: Configure Alarm music volume</label>
+        <description>Configure Alarm music volume</description>
+        <default>2</default>
+      </parameter>
+
+      <parameter name="config_2_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>2: Alarm music duration time</label>
+        <description>Alarm music duration time</description>
+        <default>2</default>
+      </parameter>
+
+      <parameter name="config_3_1" type="integer" groupName="configuration"
+                 min="0" max="255">
+        <label>3: Door bell music duration time</label>
+        <description>Door bell music duration time</description>
+        <default>1</default>
+      </parameter>
+
+      <parameter name="config_4_1" type="integer" groupName="configuration"
+                 min="1" max="3">
+        <label>4: Door bell music volume</label>
+        <description>Door bell music volume</description>
+        <default>2</default>
+      </parameter>
+
+      <parameter name="config_5_1" type="integer" groupName="configuration"
+                 min="1" max="10">
+        <label>5: Alarm music index</label>
+        <description>Alarm music index</description>
+        <default>9</default>
+      </parameter>
+
+      <parameter name="config_6_1" type="integer" groupName="configuration"
+                 min="1" max="10">
+        <label>6: Door bell music index</label>
+        <description>Door bell music index</description>
+        <default>10</default>
+      </parameter>
+
+      <parameter name="config_7_1" type="integer" groupName="configuration"
+                 min="1" max="2">
+        <label>7: Default Siren on mode</label>
+        <description><![CDATA[
+Default Siren on mode<br /><h1>Overview</h1><p>This parameter defines the default music index, volume and duration time for siren on.</p> <p>This parameter can be selected between ALARM MUSIC and DOOR BELL music.</p> <p>The settings for ALARM MUSIC defines by Param #1, #2, #5.</p> <p>The settings for DOOR BELL defines by Param #3, #4, #6.</p>
+        ]]></description>
+        <default>1</default>
+      </parameter>
+
+      <!-- ASSOCIATION DEFINITIONS -->
+      <parameter-group name="association">
+        <context>link</context>
+        <label>Association Groups</label>
+      </parameter-group>
+
+      <parameter name="group_1" type="text" groupName="association" multiple="true">
+        <label>1: Group 1</label>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+      <parameter name="group_2" type="text" groupName="association" multiple="true">
+        <label>2: Group 2</label>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+      <parameter name="group_3" type="text" groupName="association" multiple="true">
+        <label>3: Group2</label>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+    </config-description>
+
+  </thing-type>
+
+</thing:thing-descriptions>

--- a/ESH-INF/thing/vision_zs5101_0_0.xml
+++ b/ESH-INF/thing/vision_zs5101_0_0.xml
@@ -19,10 +19,16 @@ Shock Sensor<br /><h1>Overview</h1><p>ZS5101 detects the vibrations made by an i
           <property name="binding:*:OnOffType">COMMAND_CLASS_SENSOR_BINARY</property>
         </properties>
       </channel>
-      <channel id="alarm_burglar" typeId="alarm_burglar">
-        <label>Alarm (burglar)</label>
+      <channel id="alarm_access" typeId="alarm_access">
+        <label>Shock Alarm</label>
         <properties>
-          <property name="binding:*:OnOffType">COMMAND_CLASS_ALARM;type=BURGLAR</property>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_ALARM;type=BURGLAR, event=2</property>
+        </properties>
+      </channel>
+      <channel id="alarm_tamper" typeId="alarm_tamper">
+        <label>Tamper Alarm</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_ALARM;type=BURGLAR, event=3</property>
         </properties>
       </channel>
       <channel id="battery-level" typeId="system.battery-level">
@@ -39,7 +45,23 @@ Shock Sensor<br /><h1>Overview</h1><p>ZS5101 detects the vibrations made by an i
       <property name="manufacturerId">0109</property>
       <property name="manufacturerRef">2003:0306,2003:0307</property>
       <property name="dbReference">442</property>
+      <property name="defaultAssociations">1</property>
     </properties>
+
+    <!-- CONFIGURATION DESCRIPTIONS -->
+    <config-description>
+
+      <!-- ASSOCIATION DEFINITIONS -->
+      <parameter-group name="association">
+        <context>link</context>
+        <label>Association Groups</label>
+      </parameter-group>
+
+      <parameter name="group_1" type="text" groupName="association">
+        <label>1: Lifeline</label>
+      </parameter>
+
+    </config-description>
 
   </thing-type>
 

--- a/ESH-INF/thing/yale_yrd220_0_0.xml
+++ b/ESH-INF/thing/yale_yrd220_0_0.xml
@@ -37,7 +37,7 @@ Yale Real Living Touchscreen Deadbolt<br /><h2>Inclusion Information</h2><p>To i
       <property name="vendor">ASSA ABLOY</property>
       <property name="modelId">YRD220</property>
       <property name="manufacturerId">0129</property>
-      <property name="manufacturerRef">0002:0000,0002:AA00,0002:FFFF</property>
+      <property name="manufacturerRef">0002:0000,0002:0209,0002:AA00,0002:FFFF</property>
       <property name="dbReference">321</property>
       <property name="defaultAssociations">1</property>
     </properties>

--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
@@ -681,11 +681,18 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
         return controller.getNodes();
     }
 
-    public void sendData(ZWaveCommandClassTransactionPayload zWaveCommandClassTransactionPayload) {
+    /**
+     * Transmits the {@link ZWaveCommandClassTransactionPayload} to a Node.
+     * This will not wait for the transaction response.
+     *
+     * @param transaction
+     *            the {@link ZWaveCommandClassTransactionPayload} message to send.
+     */
+    public void sendData(ZWaveCommandClassTransactionPayload transaction) {
         if (controller == null) {
             return;
         }
-        controller.sendData(zWaveCommandClassTransactionPayload);
+        controller.sendData(transaction);
     }
 
     public boolean addEventListener(ZWaveThingHandler zWaveThingHandler) {

--- a/src/main/java/org/openhab/binding/zwave/internal/ZWaveProduct.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/ZWaveProduct.java
@@ -76,14 +76,14 @@ public class ZWaveProduct {
 
         // If the node version is less than the database version, then no match
         if (versionMin != null) {
-            if (vIn.compareTo(versionMin) < 0) {
+            if (vIn.compareTo(versionMin) <= 0) {
                 return false;
             }
         }
 
         // If the node version is greater than the database version, then no match
         if (versionMax != null) {
-            if (vIn.compareTo(versionMax) > 0) {
+            if (vIn.compareTo(versionMax) >= 0) {
                 return false;
             }
         }

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -482,46 +482,57 @@ public class ZWaveController {
 
     /**
      * Queues a message for sending on the send queue.
+     * This does not wait for a response.
      *
-     * @param zWaveCommandClassTransactionPayload
-     *            the serial message to enqueue.
+     * @param transaction
+     *            the {@link ZWaveMessagePayloadTransaction} message to enqueue.
      */
-    public void enqueue(ZWaveMessagePayloadTransaction payload) {
+    public void enqueue(ZWaveMessagePayloadTransaction transaction) {
         // Sanity check!
-        if (payload == null) {
+        if (transaction == null) {
             logger.debug("Attempt to queue null message");
             return;
         }
 
-        transactionManager.queueTransactionForSend(payload);
+        // Since this method doesn't wait for a response, we tell the transaction handler not to wait for DATA
+        if (transaction instanceof ZWaveCommandClassTransactionPayload) {
+            ((ZWaveCommandClassTransactionPayload) transaction).setRequiresResponse(false);
+        }
+
+        transactionManager.queueTransactionForSend(transaction);
     }
 
-    public void enqueueNonce(ZWaveMessagePayloadTransaction payload) {
+    /**
+     * Queues a message for sending on the nonce send queue.
+     * This does not wait for a response.
+     *
+     * @param transaction
+     *            the {@link ZWaveMessagePayloadTransaction} message to enqueue.
+     */
+    public void enqueueNonce(ZWaveMessagePayloadTransaction transaction) {
         // Sanity check!
-        if (payload == null) {
+        if (transaction == null) {
             logger.debug("Attempt to queue null message");
             return;
         }
 
-        transactionManager.queueNonceReportForSend(payload);
+        transactionManager.queueNonceReportForSend(transaction);
     }
 
+    /**
+     * Queues a message for sending and returns the response once received.
+     *
+     * @param transaction
+     *            the {@link ZWaveMessagePayloadTransaction} message to enqueue.
+     */
     public ZWaveTransactionResponse sendTransaction(ZWaveMessagePayloadTransaction transaction) {
         return transactionManager.sendTransaction(transaction);
     }
 
     /**
-     * Returns the size of the send queue.
-     */
-    // public int getSendQueueLength() {
-    // return transactionManager.getSendQueueLength();
-    // }
-
-    /**
      * Returns the size of the send queue for a specific node.
      */
     public int getSendQueueLength(int nodeId) {
-        // TODO: Should this also account for outstanding transactions???
         return transactionManager.getSendQueueLength(nodeId);
     }
 
@@ -1004,16 +1015,16 @@ public class ZWaveController {
     }
 
     /**
-     * Transmits the SerialMessage to a single ZWave Node. Sets the transmission options as well.
+     * Transmits the {@link ZWaveCommandClassTransactionPayload} to a single ZWave Node.
      *
-     * @param zWaveCommandClassTransactionPayload
-     *            the Serial message to send.
+     * @param payload
+     *            the {@link ZWaveCommandClassTransactionPayload} message to send.
      */
-    public void sendData(ZWaveCommandClassTransactionPayload payload) {
-        if (payload == null) {
+    public void sendData(ZWaveCommandClassTransactionPayload transaction) {
+        if (transaction == null) {
             return;
         }
-        enqueue(payload);
+        enqueue(transaction);
     }
 
     /**

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveIoHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveIoHandler.java
@@ -8,6 +8,11 @@
  */
 package org.openhab.binding.zwave.internal.protocol;
 
+/**
+ *
+ * @author Chris Jackson - Initial Contribution
+ *
+ */
 public interface ZWaveIoHandler {
     void deviceDiscovered(int node);
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveMessagePayload.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveMessagePayload.java
@@ -1,5 +1,10 @@
 package org.openhab.binding.zwave.internal.protocol;
 
+/**
+ *
+ * @author Chris Jackson - Initial Contribution
+ *
+ */
 public interface ZWaveMessagePayload {
     public byte[] getPayloadBuffer();
 }

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveMessagePayloadTransaction.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveMessagePayloadTransaction.java
@@ -3,6 +3,11 @@ package org.openhab.binding.zwave.internal.protocol;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
 import org.openhab.binding.zwave.internal.protocol.ZWaveTransaction.TransactionPriority;
 
+/**
+ *
+ * @author Chris Jackson - Initial Contribution
+ *
+ */
 public interface ZWaveMessagePayloadTransaction extends ZWaveMessagePayload {
     public int getMaxAttempts();
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -1025,7 +1025,7 @@ public class ZWaveNode {
     public ZWaveCommandClassTransactionPayload encapsulate(ZWaveCommandClassTransactionPayload transaction,
             ZWaveCommandClass commandClass, int endpointId) {
         ZWaveMultiInstanceCommandClass multiInstanceCommandClass;
-        logger.warn("NODE {}: Encapsulating message, endpoint {}", getNodeId(), endpointId);
+        logger.debug("NODE {}: Encapsulating message, endpoint {}", getNodeId(), endpointId);
 
         if (transaction == null) {
             return null;

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionComparator.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionComparator.java
@@ -2,6 +2,11 @@ package org.openhab.binding.zwave.internal.protocol;
 
 import java.util.Comparator;
 
+/**
+ *
+ * @author Chris Jackson - Initial Contribution
+ *
+ */
 public class ZWaveTransactionComparator implements Comparator<ZWaveTransaction> {
 
     // private final ZWaveController controller;

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionManager.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionManager.java
@@ -121,7 +121,7 @@ public class ZWaveTransactionManager {
     private Logger logger = LoggerFactory.getLogger(ZWaveTransactionManager.class);
 
     private final int INITIAL_TX_QUEUE_SIZE = 128;
-    private final int MAX_OUTSTANDING_TRANSACTIONS = 3;
+    // private final int MAX_OUTSTANDING_TRANSACTIONS = 3;
 
     public final int TRANSMIT_OPTION_ACK = 0x01;
     public final int TRANSMIT_OPTION_AUTO_ROUTE = 0x04;
@@ -246,6 +246,7 @@ public class ZWaveTransactionManager {
     }
 
     public long queueTransactionForSend(ZWaveMessagePayloadTransaction payload) {
+
         // Create a transaction from our payload data
         ZWaveTransaction transaction = new ZWaveTransaction(payload);
         if (payload.getMaxAttempts() != 0) {
@@ -399,7 +400,7 @@ public class ZWaveTransactionManager {
                         ZWaveNode node = controller.getNode(nodeId);
 
                         if (node == null) {
-                            logger.warn("NODE {}: Not initialized yet (ie node unknown), ignoring message.", nodeId);
+                            logger.warn("NODE {}: Not initialized (ie node unknown), ignoring message.", nodeId);
                         } else {
                             logger.debug("NODE {}: Application Command Request ({}:{})", nodeId,
                                     node.getNodeState().toString(), node.getNodeInitStage().toString());
@@ -421,6 +422,8 @@ public class ZWaveTransactionManager {
                                                     transaction.getExpectedReplyClass());
                                             logger.debug("NODE {}: Checking transaction : state >> {}", nodeId,
                                                     transaction.getTransactionState());
+                                            logger.debug("NODE {}: Checking transaction : node  >> {}", nodeId,
+                                                    transaction.getNodeId());
                                             logger.debug("NODE {}: Checking transaction : class >> {} == {}.", nodeId,
                                                     command.getCommandClassId(),
                                                     transaction.getExpectedCommandClass() == null ? null
@@ -441,6 +444,7 @@ public class ZWaveTransactionManager {
                                                     && transaction.getExpectedCommandClass() != null
                                                     && command.getCommandClassId() == transaction
                                                             .getExpectedCommandClass().getKey()
+                                                    && nodeId == transaction.getNodeId()
                                                     && command.getCommandClassCommand() == transaction
                                                             .getExpectedCommandClassCommand()) {
                                                 logger.debug("NODE {}: Command verified {}.", nodeId, command);
@@ -548,6 +552,8 @@ public class ZWaveTransactionManager {
                                 lastTransaction = null;
                                 logger.debug("XXXXXXXXXXXXXXXXX lastTransaction COMPLETED - at DATA - "
                                         + currentTransaction.getCallbackId());
+                            } else if (currentTransaction.getWaitForResponse()) {
+
                             }
                             break;
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionManager.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionManager.java
@@ -407,30 +407,31 @@ public class ZWaveTransactionManager {
                             List<ZWaveCommandClassPayload> commands = node
                                     .processCommand(new ZWaveCommandClassPayload(incomingMessage));
                             if (commands != null) {
-                                logger.warn("NODE {}: Commands processed {}.", nodeId, commands.size());
+                                logger.debug("NODE {}: Commands processed {}.", nodeId, commands.size());
 
                                 for (ZWaveCommandClassPayload command : commands) {
-                                    logger.warn("NODE {}: Checking command {}.", nodeId, command);
+                                    logger.debug("NODE {}: Checking command {}.", nodeId, command);
                                     // Correlate transactions
                                     List<ZWaveTransaction> completed = new ArrayList<ZWaveTransaction>();
 
                                     synchronized (sendQueue) {
                                         for (ZWaveTransaction transaction : outstandingTransactions) {
-                                            logger.warn("NODE {}: Checking transaction {}  {}.", nodeId,
+                                            logger.debug("NODE {}: Checking transaction {}  {}.", nodeId,
                                                     transaction.getTransactionId(),
                                                     transaction.getExpectedReplyClass());
-                                            logger.warn("NODE {}: Checking transaction : state >> {}", nodeId,
+                                            logger.debug("NODE {}: Checking transaction : state >> {}", nodeId,
                                                     transaction.getTransactionState());
-                                            logger.warn("NODE {}: Checking transaction : class >> {} == {}.", nodeId,
+                                            logger.debug("NODE {}: Checking transaction : class >> {} == {}.", nodeId,
                                                     command.getCommandClassId(),
                                                     transaction.getExpectedCommandClass() == null ? null
                                                             : transaction.getExpectedCommandClass().getKey());
-                                            logger.warn("NODE {}: Checking transaction : commd >> {} == {}.", nodeId,
+                                            logger.debug("NODE {}: Checking transaction : commd >> {} == {}.", nodeId,
                                                     command.getCommandClassCommand(),
                                                     transaction.getExpectedCommandClassCommand());
 
                                             if (transaction.getTransactionState() != TransactionState.WAIT_DATA) {
-                                                logger.warn("NODE {}: Ignoring transaction since not waiting for data.",
+                                                logger.debug(
+                                                        "NODE {}: Ignoring transaction since not waiting for data.",
                                                         nodeId);
                                                 continue;
                                             }
@@ -442,7 +443,7 @@ public class ZWaveTransactionManager {
                                                             .getExpectedCommandClass().getKey()
                                                     && command.getCommandClassCommand() == transaction
                                                             .getExpectedCommandClassCommand()) {
-                                                logger.warn("NODE {}: Command verified {}.", nodeId, command);
+                                                logger.debug("NODE {}: Command verified {}.", nodeId, command);
 
                                                 transaction.transactionAdvance(incomingMessage);
 
@@ -466,14 +467,14 @@ public class ZWaveTransactionManager {
                                                             .getLinkedTransaction());
                                                 }
                                             } else {
-                                                logger.warn("NODE {}: Command NOT verified {}.", nodeId, command);
+                                                logger.debug("NODE {}: Command NOT verified {}.", nodeId, command);
                                             }
                                         }
 
-                                        logger.warn("Transaction completed - outstandingTransactions {}",
+                                        logger.debug("Transaction completed - outstandingTransactions {}",
                                                 outstandingTransactions.size());
                                         outstandingTransactions.removeAll(completed);
-                                        logger.warn("Transaction completed - outstandingTransactions {}",
+                                        logger.debug("Transaction completed - outstandingTransactions {}",
                                                 outstandingTransactions.size());
                                     }
                                 }
@@ -596,7 +597,7 @@ public class ZWaveTransactionManager {
                             // enqueue(currentTransaction); TODO: Handle retries...
                             // }
                             // } else {
-                            // logger.warn("NODE {}: Retry count exceeded. Discarding message: {}",
+                            // logger.debug("NODE {}: Retry count exceeded. Discarding message: {}",
                             // currentTransaction.getNodeId(), currentTransaction.toString());
                             // Notify our users...
                             transactionCompleted = true;

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionResponse.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionResponse.java
@@ -1,5 +1,10 @@
 package org.openhab.binding.zwave.internal.protocol;
 
+/**
+ *
+ * @author Chris Jackson - Initial Contribution
+ *
+ */
 public class ZWaveTransactionResponse {
     public enum State {
         CANCELLED,

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatSetbackCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatSetbackCommandClass.java
@@ -23,7 +23,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
  * @author Chris Jackson
  *
  */
-@XStreamAlias("COMMAND_CLASS_THERMOSTAT_SETPOINT")
+@XStreamAlias("COMMAND_CLASS_THERMOSTAT_SETBACK")
 public class ZWaveThermostatSetbackCommandClass extends ZWaveCommandClass {
 
     @XStreamOmitField
@@ -45,6 +45,6 @@ public class ZWaveThermostatSetbackCommandClass extends ZWaveCommandClass {
      */
     @Override
     public CommandClass getCommandClass() {
-        return CommandClass.COMMAND_CLASS_THERMOSTAT_SETPOINT;
+        return CommandClass.COMMAND_CLASS_THERMOSTAT_SETBACK;
     }
 }

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/transaction/ZWaveCommandClassTransactionPayload.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/transaction/ZWaveCommandClassTransactionPayload.java
@@ -7,9 +7,12 @@ import org.openhab.binding.zwave.internal.protocol.ZWaveCommandClassPayload;
 import org.openhab.binding.zwave.internal.protocol.ZWaveMessagePayloadTransaction;
 import org.openhab.binding.zwave.internal.protocol.ZWaveTransaction.TransactionPriority;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ *
+ * @author Chris Jackson - Initial Contribution
+ *
+ */
 public class ZWaveCommandClassTransactionPayload extends ZWaveCommandClassPayload
         implements ZWaveMessagePayloadTransaction {
     private final int nodeId;
@@ -19,8 +22,7 @@ public class ZWaveCommandClassTransactionPayload extends ZWaveCommandClassPayloa
     private int maxAttempts = 0;
 
     private boolean requiresSecurity = false;
-
-    private static final Logger logger = LoggerFactory.getLogger(ZWaveCommandClassTransactionPayload.class);
+    private boolean requiresResponse = true;
 
     /**
      *
@@ -136,4 +138,11 @@ public class ZWaveCommandClassTransactionPayload extends ZWaveCommandClassPayloa
         return requiresSecurity;
     }
 
+    public void setRequiresResponse(boolean requiresResponse) {
+        this.requiresResponse = requiresResponse;
+    }
+
+    public boolean getRequiresResponse() {
+        return requiresResponse;
+    }
 }

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/transaction/ZWaveCommandClassTransactionPayloadComparator.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/transaction/ZWaveCommandClassTransactionPayloadComparator.java
@@ -4,6 +4,11 @@ import java.util.Comparator;
 
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
 
+/**
+ *
+ * @author Chris Jackson - Initial Contribution
+ *
+ */
 public class ZWaveCommandClassTransactionPayloadComparator implements Comparator<ZWaveCommandClassTransactionPayload> {
 
     /**

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/transaction/ZWaveTransactionMessageBuilder.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/transaction/ZWaveTransactionMessageBuilder.java
@@ -5,7 +5,7 @@ import org.openhab.binding.zwave.internal.protocol.ZWaveSerialPayload;
 import org.openhab.binding.zwave.internal.protocol.ZWaveTransaction.TransactionPriority;
 
 /**
- * Builder class for serial message
+ * Builder class for transaction
  *
  * @author Chris Jackson - Initial Implementation
  *


### PR DESCRIPTION
Main changes -:
* Only poll channels where there are items linked
* Add a flag so as not to wait for data when doing "non-transaction" requests. This means that polls will only wait for the initial ACK from the controller, and not the actual data. This should make it more responsive, and also eliminate delays where a device doesn't respond for any reason (eg misconfiguration). In general, the only transactions where we need to wait for a response currently is during initialisation and heal. [this is a little experimental - if polling many channels on a single device, it could have problems].
* Change product comparison to include equals (#341)
