### PR TITLE
WIP: Add support for auto setting the lifeline association

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -115,6 +115,7 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
     private Map<Integer, ZWaveConfigSubParameter> subParameters = new HashMap<Integer, ZWaveConfigSubParameter>();
     private Map<String, Object> pendingCfg = new HashMap<String, Object>();
 
+    private final Object pollingSync = new Object();
     private ScheduledFuture<?> pollingJob = null;
     private final long POLLING_PERIOD_MIN = 15;
     private final long POLLING_PERIOD_MAX = 86400;
@@ -406,7 +407,7 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
             }
         };
 
-        synchronized (pollingJob) {
+        synchronized (pollingSync) {
             if (pollingJob != null) {
                 pollingJob.cancel(true);
                 pollingJob = null;
@@ -523,7 +524,7 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
             nodeId = 0;
         }
 
-        synchronized (pollingJob) {
+        synchronized (pollingSync) {
             if (pollingJob != null) {
                 pollingJob.cancel(true);
                 pollingJob = null;
@@ -1364,7 +1365,7 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
                     updateStatus(ThingStatus.REMOVED, ThingStatusDetail.NONE, "Node was excluded from the controller");
 
                     // Stop polling
-                    synchronized (pollingJob) {
+                    synchronized (pollingSync) {
                         if (pollingJob != null) {
                             pollingJob.cancel(true);
                             pollingJob = null;

--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -1076,6 +1076,7 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
                     break;
 
                 case COMMAND_CLASS_ASSOCIATION:
+                case COMMAND_CLASS_MULTI_CHANNEL_ASSOCIATION:
                     int groupId = ((ZWaveAssociationEvent) event).getGroupId();
                     List<ZWaveAssociation> groupMembers = ((ZWaveAssociationEvent) event).getGroupMembers();
                     if (groupMembers != null) {
@@ -1087,7 +1088,7 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
                         for (ZWaveAssociation groupMember : groupMembers) {
                             logger.debug("NODE {}: Update ASSOCIATION group_{}: Adding node_{}_{}", nodeId, groupId,
                                     groupMember.getNode(), groupMember.getEndpoint());
-                            group.add("node_" + groupMember.getNode() + "_" + groupMember.getEndpoint());
+                            group.add(groupMember.toString());
                         }
                         logger.debug("NODE {}: Update ASSOCIATION group_{}: {} members", nodeId, groupId, group.size());
 
@@ -1494,7 +1495,7 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
             for (ZWaveAssociation groupMember : group.getAssociations()) {
                 logger.debug("NODE {}: Update ASSOCIATION group_{}: Adding node_{}_{}", nodeId, group,
                         groupMember.getNode(), groupMember.getEndpoint());
-                members.add("node_" + groupMember.getNode() + "_" + groupMember.getEndpoint());
+                members.add(groupMember.toString());
             }
 
             config.put("group_" + group.getIndex(), members);

--- a/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
@@ -521,12 +521,6 @@ public class ZWaveConfigProvider implements ConfigDescriptionProvider, ConfigOpt
             // TODO: Add this when thing names are supported!
             // Thing thingNode = getThing(thingUID);
 
-            // Add the node for the standard association class if it supports a controllable class
-            if (supportsControllableClass(node)) {
-                // TODO: Use the node name
-                options.add(new ParameterOption("node_" + node.getNodeId() + "_0", "Node " + node.getNodeId()));
-            }
-
             // If the device supports multi_instance_association class, then add all controllable endpoints as well...
             // If this node also supports multi_instance class
             if (supportsMultiInstanceAssociation == true
@@ -540,6 +534,10 @@ public class ZWaveConfigProvider implements ConfigDescriptionProvider, ConfigOpt
                                 "Node " + node.getNodeId() + " Endpoint " + endpointId));
                     }
                 }
+            } else if (supportsControllableClass(node)) {
+                // Add the node for the standard association class if it supports a controllable class
+                // TODO: Use the node name
+                options.add(new ParameterOption("node_" + node.getNodeId(), "Node " + node.getNodeId()));
             }
         }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveAssociation.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveAssociation.java
@@ -18,14 +18,14 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("associationMember")
 public class ZWaveAssociation {
     private int node;
-    private int endpoint;
+    private Integer endpoint;
 
     public ZWaveAssociation(int node) {
         this.node = node;
-        this.endpoint = 0;
+        this.endpoint = null;
     }
 
-    public ZWaveAssociation(int node, int endpoint) {
+    public ZWaveAssociation(int node, Integer endpoint) {
         this.node = node;
         this.endpoint = endpoint;
     }
@@ -34,16 +34,53 @@ public class ZWaveAssociation {
         return node;
     }
 
-    public int getEndpoint() {
+    public Integer getEndpoint() {
         return endpoint;
     }
 
     @Override
-    public boolean equals(Object checker) {
-        ZWaveAssociation assoc = (ZWaveAssociation) checker;
-        if (this.node == assoc.node && this.endpoint == assoc.endpoint) {
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("node_");
+        builder.append(node);
+        if (endpoint != null) {
+            builder.append('_');
+            builder.append(endpoint);
+        }
+        return builder.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((endpoint == null) ? 0 : endpoint.hashCode());
+        result = prime * result + node;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
             return true;
         }
-        return false;
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ZWaveAssociation other = (ZWaveAssociation) obj;
+        if (endpoint == null) {
+            if (other.endpoint != null) {
+                return false;
+            }
+        } else if (!endpoint.equals(other.endpoint)) {
+            return false;
+        }
+        if (node != other.node) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveAssociationGroup.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveAssociationGroup.java
@@ -195,6 +195,10 @@ public class ZWaveAssociationGroup {
         this.commands = commands;
     }
 
+    public boolean isProfileKnown() {
+        return profile1 != null;
+    }
+
     public Integer getProfile1() {
         if (profile1 == null) {
             // Default profile to General:NA

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveAssociationGroup.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveAssociationGroup.java
@@ -71,7 +71,7 @@ public class ZWaveAssociationGroup {
      * @param node
      */
     public void addAssociation(int node) {
-        addAssociation(node, 0);
+        addAssociation(node, null);
     }
 
     /**
@@ -80,7 +80,7 @@ public class ZWaveAssociationGroup {
      * @param node
      * @param endpoint
      */
-    public void addAssociation(int node, int endpoint) {
+    public void addAssociation(int node, Integer endpoint) {
         // Check if we're already associated
         if (isAssociated(node, endpoint)) {
             return;
@@ -127,8 +127,18 @@ public class ZWaveAssociationGroup {
      * @param node
      * @return
      */
+    public boolean isAssociated(ZWaveAssociation association) {
+        return isAssociated(association.getNode(), association.getEndpoint());
+    }
+
+    /**
+     * Tests if a node is associated to this group
+     *
+     * @param node
+     * @return
+     */
     public boolean isAssociated(int node) {
-        return isAssociated(node, 0);
+        return isAssociated(node, null);
     }
 
     /**
@@ -138,7 +148,7 @@ public class ZWaveAssociationGroup {
      * @param endpoint
      * @return
      */
-    public boolean isAssociated(int node, int endpoint) {
+    public boolean isAssociated(int node, Integer endpoint) {
         int associationCnt = associations.size();
         for (int index = 0; index < associationCnt; index++) {
             ZWaveAssociation association = associations.get(index);
@@ -186,10 +196,18 @@ public class ZWaveAssociationGroup {
     }
 
     public Integer getProfile1() {
+        if (profile1 == null) {
+            // Default profile to General:NA
+            return 0;
+        }
         return profile1;
     }
 
     public Integer getProfile2() {
+        if (profile2 == null) {
+            // Default profile to General:NA
+            return 0;
+        }
         return profile2;
     }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -936,7 +936,7 @@ public class ZWaveNode {
             int endpointId) {
         ZWaveMultiAssociationCommandClass multiAssociationCommandClass = (ZWaveMultiAssociationCommandClass) getCommandClass(
                 CommandClass.COMMAND_CLASS_MULTI_CHANNEL_ASSOCIATION);
-        if (endpoint == null && endpointId != 0 && multiAssociationCommandClass != null) {
+        if (multiAssociationCommandClass != null) {
             return multiAssociationCommandClass.setAssociationMessage(groupId, nodeId, endpointId);
         }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAssociationGroupInfoCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAssociationGroupInfoCommandClass.java
@@ -304,7 +304,7 @@ public class ZWaveAssociationGroupInfoCommandClass extends ZWaveCommandClass
             if (refresh == true || group.getName() == null) {
                 result.add(getGroupNameMessage(group.getIndex()));
             }
-            if (refresh == true || group.getProfile1() == null) {
+            if (refresh == true || group.isProfileKnown() == false) {
                 result.add(getInfoMessage(group.getIndex()));
             }
             if (refresh == true || group.getCommandClasses() == null) {

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAssociationGroupInfoCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAssociationGroupInfoCommandClass.java
@@ -169,7 +169,6 @@ public class ZWaveAssociationGroupInfoCommandClass extends ZWaveCommandClass
             int mode = payload.getPayloadByte(4 + i * 7);
             int profile_msb = payload.getPayloadByte(5 + i * 7);
             int profile_lsb = payload.getPayloadByte(6 + i * 7);
-            int profile = (profile_msb << 8 | profile_lsb);
 
             logger.debug("NODE {}:    Group={}, Profile={} {}, mode:{}", getNode().getNodeId(), groupIdx,
                     String.format("%02X", profile_msb), String.format("%02X", profile_lsb), mode);
@@ -179,8 +178,8 @@ public class ZWaveAssociationGroupInfoCommandClass extends ZWaveCommandClass
                 group = new ZWaveAssociationGroup(groupIdx);
                 getNode().setAssociationGroup(group);
             }
-            getNode().getAssociationGroup(groupIdx).setProfile1(profile_msb);
-            getNode().getAssociationGroup(groupIdx).setProfile2(profile_lsb);
+            group.setProfile1(profile_msb);
+            group.setProfile2(profile_lsb);
 
             if ((profile_msb == PROFILE_GENERAL) && (profile_lsb == PROFILE_LIFELINE)) {
                 autoSubscribeGroups.add(groupIdx);
@@ -286,27 +285,32 @@ public class ZWaveAssociationGroupInfoCommandClass extends ZWaveCommandClass
     public Collection<ZWaveCommandClassTransactionPayload> initialize(boolean refresh) {
         ArrayList<ZWaveCommandClassTransactionPayload> result = new ArrayList<ZWaveCommandClassTransactionPayload>();
 
-        // We need the number of groups as discovered by the AssociationCommandClass
-        // if (getNode().getAssociationGroups().size() == 0) {
-        // return result;
-        // }
+        // Only initialise the root endpoint
+        if (getEndpoint() != null) {
+            return result;
+        }
 
-        // logger.debug("NODE {}: Initialising association group info - {} groups known", getNode().getNodeId(),
-        // getNode().getAssociationGroups().size());
+        // We need the number of groups as discovered by the AssociationCommandClass
+        if (getNode().getAssociationGroups().size() == 0) {
+            return result;
+        }
+
+        logger.debug("NODE {}: Initialising association group info - {} groups known", getNode().getNodeId(),
+                getNode().getAssociationGroups().size());
 
         // For each group request its name and other info
         // Only request it if we have not received an answer yet
-        // for (ZWaveAssociationGroup group : getNode().getAssociationGroups().values()) {
-        // if (refresh == true || group.getName() == null) {
-        // result.add(getGroupNameMessage(group.getIndex()));
-        // }
-        // if (refresh == true || group.getProfile1() == null) {
-        // result.add(getInfoMessage(group.getIndex()));
-        // }
-        // if (refresh == true || group.getCommandClasses() == null) {
-        // result.add(getCommandListMessage(group.getIndex()));
-        // }
-        // }
+        for (ZWaveAssociationGroup group : getNode().getAssociationGroups().values()) {
+            if (refresh == true || group.getName() == null) {
+                result.add(getGroupNameMessage(group.getIndex()));
+            }
+            if (refresh == true || group.getProfile1() == null) {
+                result.add(getInfoMessage(group.getIndex()));
+            }
+            if (refresh == true || group.getCommandClasses() == null) {
+                result.add(getCommandListMessage(group.getIndex()));
+            }
+        }
 
         return result;
     }

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStage.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStage.java
@@ -38,6 +38,7 @@ public enum ZWaveNodeInitStage {
     ASSOCIATIONS(false),
     SET_WAKEUP(false),
     SET_ASSOCIATION(false),
+    SET_LIFELINE(false),
     DELETE_SUC_ROUTES(false),
     SUC_ROUTE(false),
     STATIC_END(false),

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -52,6 +52,7 @@ import org.openhab.binding.zwave.internal.protocol.serialmessage.DeleteReturnRou
 import org.openhab.binding.zwave.internal.protocol.serialmessage.DeleteSucReturnRouteMessageClass;
 import org.openhab.binding.zwave.internal.protocol.serialmessage.GetRoutingInfoMessageClass;
 import org.openhab.binding.zwave.internal.protocol.serialmessage.IdentifyNodeMessageClass;
+import org.openhab.binding.zwave.internal.protocol.serialmessage.IsFailedNodeMessageClass;
 import org.openhab.binding.zwave.internal.protocol.serialmessage.RequestNodeInfoMessageClass;
 import org.openhab.binding.zwave.internal.protocol.serialmessage.RequestNodeNeighborUpdateMessageClass;
 import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -356,26 +356,24 @@ public class ZWaveNodeInitStageAdvancer {
             return;
         }
 
-        /**
-         * setCurrentStage(ZWaveNodeInitStage.FAILED_CHECK);
-         * do {
-         * processTransaction(new IsFailedNodeMessageClass().doRequest(node.getNodeId()));
-         * if (initRunning == false) {
-         * return;
-         * }
-         *
-         * // If the node is dead, sleep for 30 seconds then try again
-         * if (node.isDead()) {
-         * try {
-         * Thread.sleep(30000);
-         * } catch (InterruptedException e) {
-         * break;
-         * }
-         * } else {
-         * break;
-         * }
-         * } while (true);
-         */
+        setCurrentStage(ZWaveNodeInitStage.FAILED_CHECK);
+        do {
+            processTransaction(new IsFailedNodeMessageClass().doRequest(node.getNodeId()));
+            if (initRunning == false) {
+                return;
+            }
+
+            // If the node is dead, sleep for 30 seconds then try again
+            if (node.isDead()) {
+                try {
+                    Thread.sleep(30000);
+                } catch (InterruptedException e) {
+                    break;
+                }
+            } else {
+                break;
+            }
+        } while (true);
 
         // setCurrentStage(ZWaveNodeInitStage.PING);
         // ZWaveNoOperationCommandClass noOpCommandClass = (ZWaveNoOperationCommandClass) node

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -23,6 +23,7 @@ import org.eclipse.smarthome.core.thing.type.ThingType;
 import org.openhab.binding.zwave.ZWaveBindingConstants;
 import org.openhab.binding.zwave.internal.ZWaveConfigProvider;
 import org.openhab.binding.zwave.internal.protocol.ZWaveAssociation;
+import org.openhab.binding.zwave.internal.protocol.ZWaveAssociationGroup;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
 import org.openhab.binding.zwave.internal.protocol.ZWaveDeviceClass.Generic;
 import org.openhab.binding.zwave.internal.protocol.ZWaveDeviceClass.Specific;
@@ -51,7 +52,6 @@ import org.openhab.binding.zwave.internal.protocol.serialmessage.DeleteReturnRou
 import org.openhab.binding.zwave.internal.protocol.serialmessage.DeleteSucReturnRouteMessageClass;
 import org.openhab.binding.zwave.internal.protocol.serialmessage.GetRoutingInfoMessageClass;
 import org.openhab.binding.zwave.internal.protocol.serialmessage.IdentifyNodeMessageClass;
-import org.openhab.binding.zwave.internal.protocol.serialmessage.IsFailedNodeMessageClass;
 import org.openhab.binding.zwave.internal.protocol.serialmessage.RequestNodeInfoMessageClass;
 import org.openhab.binding.zwave.internal.protocol.serialmessage.RequestNodeNeighborUpdateMessageClass;
 import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
@@ -356,24 +356,26 @@ public class ZWaveNodeInitStageAdvancer {
             return;
         }
 
-        setCurrentStage(ZWaveNodeInitStage.FAILED_CHECK);
-        do {
-            processTransaction(new IsFailedNodeMessageClass().doRequest(node.getNodeId()));
-            if (initRunning == false) {
-                return;
-            }
-
-            // If the node is dead, sleep for 30 seconds then try again
-            if (node.isDead()) {
-                try {
-                    Thread.sleep(30000);
-                } catch (InterruptedException e) {
-                    break;
-                }
-            } else {
-                break;
-            }
-        } while (true);
+        /**
+         * setCurrentStage(ZWaveNodeInitStage.FAILED_CHECK);
+         * do {
+         * processTransaction(new IsFailedNodeMessageClass().doRequest(node.getNodeId()));
+         * if (initRunning == false) {
+         * return;
+         * }
+         *
+         * // If the node is dead, sleep for 30 seconds then try again
+         * if (node.isDead()) {
+         * try {
+         * Thread.sleep(30000);
+         * } catch (InterruptedException e) {
+         * break;
+         * }
+         * } else {
+         * break;
+         * }
+         * } while (true);
+         */
 
         // setCurrentStage(ZWaveNodeInitStage.PING);
         // ZWaveNoOperationCommandClass noOpCommandClass = (ZWaveNoOperationCommandClass) node
@@ -824,12 +826,7 @@ public class ZWaveNodeInitStageAdvancer {
 
         setCurrentStage(ZWaveNodeInitStage.SET_ASSOCIATION);
         if (controller.isMasterController() == true) {
-
-            // TODO: This should support MULTI_ASSOCIATION - when required
-
-            ZWaveAssociationCommandClass associationCls = (ZWaveAssociationCommandClass) node
-                    .getCommandClass(CommandClass.COMMAND_CLASS_ASSOCIATION);
-            if (associationCls == null) {
+            if (multiAssociationCommandClass == null && associationCommandClass == null) {
                 logger.debug("NODE {}: Node advancer: SET_ASSOCIATION - ASSOCIATION class not supported",
                         node.getNodeId());
             } else {
@@ -843,24 +840,39 @@ public class ZWaveNodeInitStageAdvancer {
                         logger.debug("NODE {}: Node advancer: SET_ASSOCIATION - no default associations",
                                 node.getNodeId());
                     } else {
+                        ZWaveAssociation association;
+                        if (multiAssociationCommandClass != null) {
+                            association = new ZWaveAssociation(controller.getOwnNodeId(), 0);
+                        } else {
+                            association = new ZWaveAssociation(controller.getOwnNodeId());
+                        }
+
                         String defaultGroups[] = associations.split(",");
                         for (int c = 0; c < defaultGroups.length; c++) {
                             int groupId = Integer.parseInt(defaultGroups[c]);
-                            ZWaveAssociation association = new ZWaveAssociation(controller.getOwnNodeId());
 
                             // We should know about all groups at this stage.
                             // If we don't know about the group, then assume it doesn't exist
-                            if (node.getAssociationGroup(groupId) == null) {
+                            ZWaveAssociationGroup associationGroup = node.getAssociationGroup(groupId);
+                            if (associationGroup == null) {
                                 continue;
                             }
 
                             // Check if we're already a member
-                            if (node.getAssociationGroup(groupId).getAssociations().contains(association)) {
-                                logger.debug("NODE {}: Node advancer: SET_ASSOCIATION - ASSOCIATION set for group {}",
-                                        node.getNodeId(), groupId);
+                            if (associationGroup.isAssociated(association)) {
+                                logger.debug(
+                                        "NODE {}: Node advancer: SET_ASSOCIATION - ASSOCIATION {} set for group {}",
+                                        node.getNodeId(), association, groupId);
                             } else {
-                                logger.debug("NODE {}: Node advancer: SET_ASSOCIATION - Adding ASSOCIATION to group {}",
-                                        node.getNodeId(), groupId);
+                                logger.debug(
+                                        "NODE {}: Node advancer: SET_ASSOCIATION - Adding ASSOCIATION {} to group {}",
+                                        node.getNodeId(), association, groupId);
+
+                                // If this is the lifeline
+                                if (associationGroup.getProfile1() == 0x00 && associationGroup.getProfile2() == 0x01) {
+
+                                }
+
                                 // Set the association, and request the update so we confirm if it's set
                                 processTransaction(node.setAssociation(null, groupId, controller.getOwnNodeId(), 0));
                                 if (initRunning == false) {
@@ -874,6 +886,64 @@ public class ZWaveNodeInitStageAdvancer {
                         }
                     }
                 }
+            }
+        }
+
+        setCurrentStage(ZWaveNodeInitStage.SET_LIFELINE);
+        if (controller.isMasterController() == true) {
+            if (multiAssociationCommandClass == null && associationCommandClass == null) {
+                logger.debug("NODE {}: Node advancer: SET_LIFELINE - ASSOCIATION class not supported",
+                        node.getNodeId());
+            } else {
+                ZWaveAssociation association;
+                if (multiAssociationCommandClass != null) {
+                    association = new ZWaveAssociation(controller.getOwnNodeId(), 0);
+                } else {
+                    association = new ZWaveAssociation(controller.getOwnNodeId());
+                }
+
+                Collection<ZWaveAssociationGroup> associations = node.getAssociationGroups().values();
+
+                for (ZWaveAssociationGroup associationGroup : associations) {
+                    // Check if this is the lifeline profile
+                    if (associationGroup.getProfile1() != 0x00 || associationGroup.getProfile2() != 0x01) {
+                        continue;
+                    }
+
+                    // Check if we're already a member
+                    if (associationGroup.isAssociated(association)) {
+                        logger.debug("NODE {}: Node advancer: SET_LIFELINE - ASSOCIATION {} set for group {}",
+                                node.getNodeId(), association, associationGroup.getIndex());
+                        break;
+                    }
+
+                    // Check if there's another node set
+                    if (associationGroup.getAssociationCnt() != 0) {
+                        logger.debug("NODE {}: Node advancer: SET_LIFELINE - ASSOCIATION clearing group {}",
+                                node.getNodeId(), association, associationGroup.getIndex());
+                        processTransaction(node.clearAssociation(associationGroup.getIndex()));
+                        if (initRunning == false) {
+                            return;
+                        }
+                    }
+
+                    logger.debug("NODE {}: Node advancer: SET_LIFELINE - Adding ASSOCIATION {} to group {}",
+                            node.getNodeId(), association, associationGroup.getIndex());
+
+                    // Set the association, and request the update so we confirm if it's set
+                    processTransaction(
+                            node.setAssociation(null, associationGroup.getIndex(), controller.getOwnNodeId(), 0));
+                    if (initRunning == false) {
+                        return;
+                    }
+                    processTransaction(node.getAssociation(associationGroup.getIndex()));
+                    if (initRunning == false) {
+                        return;
+                    }
+
+                    break;
+                }
+
             }
         }
 

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/ZWaveAssociationGroupTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/ZWaveAssociationGroupTest.java
@@ -3,6 +3,7 @@ package org.openhab.binding.zwave.test.internal.protocol;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.ZWaveAssociation;
 import org.openhab.binding.zwave.internal.protocol.ZWaveAssociationGroup;
 
 public class ZWaveAssociationGroupTest {
@@ -12,12 +13,36 @@ public class ZWaveAssociationGroupTest {
 
         group.addAssociation(1);
         assertEquals(1, group.getAssociationCnt());
-        assertTrue(group.isAssociated(1, 0));
+        assertTrue(group.isAssociated(1));
+        assertFalse(group.isAssociated(1, 0));
 
-        group.addAssociation(1, 0);
+        group.addAssociation(1);
         assertEquals(1, group.getAssociationCnt());
 
-        group.addAssociation(3, 2);
+        group.addAssociation(1, 0);
         assertEquals(2, group.getAssociationCnt());
+
+        group.addAssociation(3, 2);
+        assertEquals(3, group.getAssociationCnt());
+    }
+
+    @Test
+    public void testIsAssociated() {
+        ZWaveAssociationGroup group = new ZWaveAssociationGroup(1);
+        group.addAssociation(1);
+        assertTrue(group.isAssociated(1));
+        assertFalse(group.isAssociated(2));
+        assertFalse(group.isAssociated(1, 0));
+        assertFalse(group.isAssociated(1, 2));
+
+        ZWaveAssociation association = new ZWaveAssociation(1);
+        assertTrue(group.isAssociated(association));
+
+        association = new ZWaveAssociation(1, 1);
+        assertFalse(group.isAssociated(association));
+
+        group.addAssociation(1, 1);
+        association = new ZWaveAssociation(1, 1);
+        assertTrue(group.isAssociated(association));
     }
 }

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/ZWaveAssociationGroupTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/ZWaveAssociationGroupTest.java
@@ -45,4 +45,14 @@ public class ZWaveAssociationGroupTest {
         association = new ZWaveAssociation(1, 1);
         assertTrue(group.isAssociated(association));
     }
+
+    @Test
+    public void testIsProfileKnown() {
+        ZWaveAssociationGroup group = new ZWaveAssociationGroup(1);
+        assertFalse(group.isProfileKnown());
+
+        group.setProfile1(0);
+        group.setProfile2(0);
+        assertTrue(group.isProfileKnown());
+    }
 }

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/ZWaveAssociationTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/ZWaveAssociationTest.java
@@ -1,0 +1,33 @@
+package org.openhab.binding.zwave.test.internal.protocol;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.openhab.binding.zwave.internal.protocol.ZWaveAssociation;
+
+/**
+ * Tests for the Association group
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZWaveAssociationTest {
+    @Test
+    public void testAssociationEquals() {
+        ZWaveAssociation association1 = new ZWaveAssociation(1);
+        ZWaveAssociation association2 = new ZWaveAssociation(1);
+        assertTrue(association1.equals(association2));
+
+        association1 = new ZWaveAssociation(1);
+        association2 = new ZWaveAssociation(2);
+        assertFalse(association1.equals(association2));
+
+        association1 = new ZWaveAssociation(1);
+        association2 = new ZWaveAssociation(1, 0);
+        assertFalse(association1.equals(association2));
+
+        association1 = new ZWaveAssociation(1, 0);
+        association2 = new ZWaveAssociation(1, 1);
+        assertFalse(association1.equals(association2));
+    }
+}

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/ZWaveNodeTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/ZWaveNodeTest.java
@@ -30,8 +30,8 @@ public class ZWaveNodeTest {
         ZWaveCommandClassTransactionPayload msg;
         byte[] expectedResponse;
 
-        // Setting device endpoint null and receive endpoint 0 should use single instance
-        expectedResponse = new byte[] { -123, 1, 0, 5 };
+        // Setting device endpoint null and receive endpoint 0 should use multi instance
+        expectedResponse = new byte[] { -114, 1, 0, 5 };
         msg = node.setAssociation(null, 0, 5, 0);
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponse));
 

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveMultiAssociationCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveMultiAssociationCommandClassTest.java
@@ -129,6 +129,6 @@ public class ZWaveMultiAssociationCommandClassTest extends ZWaveCommandClassTest
         assertEquals(event.getGroupId(), 2);
         assertEquals(event.getGroupMembers().size(), 1);
         assertEquals(event.getGroupMembers().get(0).getNode(), 1);
-        assertEquals(event.getGroupMembers().get(0).getEndpoint(), 1);
+        assertEquals(event.getGroupMembers().get(0).getEndpoint(), Integer.valueOf(1));
     }
 }


### PR DESCRIPTION
This adds support for AGI on root node, and then adds a feature to set the lifeline during initialisation. It will remove any nodes already in the lifeline group (since this normally only allows 1 node).
Signed-off-by: Chris Jackson <chris@cd-jackson.com>