### PR TITLE
adapted code to refactored interface name "TranslationProvider"

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
+++ b/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
@@ -11,7 +11,7 @@ package org.openhab.binding.zwave;
 import java.text.MessageFormat;
 import java.util.Set;
 
-import org.eclipse.smarthome.core.i18n.I18nProvider;
+import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.openhab.binding.zwave.internal.ZWaveActivator;
 
@@ -163,32 +163,32 @@ public class ZWaveBindingConstants {
 
     public final static Set<ThingTypeUID> SUPPORTED_BRIDGE_TYPES_UIDS = ImmutableSet.of(CONTROLLER_SERIAL);
 
-    private static I18nProvider i18nProvider;
+    private static TranslationProvider translationProvider;
 
-    protected void setI18nProvider(I18nProvider i18nProvider) {
-        ZWaveBindingConstants.i18nProvider = i18nProvider;
+    protected void setI18nProvider(TranslationProvider translationProvider) {
+        ZWaveBindingConstants.translationProvider = translationProvider;
     }
 
-    protected void unsetI18nProvider(I18nProvider i18nProvider) {
-        ZWaveBindingConstants.i18nProvider = null;
+    protected void unsetI18nProvider(TranslationProvider i18nProvider) {
+        ZWaveBindingConstants.translationProvider = null;
     }
 
     public static String getI18nConstant(I18nConstant constant) {
-        I18nProvider i18nProviderLocal = i18nProvider;
-        if (i18nProviderLocal == null) {
+        TranslationProvider translationProviderLocal = translationProvider;
+        if (translationProviderLocal == null) {
             return MessageFormat.format(constant.defaultText, (Object[]) null);
         }
-        return i18nProviderLocal.getText(ZWaveActivator.getContext().getBundle(), constant.defaultText,
+        return translationProviderLocal.getText(ZWaveActivator.getContext().getBundle(), constant.defaultText,
                 constant.defaultText, null, (Object[]) null);
     }
 
     public static String getI18nConstant(I18nConstant constant, Object... arguments) {
-        I18nProvider i18nProviderLocal = i18nProvider;
-        if (i18nProviderLocal == null) {
+        TranslationProvider translationProviderLocal = translationProvider;
+        if (translationProviderLocal == null) {
             return MessageFormat.format(constant.key, arguments);
         }
-        return i18nProviderLocal.getText(ZWaveActivator.getContext().getBundle(), constant.key, constant.defaultText,
-                null, arguments);
+        return translationProviderLocal.getText(ZWaveActivator.getContext().getBundle(), constant.key,
+                constant.defaultText, null, arguments);
     }
 
     public static class I18nConstant {


### PR DESCRIPTION
Sorry @cdjackson, I missed to inform you that I just released that change in a new ESH stable.
As ZWave currently breaks the build, we should merge it asap.

Btw, I hope that this code here is really nasty and very much against all good OSGi design principles - you should always avoid putting OSGi services into static fields. I noticed that you did the same in Zigbee as well; it might be worth to consider a refactoring of these parts.

Signed-off-by: Kai Kreuzer <kai@openhab.org>