### PR TITLE
Add POWER_STRIP specific device class

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveDeviceClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveDeviceClass.java
@@ -401,6 +401,7 @@ public class ZWaveDeviceClass {
         POWER_SWITCH_BINARY(1, Generic.BINARY_SWITCH, "Binary Power Switch"),
         SCENE_SWITCH_BINARY_DISCONTINUED(2, Generic.BINARY_SWITCH, "Binary Scene Switch (Discontinued)"),
         SCENE_SWITCH_BINARY(3, Generic.BINARY_SWITCH, "Binary Scene Switch"),
+        POWER_STRIP(4, Generic.BINARY_SWITCH, "Power Strip Device"),
         SIREN_SWITCH_BINARY(5, Generic.BINARY_SWITCH, "Siren Switch"),
         VALVE_SWITCH_BINARY(6, Generic.BINARY_SWITCH, "Valve Switch"),
 


### PR DESCRIPTION
I needed this for my [Zooz ZEN20](http://products.z-wavealliance.org/products/1818) power strip to be recognized. With the new specific device class and [this thing XML](https://github.com/quadule/org.openhab.binding.zwave/commit/b50359c37ae4a6e887acc5aa2ca73ffe1831b41f) (which I will submit to the database separately) it now works as expected.

SPECIFIC_TYPE_POWER_STRIP can be found on page 31 of [this spec](http://z-wave.sigmadesigns.com/wp-content/uploads/2016/08/SDS13740-1-Z-Wave-Plus-Device-and-Command-Class-Types-and-Defines-Specification.pdf).

Signed-off-by: Milo Winningham <milo@winningham.net>