### PR TITLE
Improve secure failure logging

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -20,6 +20,7 @@ import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
 import org.openhab.binding.zwave.internal.protocol.ZWaveDeviceClass.Basic;
 import org.openhab.binding.zwave.internal.protocol.ZWaveTransaction.TransactionState;
@@ -522,7 +523,7 @@ public class ZWaveController {
      * @param transaction
      *            the {@link ZWaveMessagePayloadTransaction} message to enqueue.
      */
-    public ZWaveTransactionResponse sendTransaction(ZWaveMessagePayloadTransaction transaction) {
+    public @Nullable ZWaveTransactionResponse sendTransaction(ZWaveMessagePayloadTransaction transaction) {
         return transactionManager.sendTransaction(transaction);
     }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -21,6 +21,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.zwave.internal.HexToIntegerConverter;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAssociationCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCRC16EncapsulationCommandClass;
@@ -1319,7 +1320,8 @@ public class ZWaveNode {
         controller.sendData(encapsulate(payload, 0));
     }
 
-    public ZWaveTransactionResponse sendTransaction(ZWaveCommandClassTransactionPayload payload, int endpoint) {
+    public @Nullable ZWaveTransactionResponse sendTransaction(ZWaveCommandClassTransactionPayload payload,
+            int endpoint) {
         return controller.sendTransaction(encapsulate(payload, endpoint));
     }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionManager.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionManager.java
@@ -15,6 +15,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.PriorityBlockingQueue;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageType;
 import org.openhab.binding.zwave.internal.protocol.ZWaveTransaction.TransactionPriority;
@@ -1020,17 +1021,21 @@ public class ZWaveTransactionManager {
         return executor.submit(worker);
     }
 
-    public ZWaveTransactionResponse sendTransaction(ZWaveMessagePayloadTransaction transaction) {
+    /**
+     * Sends a transaction and waits for the response.
+     * 
+     * @param transaction {@link ZWaveMessagePayloadTransaction} to send
+     * @return The {@link ZWaveTransactionResponse} or null if there was an error
+     */
+    public @Nullable ZWaveTransactionResponse sendTransaction(ZWaveMessagePayloadTransaction transaction) {
         logger.debug("NODE {}: sendTransaction {}", transaction.getDestinationNode(), transaction);
 
         Future<ZWaveTransactionResponse> futureResponse = sendTransactionAsync(transaction);
         try {
             ZWaveTransactionResponse response = futureResponse.get();
             return response;
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        } catch (ExecutionException e) {
-            e.printStackTrace();
+        } catch (InterruptedException | ExecutionException e) {
+            logger.debug("NODE {}: sendTransaction interrupted", e);
         }
 
         return null;

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -252,7 +252,7 @@ public class ZWaveNodeInitStageAdvancer {
                 response = controller.sendTransaction(transaction);
             }
 
-            logger.debug("NODE {}: Node Init response ({}) {}", node.getNodeId(), retryCount, response.getState());
+            logger.debug("NODE {}: Node Init response ({}) {}", node.getNodeId(), retryCount, response);
             if (response != null && response.getState() == State.COMPLETE) {
                 break;
             }
@@ -471,7 +471,7 @@ public class ZWaveNodeInitStageAdvancer {
                 // Notify that secure inclusion failed
                 controller.notifyEventListeners(
                         new ZWaveInclusionEvent(ZWaveInclusionState.SecureIncludeFailed, node.getNodeId()));
-                logger.error("NODE {}: SECURITY_INC State=FAILED", node.getNodeId());
+                logger.info("NODE {}: SECURITY_INC State=FAILED, Reason=GET_SCHEME", node.getNodeId());
 
                 return;
             }
@@ -485,12 +485,12 @@ public class ZWaveNodeInitStageAdvancer {
                 // Notify that secure inclusion completed ok
                 controller.notifyEventListeners(
                         new ZWaveInclusionEvent(ZWaveInclusionState.SecureIncludeComplete, node.getNodeId()));
-                logger.error("NODE {}: SECURITY_INC State=COMPLETE", node.getNodeId());
+                logger.info("NODE {}: SECURITY_INC State=COMPLETE", node.getNodeId());
             } else {
                 // Notify that secure inclusion failed
                 controller.notifyEventListeners(
                         new ZWaveInclusionEvent(ZWaveInclusionState.SecureIncludeFailed, node.getNodeId()));
-                logger.error("NODE {}: SECURITY_INC State=FAILED", node.getNodeId());
+                logger.info("NODE {}: SECURITY_INC State=FAILED, Reason=SET_KEY", node.getNodeId());
 
                 return;
             }
@@ -506,7 +506,7 @@ public class ZWaveNodeInitStageAdvancer {
         // securely included
         logger.debug("NODE {}: SECURITY_INC State=SECURE_PING", node.getNodeId());
         if (processTransaction(securityCommandClass.getSecurityNonceGet(), 0, 3) == false) {
-            logger.error("NODE {}: SECURITY_INC State=FAILED", node.getNodeId());
+            logger.info("NODE {}: SECURITY_INC State=FAILED, Reason=SECURE_PING", node.getNodeId());
             return;
         }
 
@@ -606,7 +606,7 @@ public class ZWaveNodeInitStageAdvancer {
                     }
                 }
 
-                if (versionCommandClass != null && zwaveVersionClass.getVersion() == 0) {
+                if (zwaveVersionClass.getVersion() == 0) {
                     logger.debug("NODE {}: Node advancer: VERSION - queued   {}", node.getNodeId(),
                             zwaveVersionClass.getCommandClass());
 


### PR DESCRIPTION
Improves secure failure log by adding the reason (or the point at which it failed). Also remove some warnings related to non-null annotations.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>