### PR TITLE
Added missing meter_reset channels

### DIFF
--- a/ESH-INF/thing/aeon_zw075_0_0.xml
+++ b/ESH-INF/thing/aeon_zw075_0_0.xml
@@ -41,6 +41,12 @@
           <property name="binding:*:DecimalType">METER;type=E_KWh</property>
         </properties>
       </channel>
+      <channel id="meter_reset" typeId="meter_reset">
+        <label>Reset the total power consumption</label>
+        <properties>
+          <property name="binding:*:OnOffType">METER</property>
+        </properties>
+      </channel>
       <channel id="battery-level" typeId="system.battery-level">
         <properties>
           <property name="binding:*:PercentType">BATTERY</property>

--- a/ESH-INF/thing/fibaro_fgcc001_0_0.xml
+++ b/ESH-INF/thing/fibaro_fgcc001_0_0.xml
@@ -158,6 +158,7 @@ Parameter defines how commands are sent in specified association groups: as secu
           <option value="8">5th group "Flick RIGHT” sent as secure</option>
           <option value="16">6th group "Circular AirWheel” sent as secure</option>
         </options>
+        <limitToOptions>false</limitToOptions>
       </parameter>
 
       <parameter name="config_12_1" type="integer" groupName="configuration">
@@ -172,6 +173,7 @@ Parameter allows to choose control mode for 2nd-5th groups and scenes.<br /><h1>
           <option value="4">Toggle Mode enabled for 4th association group</option>
           <option value="8">Toggle Mode enabled for 5th association group</option>
         </options>
+        <limitToOptions>false</limitToOptions>
       </parameter>
 
       <parameter name="config_13_2" type="integer" groupName="configuration"

--- a/ESH-INF/thing/fibaro_fgrm222_0_0.xml
+++ b/ESH-INF/thing/fibaro_fgrm222_0_0.xml
@@ -49,6 +49,12 @@
           <property name="binding:*:DecimalType">METER;type=E_KWH</property>
         </properties>
       </channel>
+      <channel id="meter_reset" typeId="meter_reset">
+        <label>Reset the total power consumption</label>
+        <properties>
+          <property name="binding:*:OnOffType">METER</property>
+        </properties>
+      </channel>
     </channels>
 
     <!-- DEVICE PROPERTY DEFINITIONS -->

--- a/ESH-INF/thing/fibaro_fgrm222_24_24.xml
+++ b/ESH-INF/thing/fibaro_fgrm222_24_24.xml
@@ -51,6 +51,12 @@ Roller Shutter<br /><h1>Overview</h1><p>The device allows for controlling motors
           <property name="binding:*:DecimalType">METER;type=E_KWh</property>
         </properties>
       </channel>
+      <channel id="meter_reset" typeId="meter_reset">
+        <label>Reset the total power consumption</label>
+        <properties>
+          <property name="binding:*:OnOffType">METER</property>
+        </properties>
+      </channel>
     </channels>
 
     <!-- DEVICE PROPERTY DEFINITIONS -->

--- a/ESH-INF/thing/qubino_zmnhad_0_0.xml
+++ b/ESH-INF/thing/qubino_zmnhad_0_0.xml
@@ -35,6 +35,12 @@
           <property name="binding:*:DecimalType">METER;type=E_KWh</property>
         </properties>
       </channel>
+      <channel id="meter_reset" typeId="meter_reset">
+        <label>Reset the total power consumption</label>
+        <properties>
+          <property name="binding:*:OnOffType">METER</property>
+        </properties>
+      </channel>
       <channel id="alarm_power" typeId="alarm_power">
         <label>Alarm (power)</label>
         <properties>
@@ -57,6 +63,12 @@
         <label>Electric meter (kWh) 1</label>
         <properties>
           <property name="binding:*:DecimalType">METER:1;type=E_KWh</property>
+        </properties>
+      </channel>
+      <channel id="meter_reset1" typeId="meter_reset">
+        <label>Reset the total power consumption</label>
+        <properties>
+          <property name="binding:*:OnOffType">METER:1</property>
         </properties>
       </channel>
       <channel id="sensor_binary2" typeId="sensor_binary">

--- a/ESH-INF/thing/qubino_zmnhbd_0_0.xml
+++ b/ESH-INF/thing/qubino_zmnhbd_0_0.xml
@@ -37,6 +37,12 @@ Flush 2 relays<br /><h1>Overview</h1><p>This Z-Wave module is used for switching
           <property name="binding:*:DecimalType">METER;type=E_KWh</property>
         </properties>
       </channel>
+      <channel id="meter_reset" typeId="meter_reset">
+        <label>Reset the total power consumption</label>
+        <properties>
+          <property name="binding:*:OnOffType">METER</property>
+        </properties>
+      </channel>
       <channel id="switch_binary1" typeId="switch_binary">
         <label>Switch 1</label>
         <properties>
@@ -55,6 +61,12 @@ Flush 2 relays<br /><h1>Overview</h1><p>This Z-Wave module is used for switching
           <property name="binding:*:DecimalType">METER:1;type=E_KWh</property>
         </properties>
       </channel>
+      <channel id="meter_reset1" typeId="meter_reset">
+        <label>Reset the total power consumption</label>
+        <properties>
+          <property name="binding:*:OnOffType">METER:1</property>
+        </properties>
+      </channel>
       <channel id="switch_binary2" typeId="switch_binary">
         <label>Switch 2</label>
         <properties>
@@ -71,6 +83,12 @@ Flush 2 relays<br /><h1>Overview</h1><p>This Z-Wave module is used for switching
         <label>Electric meter (kWh) 2</label>
         <properties>
           <property name="binding:*:DecimalType">METER:2;type=E_KWh</property>
+        </properties>
+      </channel>
+      <channel id="meter_reset2" typeId="meter_reset">
+        <label>Reset the total power consumption</label>
+        <properties>
+          <property name="binding:*:OnOffType">METER:2</property>
         </properties>
       </channel>
     </channels>


### PR DESCRIPTION
I’ve added some missing meter_reset channels. I already tested this and
it works perfectly. Please add this to the main repository.

Signed-off-by: David Masshardt <david@masshardt.ch> (github:
TheNetStriker)