### PR TITLE
Remove user configuration for power level command class

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
+++ b/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
@@ -46,9 +46,6 @@ public class ZWaveBindingConstants {
     public final static String CONFIGURATION_NODENAME = "nodename_name";
     public final static String CONFIGURATION_NODELOCATION = "nodename_location";
 
-    public final static String CONFIGURATION_POWERLEVEL_LEVEL = "powerlevel_level";
-    public final static String CONFIGURATION_POWERLEVEL_TIMEOUT = "powerlevel_timeout";
-
     public final static String CONFIGURATION_USERCODE = "usercode_";
 
     public final static String CONFIGURATION_DOORLOCKTIMEOUT = "doorlock_timeout";

--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -59,8 +59,6 @@ import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveConfigurati
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveDoorLockCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveNodeNamingCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWavePlusCommandClass;
-import org.openhab.binding.zwave.internal.protocol.commandclass.ZWavePowerLevelCommandClass;
-import org.openhab.binding.zwave.internal.protocol.commandclass.ZWavePowerLevelCommandClass.ZWavePowerLevelCommandClassChangeEvent;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveSwitchAllCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveUserCodeCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveWakeUpCommandClass;
@@ -727,34 +725,6 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
                             .setValueMessage(Integer.parseInt(configurationParameter.getValue().toString())));
                 }
                 pendingCfg.put(configurationParameter.getKey(), valueObject);
-            } else if ("powerlevel".equals(cfg[0])) {
-                ZWavePowerLevelCommandClass powerlevelCommandClass = (ZWavePowerLevelCommandClass) node
-                        .getCommandClass(CommandClass.POWERLEVEL);
-                if (powerlevelCommandClass == null) {
-                    logger.debug("NODE {}: Error getting PowerLevelCommandClass", nodeId);
-                    continue;
-                }
-
-                // Since both level and timeout are set in a single command, we first check if the value exists in the
-                // pending list, and if not, use the value already stored in the command class
-                if ("level".equals(cfg[1])) {
-                    Integer timeout = (Integer) pendingCfg.get(ZWaveBindingConstants.CONFIGURATION_POWERLEVEL_TIMEOUT);
-                    if (timeout == null) {
-                        timeout = powerlevelCommandClass.getTimeout();
-                    }
-                    controllerHandler.sendData(powerlevelCommandClass.setValueMessage(
-                            (Integer.parseInt(configurationParameter.getValue().toString())), timeout));
-                }
-                if ("timeout".equals(cfg[1])) {
-                    Integer level = (Integer) pendingCfg.get(ZWaveBindingConstants.CONFIGURATION_POWERLEVEL_LEVEL);
-                    if (level == null) {
-                        level = powerlevelCommandClass.getLevel();
-                    }
-                    controllerHandler.sendData(powerlevelCommandClass.setValueMessage(level,
-                            (Integer.parseInt(configurationParameter.getValue().toString()))));
-                }
-                controllerHandler.sendData(powerlevelCommandClass.getValueMessage());
-                pendingCfg.put(configurationParameter.getKey(), valueObject);
             } else if ("doorlock".equals(cfg[0])) {
                 ZWaveDoorLockCommandClass commandClass = (ZWaveDoorLockCommandClass) node
                         .getCommandClass(CommandClass.DOOR_LOCK);
@@ -1049,15 +1019,6 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
                         default:
                             break;
                     }
-                    break;
-
-                case POWERLEVEL:
-                    ZWavePowerLevelCommandClassChangeEvent powerEvent = (ZWavePowerLevelCommandClassChangeEvent) event;
-                    cfgUpdated = true;
-                    configuration.put(ZWaveBindingConstants.CONFIGURATION_POWERLEVEL_LEVEL, powerEvent.getLevel());
-                    pendingCfg.remove(ZWaveBindingConstants.CONFIGURATION_POWERLEVEL_LEVEL);
-                    configuration.put(ZWaveBindingConstants.CONFIGURATION_POWERLEVEL_TIMEOUT, powerEvent.getTimeout());
-                    pendingCfg.remove(ZWaveBindingConstants.CONFIGURATION_POWERLEVEL_TIMEOUT);
                     break;
 
                 default:

--- a/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
@@ -220,33 +220,6 @@ public class ZWaveConfigProvider implements ConfigDescriptionProvider, ConfigOpt
                     .withGroupName("thingcfg").withOptions(options).withLimitToOptions(true).build());
         }
 
-        // If we support the powerlevel class, then add the configuration
-        if (node.getCommandClass(ZWaveCommandClass.CommandClass.POWERLEVEL) != null) {
-            options = new ArrayList<ParameterOption>();
-            options.add(new ParameterOption("0", "Normal"));
-            options.add(new ParameterOption("1", "Minus 1dB"));
-            options.add(new ParameterOption("2", "Minus 2dB"));
-            options.add(new ParameterOption("3", "Minus 3dB"));
-            options.add(new ParameterOption("4", "Minus 4dB"));
-            options.add(new ParameterOption("5", "Minus 5dB"));
-            options.add(new ParameterOption("6", "Minus 6dB"));
-            options.add(new ParameterOption("7", "Minus 7dB"));
-            options.add(new ParameterOption("8", "Minus 8dB"));
-            options.add(new ParameterOption("9", "Minus 9dB"));
-            parameters.add(ConfigDescriptionParameterBuilder
-                    .create(ZWaveBindingConstants.CONFIGURATION_POWERLEVEL_LEVEL, Type.INTEGER).withLabel("Power Level")
-                    .withDescription(
-                            "Set the RF output level - Normal is maximum power<br>Setting the power to a lower level may be useful to reduce overloading of the receiver in adjacent nodes where they are close together, or if maximum power is not required for battery devices, it may extend battery life by reducing the transmit power.")
-                    .withDefault("0").withGroupName("thingcfg").withOptions(options).withLimitToOptions(true).build());
-
-            parameters.add(ConfigDescriptionParameterBuilder
-                    .create(ZWaveBindingConstants.CONFIGURATION_POWERLEVEL_TIMEOUT, Type.INTEGER)
-                    .withLabel("Power Level Timeout")
-                    .withDescription(
-                            "Set the power level timeout in seconds<br>The node will reset to the normal power level if communications is not made within the specified number of seconds.")
-                    .withDefault("0").withGroupName("thingcfg").build());
-        }
-
         // If we support DOOR_LOCK - add options
         if (node.getCommandClass(ZWaveCommandClass.CommandClass.DOOR_LOCK) != null) {
             parameters.add(ConfigDescriptionParameterBuilder


### PR DESCRIPTION
This class is not meant for user configuration as it's part of the installation and maintenance feature set.
Closes #775 
Signed-off-by: Chris Jackson chris@cd-jackson.com