### PR TITLE
Fix NPE in association update

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -618,6 +618,7 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
                 }
 
                 ZWaveAssociationGroup currentMembers = node.getAssociationGroup(groupIndex);
+                if (currentMembers == null) currentMembers = new ZWaveAssociationGroup(groupIndex);
                 ZWaveAssociationGroup newMembers = new ZWaveAssociationGroup(groupIndex);
 
                 int totalMembers = currentMembers.getAssociationCnt();


### PR DESCRIPTION
Signed-off-by: Max Berger <max@berger.name>

---

For controllers which do not have any associations yet the "currentAssociation" can be null. This leads to an NPE such as the one below. This  happend on an un-associated WALL-C switch, with this fix I can add an association.

``22:39:23.770 [ERROR] [est.core.internal.thing.ThingResource] - Exception during HTTP PUT request for update config at 'things/zwave:device:f851f020:node30/config'
java.lang.NullPointerException: null
        at org.openhab.binding.zwave.handler.ZWaveThingHandler.handleConfigurationUpdate(ZWaveThingHandler.java:623) [252:org.openhab.binding.zwave:2.3.0.201803101457]
        at org.eclipse.smarthome.core.thing.internal.ThingRegistryImpl.updateConfiguration(ThingRegistryImpl.java:94) [117:org.eclipse.smarthome.core.thing:0.10.0.b1]
        at org.eclipse.smarthome.io.rest.core.internal.thing.ThingResource.updateConfiguration(ThingResource.java:413) [127:org.eclipse.smarthome.io.rest.core:0.10.0.b1]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:497) ~[?:?]
``