### PR TITLE
Fix error in binary switch converter when NOGET is true

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveBinarySwitchConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveBinarySwitchConverter.java
@@ -101,13 +101,10 @@ public class ZWaveBinarySwitchConverter extends ZWaveCommandClassConverter {
         messages.add(transaction);
 
         transaction = node.encapsulate(commandClass.getValueMessage(), channel.getEndpoint());
-        if (transaction == null) {
-            logger.warn("NODE {}: Generating message failed for command class = {}, endpoint = {}", node.getNodeId(),
-                    commandClass.getCommandClass(), channel.getEndpoint());
-            return null;
+        if (transaction != null) {
+            messages.add(transaction);
         }
 
-        messages.add(transaction);
         return messages;
     }
 }

--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMultiLevelSwitchConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMultiLevelSwitchConverter.java
@@ -198,7 +198,6 @@ public class ZWaveMultiLevelSwitchConverter extends ZWaveCommandClassConverter {
 
         // encapsulate the message in case this is a multi-instance node
         transaction = node.encapsulate(transaction, channel.getEndpoint());
-
         if (transaction == null) {
             logger.warn("Generating message failed for command class = {}, node = {}, endpoint = {}",
                     commandClass.getCommandClass(), node.getNodeId(), channel.getEndpoint());


### PR DESCRIPTION
If NOGET is true on a binary switch, then the SET would also not work as the converter was returning due to no messages from the GET.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>