### PR TITLE
Add "Invert percentage value" option to blinds_lamella & blinds_shutter

### DIFF
--- a/ESH-INF/thing/_channels.xml
+++ b/ESH-INF/thing/_channels.xml
@@ -309,6 +309,18 @@
         <label>Blinds Lamella Position</label>
         <description>Sets the blinds lamella position</description>
         <category>Blinds</category>
+        <config-description>
+            <parameter name="config_invert_percent" type="boolean">
+                <label>Invert percentage value</label>
+                <description>Invert the lamella percentage value</description>
+                <default>false</default>
+                <options>
+                    <option value="true">Yes</option>
+                    <option value="false">No</option>
+                </options>
+                <limitToOptions>true</limitToOptions>
+            </parameter>
+        </config-description>
     </channel-type>
 
     <channel-type id="blinds_shutter">
@@ -316,6 +328,18 @@
         <label>Blinds Shutter Position</label>
         <description>Sets the blinds shutter position</description>
         <category>Blinds</category>
+        <config-description>
+            <parameter name="config_invert_percent" type="boolean">
+                <label>Invert percentage value</label>
+                <description>Invert the lamella percentage value</description>
+                <default>false</default>
+                <options>
+                    <option value="true">Yes</option>
+                    <option value="false">No</option>
+                </options>
+                <limitToOptions>true</limitToOptions>
+            </parameter>
+        </config-description>
     </channel-type>
 
     <!-- Color Setting Channel -->


### PR DESCRIPTION
*) A new parameter has been added to the blinds_lamella and
blinds_shutter channel definition to invert the percentage value. The
same option is already present on the Rollershutter channel but was
missing in the other channels. Thus the lamella /shutter where moving in
the wrong direction when using this channels.

*) The parameter is evaluated in the proprietary converter used to
control the Fibaro FGR222 shutter.

Signed-off-by: Michael Heiß <michael.heiss@outlook.at>