### PR TITLE
Implemented dummy support for CLIMATE_CONTROL_SCHEDULE

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveClimateControlScheduleCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveClimateControlScheduleCommandClass.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2014-2016 by the respective copyright holders.
- * <p>
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveClimateControlScheduleCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveClimateControlScheduleCommandClass.java
@@ -8,27 +8,38 @@
  */
 package org.openhab.binding.zwave.internal.protocol.commandclass;
 
-import org.openhab.binding.zwave.internal.protocol.SerialMessage;
-import org.openhab.binding.zwave.internal.protocol.ZWaveController;
-import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
-import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
-import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
+import org.openhab.binding.zwave.internal.protocol.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamOmitField;
+import java.io.ByteArrayOutputStream;
+import java.util.Objects;
 
 /**
  * Handles the climate control schedule command class.
  *
  * @author Chris Jackson
+ * @author Max Berger
  */
 @XStreamAlias("climateControlScheduleCommandClass")
 public class ZWaveClimateControlScheduleCommandClass extends ZWaveCommandClass {
 
     @XStreamOmitField
     private static final Logger logger = LoggerFactory.getLogger(ZWaveClimateControlScheduleCommandClass.class);
+
+    private static final int SCHEDULE_CHANGED_GET = 0x04;
+    private static final int SCHEDULE_CHANGED_REPORT = 0x05;
+    private static final int SCHEDULE_GET = 0x02;
+    private static final int SCHEDULE_OVERRIDE_GET = 0x07;
+    private static final int SCHEDULE_OVERRIDE_REPORT = 0x08;
+    private static final int SCHEDULE_OVERRIDE_SET = 0x06;
+    private static final int SCHEDULE_REPORT = 0x03;
+    private static final int SCHEDULE_SET = 0x01;
+
+    private static final byte SCHEDULE_CHANGE_TEMPORARILY_DISABLED = 0;
+
 
     /**
      * Creates a new instance of the ZWaveClimateControlCommandClass class.
@@ -61,10 +72,80 @@ public class ZWaveClimateControlScheduleCommandClass extends ZWaveCommandClass {
                 this.getVersion());
         int command = serialMessage.getMessagePayloadByte(offset);
         switch (command) {
+            case SCHEDULE_CHANGED_GET:
+                logger.debug("Answering with noop SCHEDULE_CHANGED_REPORT");
+                getController().enqueue(getScheduleChangedReportMessage(SCHEDULE_CHANGE_TEMPORARILY_DISABLED));
+                break;
+            case SCHEDULE_OVERRIDE_REPORT:
+                OverrideType overrideType = getOverrideTypeFor(serialMessage.getMessagePayloadByte(offset + 1) & 0x03);
+                ScheduleState scheduleState = getScheduleStateFor((byte) serialMessage.getMessagePayloadByte(offset + 2));
+                logger.info("NODE {} reported: Override type: {}, ScheduleState: {}", this.getNode().getNodeId(), overrideType, scheduleState);
+                break;
             default:
                 logger.warn(String.format("NODE %d: Unsupported Command %d for command class %s (0x%02X).",
                         this.getNode().getNodeId(), command, this.getCommandClass().getLabel(),
                         this.getCommandClass().getKey()));
+        }
+    }
+
+    public ScheduleState getScheduleStateFor(byte messagePayloadByte) {
+        if (messagePayloadByte == 0x79) return new ScheduleState(ScheduleStateState.FROST_PROTECTION,0);
+        if (messagePayloadByte == 0x7A) return new ScheduleState(ScheduleStateState.ENERGY_SAVING, 0);
+        if (messagePayloadByte >= 0x7B && messagePayloadByte <= 0x7E) return new ScheduleState(ScheduleStateState.RESERVED, 0);
+        if (messagePayloadByte == 0x7F) return new ScheduleState(ScheduleStateState.UNUSED, 0);
+        return new ScheduleState(ScheduleStateState.SETBACK, messagePayloadByte);
+    }
+
+    public OverrideType getOverrideTypeFor(int i) {
+        switch (i) {
+            case 0b00: return OverrideType.NO_OVERRIDE;
+            case 0b01: return OverrideType.TEMPORARY_OVERRIDE;
+            case 0b10: return OverrideType.PERMANENT_OVERRIDE;
+            case 0b11: return OverrideType.RESERVED;
+            default: return OverrideType.RESERVED;
+        }
+    }
+
+    public SerialMessage getScheduleChangedReportMessage(byte scheduleChangeCounter) {
+        logger.debug("NODE {}: Creating new message for command SCHEDULE_CHANGED_REPORT", getNode().getNodeId());
+
+        SerialMessage result = new SerialMessage(getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData,
+                SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.SendData, SerialMessage.SerialMessagePriority.RealTime);
+
+        ByteArrayOutputStream outputData = new ByteArrayOutputStream();
+        outputData.write(getNode().getNodeId());
+        outputData.write(4);
+        outputData.write(getCommandClass().getKey());
+        outputData.write(SCHEDULE_CHANGED_REPORT);
+        outputData.write(scheduleChangeCounter);
+        result.setMessagePayload(outputData.toByteArray());
+        return result;
+    }
+
+    public enum OverrideType { NO_OVERRIDE, TEMPORARY_OVERRIDE, PERMANENT_OVERRIDE, RESERVED }
+
+    public enum ScheduleStateState { SETBACK, FROST_PROTECTION, ENERGY_SAVING, RESERVED, UNUSED }
+
+    public static class ScheduleState {
+        public ScheduleStateState state;
+        public int setBack;
+
+        public ScheduleState(ScheduleStateState _state, int _setBack) { this.state = _state; this.setBack = _setBack; }
+
+        @Override public String toString() { return "[" + state + " " + setBack/10.0 + "]"; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ScheduleState that = (ScheduleState) o;
+            return setBack == that.setBack &&
+                    state == that.state;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(state, setBack);
         }
     }
 }

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveClimateControlScheduleCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveClimateControlScheduleCommandClassTest.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2014-2016 by the respective copyright holders.
- *
+ * <p>
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,35 +28,32 @@ public class ZWaveClimateControlScheduleCommandClassTest extends ZWaveCommandCla
 
     @Test
     public void getScheduleStateFor() {
-        ZWaveClimateControlScheduleCommandClass cls = (ZWaveClimateControlScheduleCommandClass) getCommandClass(CommandClass.CLIMATE_CONTROL_SCHEDULE);
-
-        assertEquals(new ScheduleState(ScheduleStateState.SETBACK, -128), cls.getScheduleStateFor((byte)0x80));
-        assertEquals(new ScheduleState(ScheduleStateState.SETBACK, -1  ), cls.getScheduleStateFor((byte)0xFF));
-        assertEquals(new ScheduleState(ScheduleStateState.SETBACK, 0   ), cls.getScheduleStateFor((byte)0x00));
-        assertEquals(new ScheduleState(ScheduleStateState.SETBACK, 1   ), cls.getScheduleStateFor((byte)0x01));
-        assertEquals(new ScheduleState(ScheduleStateState.SETBACK,  120), cls.getScheduleStateFor((byte)0x78));
-        assertEquals(new ScheduleState(ScheduleStateState.FROST_PROTECTION, 0), cls.getScheduleStateFor((byte)0x79));
-        assertEquals(new ScheduleState(ScheduleStateState.ENERGY_SAVING, 0), cls.getScheduleStateFor((byte)0x7A));
-        assertEquals(new ScheduleState(ScheduleStateState.RESERVED, 0), cls.getScheduleStateFor((byte)0x7B));
-        assertEquals(new ScheduleState(ScheduleStateState.UNUSED, 0), cls.getScheduleStateFor((byte)0x7F));
+        assertEquals(new ScheduleState(ScheduleStateState.SETBACK, -128), ScheduleState.getScheduleStateFor((byte) 0x80));
+        assertEquals(new ScheduleState(ScheduleStateState.SETBACK, -1), ScheduleState.getScheduleStateFor((byte) 0xFF));
+        assertEquals(new ScheduleState(ScheduleStateState.SETBACK, 0), ScheduleState.getScheduleStateFor((byte) 0x00));
+        assertEquals(new ScheduleState(ScheduleStateState.SETBACK, 1), ScheduleState.getScheduleStateFor((byte) 0x01));
+        assertEquals(new ScheduleState(ScheduleStateState.SETBACK, 120), ScheduleState.getScheduleStateFor((byte) 0x78));
+        assertEquals(new ScheduleState(ScheduleStateState.FROST_PROTECTION, 0), ScheduleState.getScheduleStateFor((byte) 0x79));
+        assertEquals(new ScheduleState(ScheduleStateState.ENERGY_SAVING, 0), ScheduleState.getScheduleStateFor((byte) 0x7A));
+        assertEquals(new ScheduleState(ScheduleStateState.RESERVED1, 0), ScheduleState.getScheduleStateFor((byte) 0x7B));
+        assertEquals(new ScheduleState(ScheduleStateState.UNUSED, 0), ScheduleState.getScheduleStateFor((byte) 0x7F));
     }
 
     @Test
     public void getOverrideTypeFor() {
-        ZWaveClimateControlScheduleCommandClass cls = (ZWaveClimateControlScheduleCommandClass) getCommandClass(CommandClass.CLIMATE_CONTROL_SCHEDULE);
-        assertEquals(OverrideType.NO_OVERRIDE, cls.getOverrideTypeFor(0));
-        assertEquals(OverrideType.TEMPORARY_OVERRIDE, cls.getOverrideTypeFor(1));
-        assertEquals(OverrideType.PERMANENT_OVERRIDE, cls.getOverrideTypeFor(2));
-        assertEquals(OverrideType.RESERVED, cls.getOverrideTypeFor(3));
+        assertEquals(OverrideType.NO_OVERRIDE, OverrideType.getOverrideTypeFor((byte) 0));
+        assertEquals(OverrideType.TEMPORARY_OVERRIDE, OverrideType.getOverrideTypeFor((byte) 1));
+        assertEquals(OverrideType.PERMANENT_OVERRIDE, OverrideType.getOverrideTypeFor((byte) 2));
+        assertEquals(OverrideType.RESERVED, OverrideType.getOverrideTypeFor((byte) 3));
     }
 
     @Test
     public void getScheduleChangedReportMessage() {
         ZWaveClimateControlScheduleCommandClass cls = (ZWaveClimateControlScheduleCommandClass) getCommandClass(CommandClass.CLIMATE_CONTROL_SCHEDULE);
 
-        byte[] expectedResponse = { 99, 4, 70, 5, 0 };
+        byte[] expectedResponse = {99, 4, 70, 5, 0};
 
-        SerialMessage msg = cls.getScheduleChangedReportMessage((byte)0);
+        SerialMessage msg = cls.getScheduleChangedReportMessage((byte) 0);
 
         assertArrayEquals(expectedResponse, msg.getMessagePayload());
     }

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveClimateControlScheduleCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveClimateControlScheduleCommandClassTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.protocol.commandclass;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveClimateControlScheduleCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveClimateControlScheduleCommandClass.OverrideType;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveClimateControlScheduleCommandClass.ScheduleState;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveClimateControlScheduleCommandClass.ScheduleStateState;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test cases for {@link ZWaveClimateControlScheduleCommandClass}.
+ *
+ * @author Max Berger
+ */
+public class ZWaveClimateControlScheduleCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getScheduleStateFor() {
+        ZWaveClimateControlScheduleCommandClass cls = (ZWaveClimateControlScheduleCommandClass) getCommandClass(CommandClass.CLIMATE_CONTROL_SCHEDULE);
+
+        assertEquals(new ScheduleState(ScheduleStateState.SETBACK, -128), cls.getScheduleStateFor((byte)0x80));
+        assertEquals(new ScheduleState(ScheduleStateState.SETBACK, -1  ), cls.getScheduleStateFor((byte)0xFF));
+        assertEquals(new ScheduleState(ScheduleStateState.SETBACK, 0   ), cls.getScheduleStateFor((byte)0x00));
+        assertEquals(new ScheduleState(ScheduleStateState.SETBACK, 1   ), cls.getScheduleStateFor((byte)0x01));
+        assertEquals(new ScheduleState(ScheduleStateState.SETBACK,  120), cls.getScheduleStateFor((byte)0x78));
+        assertEquals(new ScheduleState(ScheduleStateState.FROST_PROTECTION, 0), cls.getScheduleStateFor((byte)0x79));
+        assertEquals(new ScheduleState(ScheduleStateState.ENERGY_SAVING, 0), cls.getScheduleStateFor((byte)0x7A));
+        assertEquals(new ScheduleState(ScheduleStateState.RESERVED, 0), cls.getScheduleStateFor((byte)0x7B));
+        assertEquals(new ScheduleState(ScheduleStateState.UNUSED, 0), cls.getScheduleStateFor((byte)0x7F));
+    }
+
+    @Test
+    public void getOverrideTypeFor() {
+        ZWaveClimateControlScheduleCommandClass cls = (ZWaveClimateControlScheduleCommandClass) getCommandClass(CommandClass.CLIMATE_CONTROL_SCHEDULE);
+        assertEquals(OverrideType.NO_OVERRIDE, cls.getOverrideTypeFor(0));
+        assertEquals(OverrideType.TEMPORARY_OVERRIDE, cls.getOverrideTypeFor(1));
+        assertEquals(OverrideType.PERMANENT_OVERRIDE, cls.getOverrideTypeFor(2));
+        assertEquals(OverrideType.RESERVED, cls.getOverrideTypeFor(3));
+    }
+
+    @Test
+    public void getScheduleChangedReportMessage() {
+        ZWaveClimateControlScheduleCommandClass cls = (ZWaveClimateControlScheduleCommandClass) getCommandClass(CommandClass.CLIMATE_CONTROL_SCHEDULE);
+
+        byte[] expectedResponse = { 99, 4, 70, 5, 0 };
+
+        SerialMessage msg = cls.getScheduleChangedReportMessage((byte)0);
+
+        assertArrayEquals(expectedResponse, msg.getMessagePayload());
+    }
+
+}

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveClimateControlScheduleCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveClimateControlScheduleCommandClassTest.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2014-2016 by the respective copyright holders.
- * <p>
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
SCHEDULE_CHANGED_GET is implemented by returning a no-op report
SCHEDULE_OVERRIDE_REPORT is implemented by logging the data

Signed-off-by: Max Berger max@berger.name

Note: These two commands are the ones send by the devolo thermostat. The implementation here does nothing but answer these commands to make the log output look nice. It does not implement any support for climate control.