### PR TITLE
Use channel name instead of database options for notification processing

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
@@ -185,8 +185,8 @@ public class ZWaveAlarmConverter extends ZWaveCommandClassConverter {
     @Override
     public State handleEvent(ZWaveThingChannel channel, ZWaveCommandClassValueEvent event) {
         String alarmType = channel.getArguments().get("type");
-        Integer alarmEvent = (channel.getArguments().get("event") == null) ? null
-                : Integer.parseInt(channel.getArguments().get("event"));
+        // Integer alarmEvent = (channel.getArguments().get("event") == null) ? null
+        // : Integer.parseInt(channel.getArguments().get("event"));
 
         ZWaveAlarmValueEvent eventAlarm = (ZWaveAlarmValueEvent) event;
         logger.debug("Alarm converter processing {}", eventAlarm.getReportType());
@@ -194,7 +194,7 @@ public class ZWaveAlarmConverter extends ZWaveCommandClassConverter {
             case ALARM:
                 return handleAlarmReport(channel, eventAlarm, alarmType);
             case NOTIFICATION:
-                return handleNotificationReport(channel, eventAlarm, alarmType, alarmEvent);
+                return handleNotificationReport(channel, eventAlarm);
         }
 
         return null;
@@ -232,13 +232,12 @@ public class ZWaveAlarmConverter extends ZWaveCommandClassConverter {
         return state;
     }
 
-    private State handleNotificationReport(ZWaveThingChannel channel, ZWaveAlarmValueEvent eventAlarm, String alarmType,
-            Integer alarmEvent) {
+    private State handleNotificationReport(ZWaveThingChannel channel, ZWaveAlarmValueEvent eventAlarm) {
 
         // Don't trigger event if this item is bound to another event type
-        if (alarmType != null && AlarmType.valueOf(alarmType) != eventAlarm.getAlarmType()) {
-            return null;
-        }
+        // if (alarmType != null && AlarmType.valueOf(alarmType) != eventAlarm.getAlarmType()) {
+        // return null;
+        // }
 
         NotificationEvent notification = NotificationEvent.getEvent(eventAlarm.getAlarmType().toString(),
                 eventAlarm.getAlarmEvent());
@@ -257,9 +256,9 @@ public class ZWaveAlarmConverter extends ZWaveCommandClassConverter {
         }
 
         // Don't trigger event if there is no event match. Note that 0 is always acceptable
-        if (alarmEvent != null && event != 0 && alarmEvent != event) {
-            return null;
-        }
+        // if (alarmEvent != null && event != 0 && alarmEvent != event) {
+        // return null;
+        // }
 
         String channelType = channel.getUID().getId();
         switch (channelType) {

--- a/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveAlarmConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveAlarmConverterTest.java
@@ -94,11 +94,19 @@ public class ZWaveAlarmConverterTest extends ZWaveCommandClassConverterTest {
 
         ZWaveCommandClassValueEvent event = createEvent(ZWaveAlarmCommandClass.AlarmType.SMOKE, ReportType.NOTIFICATION,
                 0, 0xff);
-
         State state = converter.handleEvent(channel, event);
-
         assertEquals(state.getClass(), OnOffType.class);
         assertEquals(state, OnOffType.OFF);
+
+        event = createEvent(ZWaveAlarmCommandClass.AlarmType.SMOKE, ReportType.NOTIFICATION, 1, 0xff);
+        state = converter.handleEvent(channel, event);
+        assertEquals(state.getClass(), OnOffType.class);
+        assertEquals(state, OnOffType.ON);
+
+        event = createEvent(ZWaveAlarmCommandClass.AlarmType.SMOKE, ReportType.NOTIFICATION, 2, 0xff);
+        state = converter.handleEvent(channel, event);
+        assertEquals(state.getClass(), OnOffType.class);
+        assertEquals(state, OnOffType.ON);
     }
 
     @Test

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveAlarmCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveAlarmCommandClassTest.java
@@ -49,7 +49,7 @@ public class ZWaveAlarmCommandClassTest extends ZWaveCommandClassTest {
     }
 
     @Test
-    public void Alarm_Smoke() {
+    public void Alarm_Smoke1() {
         byte[] packetData = { 0x01, 0x10, 0x00, 0x04, 0x10, 0x28, 0x09, 0x71, 0x05, 0x00, 0x00, 0x00, (byte) 0xFF, 0x01,
                 0x00, 0x01, 0x03, 0x52 };
 
@@ -66,6 +66,26 @@ public class ZWaveAlarmCommandClassTest extends ZWaveCommandClassTest {
         assertEquals(event.getAlarmType(), ZWaveAlarmCommandClass.AlarmType.SMOKE);
         assertEquals(event.getAlarmStatus(), 0xFF);
         assertEquals(event.getAlarmEvent(), 0);
+    }
+
+    @Test
+    public void Alarm_Smoke2() {
+        byte[] packetData = { 0x01, 0x0F, 0x00, 0x04, 0x00, 0x18, 0x09, 0x71, 0x05, 0x00, 0x00, 0x00, (byte) 0xFF, 0x01,
+                0x02, 0x00, 0x6D };
+
+        List<ZWaveEvent> events = processCommandClassMessage(packetData, 3);
+
+        assertEquals(events.size(), 1);
+
+        ZWaveAlarmValueEvent event = (ZWaveAlarmValueEvent) events.get(0);
+
+        // assertEquals(event.getNodeId(), 40);
+        assertEquals(event.getEndpoint(), 0);
+        assertEquals(event.getCommandClass(), CommandClass.COMMAND_CLASS_ALARM);
+        assertEquals(event.getReportType(), ReportType.NOTIFICATION);
+        assertEquals(event.getAlarmType(), ZWaveAlarmCommandClass.AlarmType.SMOKE);
+        assertEquals(event.getAlarmStatus(), 0xFF);
+        assertEquals(event.getAlarmEvent(), 2);
     }
 
     @Test


### PR DESCRIPTION
This removes the dependancy on the database with setting events etc and instead directly uses the channel names. This is linked to the previous change which left the database options in which it shouldn't have.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>