### PR TITLE
Set node awake during inclusion

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -410,6 +410,15 @@ public class ZWaveNodeInitStageAdvancer {
         if (initRunning == false) {
             return;
         }
+
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            // Eat me
+        }
+
+        // We just started inclusion so assume the device is awake
+        node.setAwake(true);
     }
 
     private void doSecureStages() {

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/ZWaveEndpointTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/ZWaveEndpointTest.java
@@ -3,16 +3,27 @@ package org.openhab.binding.zwave.test.internal.protocol;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.ZWaveController;
 import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
+import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
 
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
 public class ZWaveEndpointTest {
     @Test
     public void testSupportedCommandClasses() {
+        ZWaveController controller = new ZWaveController(null);
+        ZWaveNode node = new ZWaveNode(0, 0, controller);
         ZWaveEndpoint endpoint = new ZWaveEndpoint(0);
 
-        endpoint.addCommandClass(new ZWaveAlarmCommandClass(null, null, null));
+        ZWaveCommandClass commandClass = new ZWaveAlarmCommandClass(node, controller, endpoint);
+        endpoint.addCommandClass(commandClass);
 
         assertTrue(endpoint.supportsCommandClass(CommandClass.COMMAND_CLASS_ALARM));
         assertFalse(endpoint.supportsCommandClass(CommandClass.COMMAND_CLASS_ASSOCIATION));


### PR DESCRIPTION
If a node is just included, assuming it is awake already.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>