### PR TITLE
Fix handling of channel types in converters

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingChannel.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingChannel.java
@@ -11,6 +11,7 @@ package org.openhab.binding.zwave.handler;
 import java.util.Map;
 
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.openhab.binding.zwave.internal.converter.ZWaveCommandClassConverter;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
@@ -35,20 +36,22 @@ public class ZWaveThingChannel {
     }
 
     // int nodeId;
-    int endpoint;
-    ChannelUID uid;
-    String commandClass;
-    ZWaveCommandClassConverter converter;
-    DataType dataType;
-    Map<String, String> arguments;
+    private int endpoint;
+    private ChannelUID uid;
+    private ChannelTypeUID channelTypeUID;
+    private String commandClass;
+    private ZWaveCommandClassConverter converter;
+    private DataType dataType;
+    private Map<String, String> arguments;
 
-    public ZWaveThingChannel(ZWaveControllerHandler controller, ChannelUID uid, DataType dataType,
-            String commandClassName, int endpoint, Map<String, String> arguments) {
+    public ZWaveThingChannel(ZWaveControllerHandler controller, ChannelTypeUID channelTypeUID, ChannelUID uid,
+            DataType dataType, String commandClassName, int endpoint, Map<String, String> arguments) {
         this.uid = uid;
         this.arguments = arguments;
         this.commandClass = commandClassName;
         this.endpoint = endpoint;
         this.dataType = dataType;
+        this.channelTypeUID = channelTypeUID;
 
         // Get the converter
         CommandClass commandClass = ZWaveCommandClass.CommandClass.getCommandClass(commandClassName);
@@ -66,6 +69,10 @@ public class ZWaveThingChannel {
         return uid;
     }
 
+    public ChannelTypeUID getChannelTypeUID() {
+        return channelTypeUID;
+    }
+
     public String getCommandClass() {
         return commandClass;
     }
@@ -80,5 +87,9 @@ public class ZWaveThingChannel {
 
     public Map<String, String> getArguments() {
         return arguments;
+    }
+
+    public ZWaveCommandClassConverter getConverter() {
+        return converter;
     }
 }

--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -254,8 +254,8 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
                         logger.warn("NODE {}: Invalid item type defined ({}). Assuming DecimalType", nodeId, dataType);
                     }
 
-                    ZWaveThingChannel chan = new ZWaveThingChannel(controllerHandler, channel.getUID(), dataType,
-                            ccSplit[0], endpoint, argumentMap);
+                    ZWaveThingChannel chan = new ZWaveThingChannel(controllerHandler, channel.getChannelTypeUID(),
+                            channel.getUID(), dataType, ccSplit[0], endpoint, argumentMap);
 
                     // First time round, and this is a command - then add the command
                     if (first && ("*".equals(bindingType[1]) || "Command".equals(bindingType[1]))) {
@@ -374,12 +374,12 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
                         }
 
                         logger.debug("NODE {}: Polling {}", nodeId, channel.getUID());
-                        if (channel.converter == null) {
+                        if (channel.getConverter() == null) {
                             logger.debug("NODE {}: Polling aborted as no converter found for {}", nodeId,
                                     channel.getUID());
                         } else {
-                            List<ZWaveCommandClassTransactionPayload> poll = channel.converter.executeRefresh(channel,
-                                    node);
+                            List<ZWaveCommandClassTransactionPayload> poll = channel.getConverter()
+                                    .executeRefresh(channel, node);
                             if (poll != null) {
                                 messages.addAll(poll);
                             }
@@ -976,13 +976,13 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
             return;
         }
 
-        if (cmdChannel.converter == null) {
+        if (cmdChannel.getConverter() == null) {
             logger.warn("NODE {}: No command converter set for command {} type {}", nodeId, channelUID, dataType);
             return;
         }
 
         List<ZWaveCommandClassTransactionPayload> messages = null;
-        messages = cmdChannel.converter.receiveCommand(cmdChannel, node, command);
+        messages = cmdChannel.getConverter().receiveCommand(cmdChannel, node, command);
 
         if (messages == null) {
             logger.debug("NODE {}: No messages returned from converter", nodeId);
@@ -1179,14 +1179,14 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
                     continue;
                 }
 
-                if (channel.converter == null) {
+                if (channel.getConverter() == null) {
                     logger.warn("NODE {}: No state converter set for channel {}", nodeId, channel.getUID());
                     return;
                 }
 
                 // logger.debug("NODE {}: Processing event as channel {} {}", nodeId, channel.getUID(),
                 // channel.dataType);
-                State state = channel.converter.handleEvent(channel, event);
+                State state = channel.getConverter().handleEvent(channel, event);
                 if (state != null) {
                     logger.debug("NODE {}: Updating channel state {} to {} [{}]", nodeId, channel.getUID(), state,
                             state.getClass().getSimpleName());

--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
@@ -267,7 +267,7 @@ public class ZWaveAlarmConverter extends ZWaveCommandClassConverter {
         // return null;
         // }
 
-        String channelType = channel.getUID().getId();
+        String channelType = channel.getChannelTypeUID().getId();
         switch (channelType) {
             case "alarm_raw":
                 Map<String, Object> object = new HashMap<String, Object>();

--- a/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveAlarmConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveAlarmConverterTest.java
@@ -20,6 +20,7 @@ import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -44,6 +45,7 @@ import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClass
 public class ZWaveAlarmConverterTest extends ZWaveCommandClassConverterTest {
     private ZWaveThingChannel createChannel(String channelType, DataType dataType, String type, String event) {
         ChannelUID uid = new ChannelUID("zwave:node:bridge:" + channelType);
+        ChannelTypeUID typeUid = new ChannelTypeUID("zwave:" + channelType);
 
         Map<String, String> args = new HashMap<String, String>();
         if (type != null) {
@@ -52,7 +54,8 @@ public class ZWaveAlarmConverterTest extends ZWaveCommandClassConverterTest {
         if (event != null) {
             args.put("event", event);
         }
-        return new ZWaveThingChannel(null, uid, dataType, CommandClass.COMMAND_CLASS_ALARM.toString(), 0, args);
+        return new ZWaveThingChannel(null, typeUid, uid, dataType, CommandClass.COMMAND_CLASS_ALARM.toString(), 0,
+                args);
     }
 
     private ZWaveCommandClassValueEvent createEvent(AlarmType type, ReportType reportType, Integer event,
@@ -199,6 +202,7 @@ public class ZWaveAlarmConverterTest extends ZWaveCommandClassConverterTest {
     @Test
     public void sendNotification() {
         ChannelUID uid = new ChannelUID("zwave:node:bridge:channel");
+        ChannelTypeUID typeUid = new ChannelTypeUID("zwave:channel");
 
         List<ZWaveCommandClassTransactionPayload> msgs;
         DecimalType command;
@@ -209,7 +213,7 @@ public class ZWaveAlarmConverterTest extends ZWaveCommandClassConverterTest {
         args.put("event4", AlarmType.EMERGENCY.toString() + ":1");
         args.put("event5", AlarmType.EMERGENCY.toString() + ":2");
         args.put("event6", AlarmType.EMERGENCY.toString() + ":3");
-        ZWaveThingChannel channel = new ZWaveThingChannel(null, uid, DataType.OnOffType,
+        ZWaveThingChannel channel = new ZWaveThingChannel(null, typeUid, uid, DataType.OnOffType,
                 CommandClass.COMMAND_CLASS_ALARM.toString(), 0, args);
 
         ZWaveAlarmConverter converter = new ZWaveAlarmConverter(null);
@@ -236,8 +240,9 @@ public class ZWaveAlarmConverterTest extends ZWaveCommandClassConverterTest {
         Map<String, String> args = new HashMap<String, String>();
 
         // Note test here that data type is ignored
-        ZWaveThingChannel channel = new ZWaveThingChannel(null, new ChannelUID("zwave:node:bridge:alarm_number"),
-                DataType.OnOffType, CommandClass.COMMAND_CLASS_ALARM.toString(), 0, args);
+        ZWaveThingChannel channel = new ZWaveThingChannel(null, new ChannelTypeUID("zwave:alarm_number"),
+                new ChannelUID("zwave:node:bridge:alarm_number"), DataType.OnOffType,
+                CommandClass.COMMAND_CLASS_ALARM.toString(), 0, args);
 
         ZWaveCommandClassValueEvent event = createEvent(1, 0xff);
         DecimalType state = (DecimalType) converter.handleEvent(channel, event);
@@ -254,8 +259,9 @@ public class ZWaveAlarmConverterTest extends ZWaveCommandClassConverterTest {
         Map<String, String> args = new HashMap<String, String>();
 
         // Note test here that data type is ignored
-        ZWaveThingChannel channel = new ZWaveThingChannel(null, new ChannelUID("zwave:node:bridge:alarm_raw"),
-                DataType.StringType, CommandClass.COMMAND_CLASS_ALARM.toString(), 0, args);
+        ZWaveThingChannel channel = new ZWaveThingChannel(null, new ChannelTypeUID("zwave:alarm_raw"),
+                new ChannelUID("zwave:node:bridge:alarm_raw"), DataType.StringType,
+                CommandClass.COMMAND_CLASS_ALARM.toString(), 0, args);
 
         ZWaveCommandClassValueEvent event = createEvent(AlarmType.ACCESS_CONTROL, ReportType.NOTIFICATION, 6, 255);
         StringType state = (StringType) converter.handleEvent(channel, event);

--- a/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveBasicConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveBasicConverterTest.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Test;
 import org.openhab.binding.zwave.handler.ZWaveThingChannel;
@@ -29,11 +30,12 @@ import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueE
  */
 public class ZWaveBasicConverterTest extends ZWaveCommandClassConverterTest {
     final ChannelUID uid = new ChannelUID("zwave:node:bridge:channel");
+    final ChannelTypeUID typeUid = new ChannelTypeUID("zwave:channel");
 
     @Test
     public void Event_Percent() {
         ZWaveBasicConverter converter = new ZWaveBasicConverter(null);
-        ZWaveThingChannel channel = new ZWaveThingChannel(null, uid, DataType.PercentType,
+        ZWaveThingChannel channel = new ZWaveThingChannel(null, typeUid, uid, DataType.PercentType,
                 CommandClass.COMMAND_CLASS_BASIC.toString(), 0, new HashMap<String, String>());
 
         State state;

--- a/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveBatteryConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveBatteryConverterTest.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Test;
 import org.openhab.binding.zwave.handler.ZWaveThingChannel;
@@ -29,11 +30,12 @@ import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueE
  */
 public class ZWaveBatteryConverterTest extends ZWaveCommandClassConverterTest {
     final ChannelUID uid = new ChannelUID("zwave:node:bridge:channel");
+    final ChannelTypeUID typeUid = new ChannelTypeUID("zwave:channel");
 
     @Test
     public void Event_Percent() {
         ZWaveBatteryConverter converter = new ZWaveBatteryConverter(null);
-        ZWaveThingChannel channel = new ZWaveThingChannel(null, uid, DataType.PercentType,
+        ZWaveThingChannel channel = new ZWaveThingChannel(null, typeUid, uid, DataType.PercentType,
                 CommandClass.COMMAND_CLASS_BATTERY.toString(), 0, new HashMap<String, String>());
 
         State state;

--- a/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveColorConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveColorConverterTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -37,6 +38,7 @@ import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueE
  */
 public class ZWaveColorConverterTest extends ZWaveCommandClassConverterTest {
     final ChannelUID uid = new ChannelUID("zwave:node:bridge:channel");
+    final ChannelTypeUID typeUid = new ChannelTypeUID("zwave:channel");
 
     private ZWaveCommandClassValueEvent createEvent(Map<ZWaveColorType, Integer> colorMap) {
         ZWaveController controller = Mockito.mock(ZWaveController.class);
@@ -51,7 +53,7 @@ public class ZWaveColorConverterTest extends ZWaveCommandClassConverterTest {
     public void Event_ColorSupported_None() {
         // This simulates the initial color_supported message which returns colors with null
         ZWaveColorConverter converter = new ZWaveColorConverter(null);
-        ZWaveThingChannel channel = new ZWaveThingChannel(null, uid, DataType.HSBType,
+        ZWaveThingChannel channel = new ZWaveThingChannel(null, typeUid, uid, DataType.HSBType,
                 CommandClass.COMMAND_CLASS_SWITCH_COLOR.toString(), 0, new HashMap<String, String>());
 
         final Map<ZWaveColorType, Integer> colorMap = new HashMap<ZWaveColorType, Integer>();

--- a/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveConfigurationConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveConfigurationConverterTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -42,11 +43,12 @@ import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClass
  */
 public class ZWaveConfigurationConverterTest extends ZWaveCommandClassConverterTest {
     final ChannelUID uid = new ChannelUID("zwave:node:bridge:channel");
+    final ChannelTypeUID typeUid = new ChannelTypeUID("zwave:channel");
 
     private ZWaveThingChannel createChannel(String parameter) {
         Map<String, String> args = new HashMap<String, String>();
         args.put("parameter", parameter);
-        return new ZWaveThingChannel(null, uid, DataType.DecimalType,
+        return new ZWaveThingChannel(null, typeUid, uid, DataType.DecimalType,
                 CommandClass.COMMAND_CLASS_CONFIGURATION.toString(), 0, args);
     }
 

--- a/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveManufacturerProprietaryFibaroFgrm222ConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveManufacturerProprietaryFibaroFgrm222ConverterTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Test;
 import org.openhab.binding.zwave.handler.ZWaveThingChannel;
@@ -34,13 +35,14 @@ import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClass
  */
 public class ZWaveManufacturerProprietaryFibaroFgrm222ConverterTest extends ZWaveCommandClassConverterTest {
     final ChannelUID shutterUid = new ChannelUID("zwave:node:bridge:blinds_shutter");
+    final ChannelTypeUID typeUid = new ChannelTypeUID("zwave:blinds_shutter");
 
     @Test
     public void Event_Fgrm222_Lamella() {
         ZWaveManufacturerProprietaryConverter converter = new ZWaveManufacturerProprietaryConverter(null);
 
         ChannelUID uid = new ChannelUID("zwave:node:bridge:blinds_lamella");
-        ZWaveThingChannel channel = new ZWaveThingChannel(null, uid, DataType.PercentType,
+        ZWaveThingChannel channel = new ZWaveThingChannel(null, typeUid, uid, DataType.PercentType,
                 CommandClass.COMMAND_CLASS_MANUFACTURER_PROPRIETARY.toString(), 0, new HashMap<String, String>());
 
         State state;
@@ -60,7 +62,7 @@ public class ZWaveManufacturerProprietaryFibaroFgrm222ConverterTest extends ZWav
         ZWaveManufacturerProprietaryConverter converter = new ZWaveManufacturerProprietaryConverter(null);
 
         ChannelUID uid = new ChannelUID("zwave:node:bridge:blinds_shutter");
-        ZWaveThingChannel channel = new ZWaveThingChannel(null, uid, DataType.PercentType,
+        ZWaveThingChannel channel = new ZWaveThingChannel(null, typeUid, uid, DataType.PercentType,
                 CommandClass.COMMAND_CLASS_MANUFACTURER_PROPRIETARY.toString(), 0, new HashMap<String, String>());
 
         State state;
@@ -80,7 +82,8 @@ public class ZWaveManufacturerProprietaryFibaroFgrm222ConverterTest extends ZWav
         ZWaveManufacturerProprietaryConverter converter = new ZWaveManufacturerProprietaryConverter(null);
 
         ChannelUID uid = new ChannelUID("zwave:node:bridge:blinds_lamella");
-        ZWaveThingChannel channel = new ZWaveThingChannel(null, uid, DataType.PercentType,
+        ChannelTypeUID typeUid = new ChannelTypeUID("zwave:blinds_lamella");
+        ZWaveThingChannel channel = new ZWaveThingChannel(null, typeUid, uid, DataType.PercentType,
                 CommandClass.COMMAND_CLASS_MANUFACTURER_PROPRIETARY.toString(), 0, new HashMap<String, String>());
 
         ZWaveNode node = CreateMockedNode(1);
@@ -101,7 +104,8 @@ public class ZWaveManufacturerProprietaryFibaroFgrm222ConverterTest extends ZWav
         ZWaveManufacturerProprietaryConverter converter = new ZWaveManufacturerProprietaryConverter(null);
 
         ChannelUID uid = new ChannelUID("zwave:node:bridge:blinds_shutter");
-        ZWaveThingChannel channel = new ZWaveThingChannel(null, uid, DataType.PercentType,
+        ChannelTypeUID typeUid = new ChannelTypeUID("zwave:blinds_shutter");
+        ZWaveThingChannel channel = new ZWaveThingChannel(null, typeUid, uid, DataType.PercentType,
                 CommandClass.COMMAND_CLASS_MANUFACTURER_PROPRIETARY.toString(), 0, new HashMap<String, String>());
 
         ZWaveNode node = CreateMockedNode(1);

--- a/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveMeterConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveMeterConverterTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -42,12 +43,13 @@ import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClass
  */
 public class ZWaveMeterConverterTest extends ZWaveCommandClassConverterTest {
     final ChannelUID uid = new ChannelUID("zwave:node:bridge:channel");
+    final ChannelTypeUID typeUid = new ChannelTypeUID("zwave:channel");
 
     private ZWaveThingChannel createChannel(String type) {
         Map<String, String> args = new HashMap<String, String>();
         args.put("type", type);
-        return new ZWaveThingChannel(null, uid, DataType.DecimalType, CommandClass.COMMAND_CLASS_METER.toString(), 0,
-                args);
+        return new ZWaveThingChannel(null, typeUid, uid, DataType.DecimalType,
+                CommandClass.COMMAND_CLASS_METER.toString(), 0, args);
     }
 
     private ZWaveCommandClassValueEvent createEvent(MeterType type, MeterScale scale, BigDecimal value) {
@@ -77,7 +79,7 @@ public class ZWaveMeterConverterTest extends ZWaveCommandClassConverterTest {
     @Test
     public void Reset() {
         Map<String, String> args = new HashMap<String, String>();
-        ZWaveThingChannel channel = new ZWaveThingChannel(null, uid, DataType.OnOffType,
+        ZWaveThingChannel channel = new ZWaveThingChannel(null, typeUid, uid, DataType.OnOffType,
                 CommandClass.COMMAND_CLASS_METER.toString(), 0, args);
         ZWaveMeterConverter converter = new ZWaveMeterConverter(null);
 

--- a/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveMeterTblMonitorConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveMeterTblMonitorConverterTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -38,11 +39,12 @@ import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueE
  */
 public class ZWaveMeterTblMonitorConverterTest {
     final ChannelUID uid = new ChannelUID("zwave:node:bridge:channel");
+    final ChannelTypeUID typeUid = new ChannelTypeUID("zwave:channel");
 
     private ZWaveThingChannel createChannel(String type) {
         Map<String, String> args = new HashMap<String, String>();
         args.put("type", type);
-        return new ZWaveThingChannel(null, uid, DataType.DecimalType,
+        return new ZWaveThingChannel(null, typeUid, uid, DataType.DecimalType,
                 CommandClass.COMMAND_CLASS_METER_TBL_MONITOR.toString(), 0, args);
     }
 

--- a/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveMultiLevelSensorConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveMultiLevelSensorConverterTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -36,11 +37,12 @@ import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueE
  */
 public class ZWaveMultiLevelSensorConverterTest {
     final ChannelUID uid = new ChannelUID("zwave:node:bridge:channel");
+    final ChannelTypeUID typeUid = new ChannelTypeUID("zwave:channel");
 
     private ZWaveThingChannel createChannel(String type) {
         Map<String, String> args = new HashMap<String, String>();
         args.put("type", type);
-        return new ZWaveThingChannel(null, uid, DataType.DecimalType,
+        return new ZWaveThingChannel(null, typeUid, uid, DataType.DecimalType,
                 CommandClass.COMMAND_CLASS_SENSOR_MULTILEVEL.toString(), 0, args);
     }
 

--- a/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveProtectionConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveProtectionConverterTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Test;
 import org.openhab.binding.zwave.handler.ZWaveThingChannel;
@@ -33,12 +34,13 @@ import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueE
  */
 public class ZWaveProtectionConverterTest {
     final ChannelUID uid = new ChannelUID("zwave:node:bridge:channel");
+    final ChannelTypeUID typeUid = new ChannelTypeUID("zwave:channel");
 
     private ZWaveThingChannel createChannel(String type) {
         Map<String, String> args = new HashMap<String, String>();
         args.put("type", type);
-        return new ZWaveThingChannel(null, uid, DataType.DecimalType, CommandClass.COMMAND_CLASS_PROTECTION.toString(),
-                0, args);
+        return new ZWaveThingChannel(null, typeUid, uid, DataType.DecimalType,
+                CommandClass.COMMAND_CLASS_PROTECTION.toString(), 0, args);
     }
 
     @Test

--- a/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveThermostatFanStateConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/converter/ZWaveThermostatFanStateConverterTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Test;
 import org.mockito.Matchers;
@@ -37,10 +38,11 @@ import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClass
  */
 public class ZWaveThermostatFanStateConverterTest {
     final ChannelUID uid = new ChannelUID("zwave:node:bridge:channel");
+    final ChannelTypeUID typeUid = new ChannelTypeUID("zwave:channel");
 
     private ZWaveThingChannel createChannel() {
         Map<String, String> args = new HashMap<String, String>();
-        return new ZWaveThingChannel(null, uid, DataType.DecimalType,
+        return new ZWaveThingChannel(null, typeUid, uid, DataType.DecimalType,
                 CommandClass.COMMAND_CLASS_THERMOSTAT_FAN_STATE.toString(), 0, args);
     }
 


### PR DESCRIPTION
For multi-endpoint channels this was not working correctly for converters that relied on channel type.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>