### PR TITLE
add channel for thermostat_setpoint

### DIFF
--- a/ESH-INF/thing/systemair_29990_0_0.xml
+++ b/ESH-INF/thing/systemair_29990_0_0.xml
@@ -17,6 +17,12 @@
           <property name="binding:*:OnOffType">SWITCH_BINARY</property>
         </properties>
       </channel>
+      <channel id="thermostat_setpoint" typeId="systemair_29990_00_000_thermostat_setpoint">
+        <label>Thermostat setpoint</label>
+        <properties>
+          <property name="binding:*:DecimalType">THERMOSTAT_SETPOINT</property>
+        </properties>
+      </channel>
       <channel id="thermostat_mode" typeId="systemair_29990_00_000_thermostat_mode">
         <label>Thermostat mode</label>
         <properties>


### PR DESCRIPTION
This ZWave unit has a command class that seems to miss a channel - at least I know this hardware can control a thermostat setpoint, but in OpenHAB there is no channel for the thermostat setpoint.

The pull request is an educated guess at what is required - but this is my first OpenHAB contribution - so I do not yet understand if this is everything that is required to get the extra channel properly defined. 

Signed-off-by: Håvard Berland <havardberlandh@gmail.com> (github: berland)