### PR TITLE
Remove Jekyll preamble from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
----
-layout: documentation
----
-
-{% include base.html %}
-
 # ZWave Binding
+
 The ZWave binding supports an interface to a wireless Z-Wave home automation network. 
 
 ZWave is a wireless home automation protocol with reliable two way communications between nodes. It supports a mesh network where mains powered nodes can route messages between nodes that could otherwise not communicate with each other. The network supports hop distances of up to four hops.


### PR DESCRIPTION
It interferes with the documentation build process, which applies its own correct preamble.