### PR TITLE
Add missing references for localisation of WallMotes

### DIFF
--- a/ESH-INF/thing/aeon_zw129_0_0.xml
+++ b/ESH-INF/thing/aeon_zw129_0_0.xml
@@ -43,7 +43,7 @@
       <property name="vendor">AEON Labs</property>
       <property name="modelId">ZW129</property>
       <property name="manufacturerId">0086</property>
-      <property name="manufacturerRef">0002:0081</property>
+      <property name="manufacturerRef">0002:0081,0102:0081,0202:0081</property>
       <property name="dbReference">390</property>
       <property name="defaultAssociations">1</property>
     </properties>


### PR DESCRIPTION
There are 3 of these 2 button wallmotes
ZW129-A, ZW129-B and ZW129-C
The only difference I can find is the radio frequency.
I have a ZW129-B, and the type:id is 0202:0081
It seems the other 2 are 0002:0081 and 0102:0081

This pull request is simply adding in the 2 additional id's

Having said that, **this is untested**... see this
https://community.openhab.org/t/manufacturer-reference-missing-for-zw129/34874

Andrew Frahn
nullku7@gmail.com