### PR TITLE
Handle Array our of bounds in command class

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
@@ -16,6 +16,7 @@ import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 import org.openhab.binding.zwave.internal.protocol.ZWaveCommandClassPayload;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
 import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
@@ -243,11 +244,14 @@ public abstract class ZWaveCommandClass {
         Object[] parms = { payload, endpoint };
         try {
             commands.get(payload.getCommandClassCommand()).method.invoke(this, parms);
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (IllegalArgumentException e) {
-            e.printStackTrace();
         } catch (InvocationTargetException e) {
+            // Handle exceptions from the command class processing
+            if (e.getCause() instanceof ArrayIndexOutOfBoundsException) {
+                logger.debug("NODE {}: ArrayIndexOutOfBoundsException {} V{} {} {}", getNode().getNodeId(),
+                        getCommandClass(), getVersion(), commands.get(payload.getCommandClassCommand()).name,
+                        SerialMessage.bb2hex(payload.getPayloadBuffer()));
+            }
+        } catch (IllegalAccessException | IllegalArgumentException e) {
             e.printStackTrace();
         }
     };

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSensorCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSensorCommandClass.java
@@ -112,10 +112,6 @@ public class ZWaveMultiLevelSensorCommandClass extends ZWaveCommandClass
 
     @ZWaveResponseHandler(id = SENSOR_MULTILEVEL_REPORT, name = "SENSOR_MULTILEVEL_REPORT")
     public void handleSensorMultilevelReport(ZWaveCommandClassPayload payload, int endpoint) {
-        if (payload.getPayloadLength() < 5) {
-            return;
-        }
-
         int sensorTypeCode = payload.getPayloadByte(2);
         int sensorScale = (payload.getPayloadByte(3) >> 3) & 0x03;
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatSetpointCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatSetpointCommandClass.java
@@ -134,10 +134,6 @@ public class ZWaveThermostatSetpointCommandClass extends ZWaveCommandClass
     @ZWaveResponseHandler(id = THERMOSTAT_SETPOINT_REPORT, name = "THERMOSTAT_SETPOINT_REPORT")
     public void handleThermostatSetpointReport(ZWaveCommandClassPayload payload, int endpoint) {
 
-        if (payload.getPayloadLength() < 5) {
-            return;
-        }
-
         int setpointTypeCode = payload.getPayloadByte(2);
         int scale = (payload.getPayloadByte(3) >> 3) & 0x03;
 


### PR DESCRIPTION
Catches ArrayIndexOutOfBoundsException  in command classes to catch any malformed command packets.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>