### PR TITLE
Updated handling of AlarmV2

### DIFF
--- a/ESH-INF/thing/vision_zd2102_0_0.xml
+++ b/ESH-INF/thing/vision_zd2102_0_0.xml
@@ -20,16 +20,16 @@ Door Window Sensor<br /><h1>Overview</h1><p>This sensor monitors door/ window an
           <property name="binding:*:OnOffType">COMMAND_CLASS_SENSOR_BINARY</property>
         </properties>
       </channel>
-      <channel id="alarm_burglar" typeId="alarm_burglar">
+      <channel id="alarm_tamper" typeId="alarm_tamper">
         <label>Tamper Alarm</label>
         <properties>
-          <property name="binding:*:OnOffType">COMMAND_CLASS_ALARM;type=BURGLAR</property>
+          <property name="binding:*:OnOffType">COMMAND_CLASS_ALARM;type=BURGLAR, event=3</property>
         </properties>
       </channel>
       <channel id="sensor_door" typeId="sensor_door">
         <label>Door Sensor</label>
         <properties>
-          <property name="binding:*:OpenClosedType">COMMAND_CLASS_ALARM;type=ACCESS_CONTROL</property>
+          <property name="binding:*:OpenClosedType">COMMAND_CLASS_ALARM;type=ACCESS_CONTROL, event=2</property>
         </properties>
       </channel>
       <channel id="battery-level" typeId="system.battery-level">

--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
@@ -206,6 +206,12 @@ public class ZWaveAlarmConverter extends ZWaveCommandClassConverter {
             return null;
         }
 
+        // Check if an event is specified
+        if (channel.getArguments().get("event") != null
+                && eventAlarm.getAlarmEvent() != Integer.parseInt(channel.getArguments().get("event"))) {
+            return null;
+        }
+
         // Processing for special channel types
         if (channel.getUID().getId().equals("alarm_number")) {
             return new DecimalType(eventAlarm.getV1AlarmCode());

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAlarmCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAlarmCommandClass.java
@@ -126,6 +126,16 @@ public class ZWaveAlarmCommandClass extends ZWaveCommandClass
             notificationStatus = v1AlarmLevel;
 
             logger.debug("NODE {}: ALARM report - {} = {}", getNode().getNodeId(), v1AlarmTypeCode, v1AlarmLevel);
+        } else if (getVersion() == 2) {
+            eventType = ReportType.ALARM;
+            notificationStatus = payload.getPayloadByte(5);
+            notificationTypeCode = payload.getPayloadByte(6);
+            notificationEvent = payload.getPayloadByte(7);
+            alarmType = AlarmType.getAlarmType(notificationTypeCode);
+
+            notificationStatus = v1AlarmLevel;
+
+            logger.debug("NODE {}: ALARM report - {} = {}", getNode().getNodeId(), v1AlarmTypeCode, v1AlarmLevel);
         } else {
             eventType = ReportType.NOTIFICATION;
             // Indicates if reports are enabled or disabled

--- a/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverterTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.openhab.binding.zwave.handler.ZWaveThingChannel;
 import org.openhab.binding.zwave.handler.ZWaveThingChannel.DataType;
-import org.openhab.binding.zwave.internal.converter.ZWaveAlarmConverter;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
 import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
@@ -74,6 +73,20 @@ public class ZWaveAlarmConverterTest extends ZWaveCommandClassConverterTest {
         ZWaveAlarmCommandClass cls = new ZWaveAlarmCommandClass(node, controller, endpoint);
 
         return cls.new ZWaveAlarmValueEvent(1, 0, ReportType.ALARM, null, v1Code, 0, value);
+    }
+
+    @Test
+    public void Alarm_DoorV2() {
+        ZWaveAlarmConverter converter = new ZWaveAlarmConverter(null);
+        ZWaveThingChannel channel = createChannel("alarm_smoke", DataType.OnOffType, AlarmType.SMOKE.toString(), "0");
+
+        ZWaveCommandClassValueEvent event = createEvent(ZWaveAlarmCommandClass.AlarmType.SMOKE, ReportType.ALARM, 0,
+                0xff);
+
+        State state = converter.handleEvent(channel, event);
+
+        assertEquals(state.getClass(), OnOffType.class);
+        assertEquals(state, OnOffType.ON);
     }
 
     @Test
@@ -268,5 +281,27 @@ public class ZWaveAlarmConverterTest extends ZWaveCommandClassConverterTest {
         assertEquals(
                 "{\"notification\":\"ACCESS_CONTROL__KEYPAD_UNLOCK\",\"type\":\"ACCESS_CONTROL\",\"event\":\"6\",\"status\":\"255\"}",
                 state.toString());
+    }
+
+    @Test
+    public void AlarmV2_Door() {
+        State state;
+        ZWaveCommandClassValueEvent event;
+        ZWaveAlarmConverter converter = new ZWaveAlarmConverter(null);
+        ZWaveThingChannel channel = createChannel("sensor_door", DataType.OnOffType, "BURGLAR", "2");
+
+        event = createEvent(ZWaveAlarmCommandClass.AlarmType.BURGLAR, ReportType.ALARM, 2, 0xff);
+        state = converter.handleEvent(channel, event);
+        assertEquals(OnOffType.class, state.getClass());
+        assertEquals(OnOffType.ON, state);
+
+        event = createEvent(ZWaveAlarmCommandClass.AlarmType.BURGLAR, ReportType.ALARM, 2, 0x00);
+        state = converter.handleEvent(channel, event);
+        assertEquals(OnOffType.class, state.getClass());
+        assertEquals(OnOffType.OFF, state);
+
+        event = createEvent(ZWaveAlarmCommandClass.AlarmType.BURGLAR, ReportType.ALARM, 3, 0x00);
+        state = converter.handleEvent(channel, event);
+        assertNull(state);
     }
 }

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAlarmCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAlarmCommandClassTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 
 import org.junit.Test;
 import org.openhab.binding.zwave.internal.protocol.ZWaveCommandClassPayload;
-import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmCommandClass.AlarmType;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmCommandClass.ReportType;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmCommandClass.ZWaveAlarmValueEvent;
@@ -299,6 +298,46 @@ public class ZWaveAlarmCommandClassTest extends ZWaveCommandClassTest {
         assertEquals(event.getAlarmType(), ZWaveAlarmCommandClass.AlarmType.ACCESS_CONTROL);
         assertEquals(event.getAlarmStatus(), 0xFF);
         assertTrue(Arrays.equals(new int[] { 0x01 }, event.getParameters()));
+    }
+
+    @Test
+    public void Alarm_DoorV2() {
+        byte[] dataDoorOpen = { 0x01, 0x10, 0x00, 0x04, 0x00, 0x17, 0x0A, 0x71, 0x05, 0x07, 0x00, 0x00, (byte) 0xFF,
+                0x07, 0x02, 0x00, 0x00, 0x7F };
+        byte[] dataDoorClosed = { 0x01, 0x10, 0x00, 0x04, 0x00, 0x17, 0x0A, 0x71, 0x05, 0x07, (byte) 0xFF, 0x00,
+                (byte) 0xFF, 0x07, 0x02, 0x00, 0x00, (byte) 0x80 };
+        byte[] dataDoorTamper = { 0x01, 0x10, 0x00, 0x04, 0x00, 0x17, 0x0A, 0x71, 0x05, 0x07, (byte) 0xFF, 0x00,
+                (byte) 0xFF, 0x07, 0x03, 0x00, 0x00, (byte) 0x81 };
+
+        List<ZWaveEvent> events;
+        ZWaveAlarmValueEvent event;
+
+        events = processCommandClassMessage(dataDoorOpen, 2);
+        assertEquals(events.size(), 1);
+        event = (ZWaveAlarmValueEvent) events.get(0);
+        assertEquals(0, event.getEndpoint());
+        assertEquals(ReportType.ALARM, event.getReportType());
+        assertEquals(AlarmType.BURGLAR, event.getAlarmType());
+        assertEquals(2, event.getAlarmEvent());
+        assertEquals(0x00, event.getAlarmStatus());
+
+        events = processCommandClassMessage(dataDoorClosed, 2);
+        assertEquals(events.size(), 1);
+        event = (ZWaveAlarmValueEvent) events.get(0);
+        assertEquals(0, event.getEndpoint());
+        assertEquals(ReportType.ALARM, event.getReportType());
+        assertEquals(AlarmType.BURGLAR, event.getAlarmType());
+        assertEquals(2, event.getAlarmEvent());
+        assertEquals(0xff, event.getAlarmStatus());
+
+        events = processCommandClassMessage(dataDoorTamper, 2);
+        assertEquals(events.size(), 1);
+        event = (ZWaveAlarmValueEvent) events.get(0);
+        assertEquals(0, event.getEndpoint());
+        assertEquals(ReportType.ALARM, event.getReportType());
+        assertEquals(AlarmType.BURGLAR, event.getAlarmType());
+        assertEquals(3, event.getAlarmEvent());
+        assertEquals(0xff, event.getAlarmStatus());
     }
 
 }


### PR DESCRIPTION
https://community.openhab.org/t/vision-door-windows-sensor-zd2102-open-close-and-tamper-are-not-triggered-to-different-events/27972/65

Signed-off-by: Chris Jackson <chris@cd-jackson.com>