### PR TITLE
Update handling for wakeup configuration to correlate interval and node settings

### DIFF
--- a/ESH-INF/thing/aeon_zw122_0_0.xml
+++ b/ESH-INF/thing/aeon_zw122_0_0.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="zwave"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+  xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0
+                      http://eclipse.org/smarthome/schemas/thing-description/v1.0.0">
+
+  <thing-type id="aeon_zw122_00_000" listed="false">
+    <label>ZW122 Water Sensor 6</label>
+    <description>Water Sensor 6</description>
+
+    <!-- CHANNEL DEFINITIONS -->
+    <channels>
+      <channel id="sensor_temperature" typeId="sensor_temperature">
+        <label>Sensor (temperature)</label>
+        <properties>
+          <property name="binding:*:DecimalType">COMMAND_CLASS_SENSOR_MULTILEVEL;type=TEMPERATURE</property>
+        </properties>
+      </channel>
+      <channel id="alarm_burglar" typeId="alarm_burglar">
+        <label>Alarm (burglar)</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_ALARM;type=BURGLAR</property>
+        </properties>
+      </channel>
+      <channel id="alarm_heat" typeId="alarm_heat">
+        <label>Alarm (heat)</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_ALARM;type=HEAT</property>
+        </properties>
+      </channel>
+      <channel id="alarm_flood" typeId="alarm_flood">
+        <label>Alarm (flood)</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_ALARM;type=FLOOD</property>
+        </properties>
+      </channel>
+      <channel id="battery-level" typeId="system.battery-level">
+        <properties>
+          <property name="binding:*:PercentType">COMMAND_CLASS_BATTERY</property>
+        </properties>
+      </channel>
+      <channel id="alarm_flood1" typeId="alarm_flood">
+        <label>Alarm (flood) 1</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_ALARM:1;type=FLOOD</property>
+        </properties>
+      </channel>
+      <channel id="alarm_flood2" typeId="alarm_flood">
+        <label>Alarm (flood) 2</label>
+        <properties>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_ALARM:2;type=FLOOD</property>
+        </properties>
+      </channel>
+    </channels>
+
+    <!-- DEVICE PROPERTY DEFINITIONS -->
+    <properties>
+      <property name="vendor">AEON Labs</property>
+      <property name="modelId">ZW122</property>
+      <property name="manufacturerId">0086</property>
+      <property name="manufacturerRef">0002:007A</property>
+      <property name="dbReference">721</property>
+      <property name="defaultAssociations">1</property>
+    </properties>
+
+    <!-- CONFIGURATION DESCRIPTIONS -->
+    <config-description>
+
+      <!-- ASSOCIATION DEFINITIONS -->
+      <parameter-group name="association">
+        <context>link</context>
+        <label>Association Groups</label>
+      </parameter-group>
+
+      <parameter name="group_1" type="text" groupName="association" multiple="true">
+        <label>1: Lifeline</label>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+      <parameter name="group_2" type="text" groupName="association" multiple="true">
+        <label>2: Sensor Status</label>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+      <parameter name="group_3" type="text" groupName="association" multiple="true">
+        <label>3: Sensor 1 Alarm</label>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+      <parameter name="group_4" type="text" groupName="association" multiple="true">
+        <label>4: Sensor 2 Alarm</label>
+        <multipleLimit>5</multipleLimit>
+      </parameter>
+
+    </config-description>
+
+  </thing-type>
+
+</thing:thing-descriptions>

--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
@@ -726,6 +726,15 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
         return true;
     }
 
+    /**
+     * Gets the default wakeup period configured for this network
+     * 
+     * @return the default wakeup, or null if not set
+     */
+    public Integer getDefaultWakeupPeriod() {
+        return wakeupDefaultPeriod;
+    }
+
     public UID getUID() {
         return thing.getUID();
     }

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAssociationGroupInfoCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAssociationGroupInfoCommandClass.java
@@ -52,7 +52,7 @@ public class ZWaveAssociationGroupInfoCommandClass extends ZWaveCommandClass
     private static final byte ASSOCIATION_GROUP_INFO_LIST_GET = 5;
     private static final byte ASSOCIATION_GROUP_INFO_LIST_REPORT = 6;
 
-    private static final int MAX_STRING_LENGTH = 25;
+    private static final int MAX_STRING_LENGTH = 42;
 
     private static final int GET_LISTMODE_MASK = 0x40;
     // not used private static final int GET_REFRESHCACHE_MASK = 0x80;
@@ -287,6 +287,8 @@ public class ZWaveAssociationGroupInfoCommandClass extends ZWaveCommandClass
 
         // Only initialise the root endpoint
         if (getEndpoint() != null) {
+            logger.debug("NODE {}: Association group info ignoring endpoint {}", getNode().getNodeId(),
+                    getEndpoint().getEndpointId());
             return result;
         }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveWakeUpCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveWakeUpCommandClass.java
@@ -445,20 +445,19 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass implements ZWaveC
      */
 
     /**
-     * Sends a command to the device to set the wakeup interval.
-     * The wakeup node is set to the controller.
+     * Sends a command to the device to set the wakeup interval and target node.
      *
+     * @param nodeId the wakeup target node ID
      * @param interval the wakeup interval in seconds
-     * @return the serial message
+     * @return the {@link ZWaveCommandClassTransactionPayload}
      */
-    public ZWaveCommandClassTransactionPayload setInterval(int interval) {
-        logger.debug("NODE {}: Creating new message for application command WAKE_UP_INTERVAL_SET to {}",
-                getNode().getNodeId(), interval);
+    public ZWaveCommandClassTransactionPayload setInterval(int nodeId, int interval) {
+        logger.debug("NODE {}: Creating new message for command WAKE_UP_INTERVAL_SET to {}s, node {}",
+                getNode().getNodeId(), interval, nodeId);
 
         return new ZWaveCommandClassTransactionPayloadBuilder(getNode().getNodeId(), getCommandClass(),
                 WAKE_UP_INTERVAL_SET)
-                        .withPayload(((interval >> 16) & 0xff), ((interval >> 8) & 0xff), (interval & 0xff),
-                                getController().getOwnNodeId())
+                        .withPayload(((interval >> 16) & 0xff), ((interval >> 8) & 0xff), (interval & 0xff), nodeId)
                         .withPriority(TransactionPriority.Config).build();
     }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -812,7 +812,7 @@ public class ZWaveNodeInitStageAdvancer {
                         node.getNodeId(), controller.getOwnNodeId(), value);
 
                 // Set the wake-up interval, and request an update
-                processTransaction(wakeupCommandClass.setInterval(value));
+                processTransaction(wakeupCommandClass.setInterval(controller.getOwnNodeId(), value));
                 if (initRunning == false) {
                     return;
                 }
@@ -867,11 +867,6 @@ public class ZWaveNodeInitStageAdvancer {
                                         "NODE {}: Node advancer: SET_ASSOCIATION - Adding ASSOCIATION {} to group {}",
                                         node.getNodeId(), association, groupId);
 
-                                // If this is the lifeline
-                                if (associationGroup.getProfile1() == 0x00 && associationGroup.getProfile2() == 0x01) {
-
-                                }
-
                                 // Set the association, and request the update so we confirm if it's set
                                 processTransaction(node.setAssociation(null, groupId, controller.getOwnNodeId(), 0));
                                 if (initRunning == false) {
@@ -904,6 +899,9 @@ public class ZWaveNodeInitStageAdvancer {
                 Collection<ZWaveAssociationGroup> associations = node.getAssociationGroups().values();
 
                 for (ZWaveAssociationGroup associationGroup : associations) {
+                    logger.debug("NODE {}: Node advancer: SET_LIFELINE - Checking group {}", node.getNodeId(),
+                            associationGroup.getIndex());
+
                     // Check if this is the lifeline profile
                     if (associationGroup.getProfile1() != 0x00 || associationGroup.getProfile2() != 0x01) {
                         continue;
@@ -911,7 +909,7 @@ public class ZWaveNodeInitStageAdvancer {
 
                     // Check if we're already a member
                     if (associationGroup.isAssociated(association)) {
-                        logger.debug("NODE {}: Node advancer: SET_LIFELINE - ASSOCIATION {} set for group {}",
+                        logger.debug("NODE {}: Node advancer: SET_LIFELINE - ASSOCIATION {} already set for group {}",
                                 node.getNodeId(), association, associationGroup.getIndex());
                         break;
                     }
@@ -942,8 +940,9 @@ public class ZWaveNodeInitStageAdvancer {
 
                     break;
                 }
-
             }
+        } else {
+            logger.debug("NODE {}: Node advancer: SET_LIFELINE - not configured as not master", node.getNodeId());
         }
 
         setCurrentStage(ZWaveNodeInitStage.GET_CONFIGURATION);

--- a/src/test/java/org/openhab/binding/zwave/test/handler/ZWaveThingHandlerTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/handler/ZWaveThingHandlerTest.java
@@ -116,7 +116,7 @@ public class ZWaveThingHandlerTest {
 
         assertEquals(2, response.size());
         msg = response.get(0);
-        assertTrue(Arrays.equals(msg.getPayloadBuffer(), new byte[] { -124, 4, 0, 2, 88, 1 }));
+        assertTrue(Arrays.equals(msg.getPayloadBuffer(), new byte[] { -124, 4, 0, 2, 88, 0 }));
         msg = response.get(1);
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), new byte[] { -124, 5 }));
     }

--- a/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveWakeUpCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/test/internal/protocol/commandclass/ZWaveWakeUpCommandClassTest.java
@@ -53,7 +53,7 @@ public class ZWaveWakeUpCommandClassTest extends ZWaveCommandClassTest {
 
         byte[] expectedResponseV1 = { -124, 4, 0, 38, -108, 0 };
         cls.setVersion(1);
-        msg = cls.setInterval(9876);
+        msg = cls.setInterval(0, 9876);
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseV1));
     }
 


### PR DESCRIPTION
Correlates the wakeup node and interval before sending the command to set the wakeup configuration.
Add ZW122 definition used for testing.
Fixes #638

Signed-off-by: Chris Jackson <chris@cd-jackson.com>