### PR TITLE
Fix battery npe

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveBatteryConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveBatteryConverter.java
@@ -11,7 +11,7 @@ package org.openhab.binding.zwave.internal.converter;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.zwave.handler.ZWaveControllerHandler;
 import org.openhab.binding.zwave.handler.ZWaveThingChannel;
@@ -68,7 +68,13 @@ public class ZWaveBatteryConverter extends ZWaveCommandClassConverter {
      */
     @Override
     public State handleEvent(ZWaveThingChannel channel, ZWaveCommandClassValueEvent event) {
-        return new DecimalType((Integer) event.getValue());
+        Integer value = (Integer) event.getValue();
+        if (value > 100) {
+            value = 100;
+        } else if (value < 0) {
+            value = 0;
+        }
+        return new PercentType(value);
     }
 
     /**

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveBatteryCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveBatteryCommandClass.java
@@ -85,11 +85,6 @@ public class ZWaveBatteryCommandClass extends ZWaveCommandClass implements ZWave
             batteryLow = false;
         }
 
-        // If the battery level is outside bounds, then we don't know what's up!
-        if (batteryLevel < 0 || batteryLevel > 100) {
-            logger.warn("NODE {}: Battery state unknown ({})!", getNode().getNodeId(), batteryLevel);
-            batteryLevel = null;
-        }
         ZWaveCommandClassValueEvent zEvent = new ZWaveCommandClassValueEvent(getNode().getNodeId(), endpoint,
                 getCommandClass(), batteryLevel);
         getController().notifyEventListeners(zEvent);

--- a/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveBatteryConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveBatteryConverterTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.test.internal.converter;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.types.State;
+import org.junit.Test;
+import org.openhab.binding.zwave.handler.ZWaveThingChannel;
+import org.openhab.binding.zwave.handler.ZWaveThingChannel.DataType;
+import org.openhab.binding.zwave.internal.converter.ZWaveBatteryConverter;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZWaveBatteryConverterTest extends ZWaveCommandClassConverterTest {
+    final ChannelUID uid = new ChannelUID("zwave:node:bridge:channel");
+
+    @Test
+    public void Event_Percent() {
+        ZWaveBatteryConverter converter = new ZWaveBatteryConverter(null);
+        ZWaveThingChannel channel = new ZWaveThingChannel(null, uid, DataType.PercentType,
+                CommandClass.COMMAND_CLASS_BATTERY.toString(), 0, new HashMap<String, String>());
+
+        State state;
+        ZWaveCommandClassValueEvent event;
+
+        event = new ZWaveCommandClassValueEvent(1, 0, CommandClass.COMMAND_CLASS_BASIC, 100);
+        state = converter.handleEvent(channel, event);
+        assertEquals(DecimalType.class, state.getClass());
+        assertEquals(state, new DecimalType(100));
+
+        event = new ZWaveCommandClassValueEvent(1, 0, CommandClass.COMMAND_CLASS_BASIC, 50);
+        state = converter.handleEvent(channel, event);
+        assertEquals(DecimalType.class, state.getClass());
+        assertEquals(state, new DecimalType(50));
+
+        event = new ZWaveCommandClassValueEvent(1, 0, CommandClass.COMMAND_CLASS_BASIC, 101);
+        state = converter.handleEvent(channel, event);
+        assertEquals(DecimalType.class, state.getClass());
+        assertEquals(state, new DecimalType(101));
+    }
+}

--- a/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveBatteryConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveBatteryConverterTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
 
-import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Test;
@@ -41,17 +41,17 @@ public class ZWaveBatteryConverterTest extends ZWaveCommandClassConverterTest {
 
         event = new ZWaveCommandClassValueEvent(1, 0, CommandClass.COMMAND_CLASS_BASIC, 100);
         state = converter.handleEvent(channel, event);
-        assertEquals(DecimalType.class, state.getClass());
-        assertEquals(state, new DecimalType(100));
+        assertEquals(PercentType.class, state.getClass());
+        assertEquals(state, new PercentType(100));
 
         event = new ZWaveCommandClassValueEvent(1, 0, CommandClass.COMMAND_CLASS_BASIC, 50);
         state = converter.handleEvent(channel, event);
-        assertEquals(DecimalType.class, state.getClass());
-        assertEquals(state, new DecimalType(50));
+        assertEquals(PercentType.class, state.getClass());
+        assertEquals(state, new PercentType(50));
 
         event = new ZWaveCommandClassValueEvent(1, 0, CommandClass.COMMAND_CLASS_BASIC, 101);
         state = converter.handleEvent(channel, event);
-        assertEquals(DecimalType.class, state.getClass());
-        assertEquals(state, new DecimalType(101));
+        assertEquals(PercentType.class, state.getClass());
+        assertEquals(state, new PercentType(100));
     }
 }

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveBatteryCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveBatteryCommandClassTest.java
@@ -8,13 +8,16 @@
  */
 package org.openhab.binding.zwave.test.internal.protocol.commandclass;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Test;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveBatteryCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
 import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
 
 /**
@@ -34,4 +37,21 @@ public class ZWaveBatteryCommandClassTest extends ZWaveCommandClassTest {
         msg = cls.getValueMessage();
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseV1));
     }
+
+    @Test
+    public void handleReport() {
+        byte[] packetData = { 0x01, 0x0A, 0x00, 0x04, 0x00, 0x49, 0x04, 0x71, 0x05, 0x00, 0x00, (byte) 0xC8 };
+
+        List<ZWaveEvent> events = processCommandClassMessage(packetData, 3);
+
+        assertEquals(events.size(), 1);
+
+        ZWaveCommandClassValueEvent event = (ZWaveCommandClassValueEvent) events.get(0);
+
+        // assertEquals(event.getNodeId(), 40);
+        assertEquals(event.getEndpoint(), 0);
+        assertEquals(CommandClass.COMMAND_CLASS_BATTERY, event.getCommandClass());
+        assertEquals(0x00, event.getValue());
+    }
+
 }

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveBatteryCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveBatteryCommandClassTest.java
@@ -32,7 +32,7 @@ public class ZWaveBatteryCommandClassTest extends ZWaveCommandClassTest {
         ZWaveBatteryCommandClass cls = (ZWaveBatteryCommandClass) getCommandClass(CommandClass.COMMAND_CLASS_BATTERY);
         ZWaveCommandClassTransactionPayload msg;
 
-        byte[] expectedResponseV1 = { -128, 2 };
+        byte[] expectedResponseV1 = { (byte) 0x80, 0x02 };
         cls.setVersion(1);
         msg = cls.getValueMessage();
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseV1));
@@ -40,7 +40,7 @@ public class ZWaveBatteryCommandClassTest extends ZWaveCommandClassTest {
 
     @Test
     public void handleReport() {
-        byte[] packetData = { 0x01, 0x0A, 0x00, 0x04, 0x00, 0x49, 0x04, 0x71, 0x05, 0x00, 0x00, (byte) 0xC8 };
+        byte[] packetData = { 0x01, 0x09, 0x00, 0x04, 0x00, 0x05, 0x03, (byte) 0x80, 0x03, 0x6C, 0x1B };
 
         List<ZWaveEvent> events = processCommandClassMessage(packetData, 3);
 
@@ -51,7 +51,7 @@ public class ZWaveBatteryCommandClassTest extends ZWaveCommandClassTest {
         // assertEquals(event.getNodeId(), 40);
         assertEquals(event.getEndpoint(), 0);
         assertEquals(CommandClass.COMMAND_CLASS_BATTERY, event.getCommandClass());
-        assertEquals(0x00, event.getValue());
+        assertEquals(108, event.getValue());
     }
 
 }


### PR DESCRIPTION
Change handling of battery reports when relating to values > 100%. Move the checks into the converter.
#603 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>