### PR TITLE
Add clock and emergency alarm channels

### DIFF
--- a/ESH-INF/thing/_channels.xml
+++ b/ESH-INF/thing/_channels.xml
@@ -19,6 +19,7 @@
         </state>
     </channel-type>
     
+    <!-- Battery Alarm Channel -->
     <channel-type id="alarm_battery">
         <item-type>Switch</item-type>
         <label>Low battery alarm</label>
@@ -68,6 +69,36 @@
         <item-type>Switch</item-type>
         <label>Carbon-dioxide alarm</label>
         <description>Indicates if the carbon dioxide alarm is triggered
+        </description>
+        <category>Door</category>
+        <state readOnly="true">
+            <options>
+                <option value="OFF">Ok</option>
+                <option value="ON">Alarm</option>
+            </options>
+        </state>
+    </channel-type>
+
+    <!-- Clock Alarm Channel -->
+    <channel-type id="alarm_clock">
+        <item-type>Switch</item-type>
+        <label>Clock alarm</label>
+        <description>Indicates if the clock alarm is triggered
+        </description>
+        <category>Door</category>
+        <state readOnly="true">
+            <options>
+                <option value="OFF">Ok</option>
+                <option value="ON">Alarm</option>
+            </options>
+        </state>
+    </channel-type>
+
+    <!-- Emergency Alarm Channel -->
+    <channel-type id="alarm_emergency">
+        <item-type>Switch</item-type>
+        <label>Emergency alarm</label>
+        <description>Indicates if the emergency alarm is triggered
         </description>
         <category>Door</category>
         <state readOnly="true">


### PR DESCRIPTION
This adds the two alarm channels that are required for the [Aeon ZW097](http://www.cd-jackson.com/index.php/zwave/zwave-device-database/zwave-device-list/devicesummary/267).

The [Alphonsus Tech IDL-101](http://www.cd-jackson.com/index.php/zwave/zwave-device-database/zwave-device-list/devicesummary/384) also seems to make use of the emergency alarm, but is currently configured to use the alarm_general channel.

Signed-off-by: Andrew Nagle <kabili@zyrenth.com>