### PR TITLE
Don't initialise sleeping devices that are already initialised

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -357,6 +357,16 @@ public class ZWaveNodeInitStageAdvancer {
             return;
         }
 
+        ZWaveWakeUpCommandClass wakeupCommandClass = (ZWaveWakeUpCommandClass) node
+                .getCommandClass(CommandClass.COMMAND_CLASS_WAKE_UP);
+        if (wakeupCommandClass != null && wakeupCommandClass.getTargetNodeId() == controller.getOwnNodeId()
+                && wakeupCommandClass.getInterval() == 0) {
+            logger.debug("NODE {}: Node advancer: FAILED_CHECK - Sleeping node - terminating initialisation",
+                    node.getNodeId());
+            setCurrentStage(ZWaveNodeInitStage.DONE);
+            return;
+        }
+
         setCurrentStage(ZWaveNodeInitStage.FAILED_CHECK);
         do {
             processTransaction(new IsFailedNodeMessageClass().doRequest(node.getNodeId()));


### PR DESCRIPTION
This adds logic to not perform device initialisation if the device has previously been initialised, has the wakeup node set to the controller, and has the wakeup time set to 0.
Closes #834 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>