### PR TITLE
Avoid NPE during Thing update

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.ScheduledFuture;
@@ -1396,7 +1397,7 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
         for (String property : config.getProperties().keySet()) {
             logger.debug("NODE {}: Property to update: {}, {}, {}", nodeId, property, config.get(property),
                     originalConfig.get(property));
-            if (config.get(property).equals(originalConfig.get(property)) == false) {
+            if (!Objects.equals(config.get(property), originalConfig.get(property))) {
                 update = true;
                 break;
             }


### PR DESCRIPTION
Compare equality using Objects.equals(Object, Object) which is null-safe.

Possible fix for #755.

Also mentioned here: https://community.openhab.org/t/item-update-results-in-exception-occurred-while-calling-thing-updated-at-thinghandler/34526/2

It’s very hard to add a unit test because the updateNodeProperties() method is private and 144 lines long. Would patches to split this function out be acceptable?

An alternative fix would be to simply do:

```java
update = config.equals(originalConfig);
```

because `org.eclipse.smarthome.config.core.Configuration` implements the `equals` method, but then we wouldn’t be able to have the debug messages showing what changed. Having said that, you’ll only see the first changed key logged anyway because of the `break` statement.

Signed-off-by: Jon Evans <jon.evans@pobox.com> (github: evansj)