### PR TITLE
Fix error with inclusion transaction timeout

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialMessage.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialMessage.java
@@ -432,7 +432,7 @@ public class SerialMessage {
      * @param callbackId the callbackId to set
      */
     public void setCallbackId(int callbackId) {
-        // this.callbackId = callbackId;
+        this.callbackId = callbackId;
         // callbackSequence.set(callbackId);
     }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveSerialPayload.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveSerialPayload.java
@@ -21,6 +21,7 @@ import org.openhab.binding.zwave.internal.protocol.ZWaveTransaction.TransactionP
  */
 public class ZWaveSerialPayload implements ZWaveMessagePayloadTransaction {
     private int nodeId = 255;
+    private int callbackId = -1;
     private final byte[] payload;
     private SerialMessageClass messageClass;
     private SerialMessageClass responseClass;
@@ -76,6 +77,9 @@ public class ZWaveSerialPayload implements ZWaveMessagePayloadTransaction {
     public SerialMessage getSerialMessage() {
         SerialMessage msg = new SerialMessage(messageClass, SerialMessageType.Request);
         msg.setMessagePayload(payload);
+        if (callbackId != -1) {
+            msg.setCallbackId(callbackId);
+        }
 
         return msg;
     }
@@ -109,5 +113,9 @@ public class ZWaveSerialPayload implements ZWaveMessagePayloadTransaction {
     @Override
     public void setMaxAttempts(int maxAttempts) {
         this.maxAttempts = maxAttempts;
+    }
+
+    public void setCallbackId(int callbackId) {
+        this.callbackId = callbackId;
     }
 }

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionManager.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionManager.java
@@ -440,8 +440,7 @@ public class ZWaveTransactionManager {
                                 commands = node.processCommand(new ZWaveCommandClassPayload(incomingMessage));
                             } catch (Exception e) {
                                 commands = null;
-                                logger.error("Exception processing frame: {}", incomingMessage);
-                                logger.error("Exception processing frame: ", e);
+                                logger.error("Exception processing frame: {}: ", incomingMessage, e);
                             }
                             if (commands != null) {
                                 logger.debug("NODE {}: Commands processed {}.", nodeId, commands.size());
@@ -1030,7 +1029,7 @@ public class ZWaveTransactionManager {
 
     /**
      * Sends a transaction and waits for the response.
-     * 
+     *
      * @param transaction {@link ZWaveMessagePayloadTransaction} to send
      * @return The {@link ZWaveTransactionResponse} or null if there was an error
      */

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
@@ -62,7 +62,7 @@ public class AddNodeMessageClass extends ZWaveCommandProcessor {
             command |= OPTION_NETWORK_WIDE;
         }
 
-        return new ZWaveTransactionMessageBuilder(SerialMessageClass.AddNodeToNetwork).withPayload(command, 1)
+        return new ZWaveTransactionMessageBuilder(SerialMessageClass.AddNodeToNetwork).withPayload(command)
                 .withRequiresData(false).build();
     }
 
@@ -70,8 +70,13 @@ public class AddNodeMessageClass extends ZWaveCommandProcessor {
         logger.debug("Ending INCLUSION mode.");
 
         // Create the request
-        return new ZWaveTransactionMessageBuilder(SerialMessageClass.AddNodeToNetwork)
-                .withPayload(ADD_NODE_STOP, complete ? 0 : 1).withRequiresData(false).build();
+        ZWaveSerialPayload payload = new ZWaveTransactionMessageBuilder(SerialMessageClass.AddNodeToNetwork)
+                .withPayload(ADD_NODE_STOP).withRequiresData(false).build();
+
+        if (complete) {
+            payload.setCallbackId(0);
+        }
+        return payload;
     }
 
     @Override

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RemoveNodeMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RemoveNodeMessageClass.java
@@ -42,16 +42,20 @@ public class RemoveNodeMessageClass extends ZWaveCommandProcessor {
         logger.debug("Setting controller into EXCLUSION mode.");
 
         // Create the request
-        return new ZWaveTransactionMessageBuilder(SerialMessageClass.RemoveNodeFromNetwork)
-                .withPayload(REMOVE_NODE_ANY, 1).withRequiresData(false).build();
+        return new ZWaveTransactionMessageBuilder(SerialMessageClass.RemoveNodeFromNetwork).withPayload(REMOVE_NODE_ANY)
+                .withRequiresData(false).build();
     }
 
     public ZWaveSerialPayload doRequestStop(boolean complete) {
         logger.debug("Ending EXCLUSION mode.");
 
-        // Create the request
-        return new ZWaveTransactionMessageBuilder(SerialMessageClass.RemoveNodeFromNetwork)
-                .withPayload(REMOVE_NODE_STOP, complete ? 0 : 1).withRequiresData(false).build();
+        ZWaveSerialPayload payload = new ZWaveTransactionMessageBuilder(SerialMessageClass.RemoveNodeFromNetwork)
+                .withPayload(REMOVE_NODE_STOP).withRequiresData(false).build();
+
+        if (complete) {
+            payload.setCallbackId(0);
+        }
+        return payload;
     }
 
     @Override

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/ZWaveInclusionControllerTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/ZWaveInclusionControllerTest.java
@@ -56,7 +56,7 @@ public class ZWaveInclusionControllerTest {
 
         assertEquals(1, txCapture.getAllValues().size());
         txFrame = txCapture.getAllValues().get(0);
-        assertTrue(Arrays.equals(new byte[] { -63, 1 }, txFrame.getPayloadBuffer()));
+        assertTrue(Arrays.equals(new byte[] { -63 }, txFrame.getPayloadBuffer()));
 
         inclusionController.ZWaveIncomingEvent(new ZWaveInclusionEvent(ZWaveInclusionState.IncludeStart));
         assertEquals(ZWaveInclusionState.IncludeStart, inclusionController.getState());
@@ -83,14 +83,16 @@ public class ZWaveInclusionControllerTest {
 
         assertEquals(2, txCapture.getAllValues().size());
         txFrame = txCapture.getAllValues().get(1);
-        assertTrue(Arrays.equals(new byte[] { 5, 1 }, txFrame.getPayloadBuffer()));
+        assertTrue(Arrays.equals(new byte[] { 5 }, txFrame.getPayloadBuffer()));
+        assertTrue(txFrame.getSerialMessage().getCallbackId() != 0);
 
         inclusionController.ZWaveIncomingEvent(new ZWaveInclusionEvent(ZWaveInclusionState.IncludeDone));
         assertEquals(ZWaveInclusionState.IncludeDone, inclusionController.getState());
 
         assertEquals(3, txCapture.getAllValues().size());
         txFrame = txCapture.getAllValues().get(2);
-        assertTrue(Arrays.equals(new byte[] { 5, 0 }, txFrame.getPayloadBuffer()));
+        assertTrue(Arrays.equals(new byte[] { 5 }, txFrame.getPayloadBuffer()));
+        assertTrue(txFrame.getSerialMessage().getCallbackId() == 0);
 
         Mockito.verify(controller, Mockito.times(1)).includeDone();
         Mockito.verify(controller, Mockito.times(1)).removeEventListener(listenerCapture.capture());
@@ -119,7 +121,7 @@ public class ZWaveInclusionControllerTest {
 
         assertEquals(1, txCapture.getAllValues().size());
         txFrame = txCapture.getAllValues().get(0);
-        assertTrue(Arrays.equals(new byte[] { 1, 1 }, txFrame.getPayloadBuffer()));
+        assertTrue(Arrays.equals(new byte[] { 1 }, txFrame.getPayloadBuffer()));
 
         inclusionController.ZWaveIncomingEvent(new ZWaveInclusionEvent(ZWaveInclusionState.ExcludeStart));
         assertEquals(ZWaveInclusionState.ExcludeStart, inclusionController.getState());
@@ -136,7 +138,8 @@ public class ZWaveInclusionControllerTest {
 
         assertEquals(2, txCapture.getAllValues().size());
         txFrame = txCapture.getAllValues().get(1);
-        assertTrue(Arrays.equals(new byte[] { 5, 0 }, txFrame.getPayloadBuffer()));
+        assertTrue(Arrays.equals(new byte[] { 5 }, txFrame.getPayloadBuffer()));
+        assertTrue(txFrame.getSerialMessage().getCallbackId() == 0);
 
         Mockito.verify(controller, Mockito.times(1)).includeDone();
         Mockito.verify(controller, Mockito.times(1)).removeEventListener(listenerCapture.capture());
@@ -165,7 +168,7 @@ public class ZWaveInclusionControllerTest {
 
         assertEquals(1, txCapture.getAllValues().size());
         txFrame = txCapture.getAllValues().get(0);
-        assertTrue(Arrays.equals(new byte[] { -63, 1 }, txFrame.getPayloadBuffer()));
+        assertTrue(Arrays.equals(new byte[] { -63 }, txFrame.getPayloadBuffer()));
 
         inclusionController.ZWaveIncomingEvent(new ZWaveInclusionEvent(ZWaveInclusionState.IncludeStart));
         assertEquals(ZWaveInclusionState.IncludeStart, inclusionController.getState());
@@ -209,7 +212,7 @@ public class ZWaveInclusionControllerTest {
 
         assertEquals(1, txCapture.getAllValues().size());
         txFrame = txCapture.getAllValues().get(0);
-        assertTrue(Arrays.equals(new byte[] { -63, 1 }, txFrame.getPayloadBuffer()));
+        assertTrue(Arrays.equals(new byte[] { -63 }, txFrame.getPayloadBuffer()));
 
         inclusionController.ZWaveIncomingEvent(new ZWaveInclusionEvent(ZWaveInclusionState.IncludeStart));
         assertEquals(ZWaveInclusionState.IncludeStart, inclusionController.getState());
@@ -220,7 +223,8 @@ public class ZWaveInclusionControllerTest {
 
         assertEquals(2, txCapture.getAllValues().size());
         txFrame = txCapture.getAllValues().get(1);
-        assertTrue(Arrays.equals(new byte[] { 5, 1 }, txFrame.getPayloadBuffer()));
+        assertTrue(Arrays.equals(new byte[] { 5 }, txFrame.getPayloadBuffer()));
+        assertTrue(txFrame.getSerialMessage().getCallbackId() != 0);
     }
 
 }

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClassTest.java
@@ -12,9 +12,13 @@ import static org.junit.Assert.*;
 import java.util.Arrays;
 
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
+import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
 import org.openhab.binding.zwave.internal.protocol.ZWaveSerialPayload;
-import org.openhab.binding.zwave.internal.protocol.serialmessage.AddNodeMessageClass;
+import org.openhab.binding.zwave.internal.protocol.ZWaveTransaction;
 
 /**
  * Test cases for AddNodeMessageClass message.
@@ -26,11 +30,11 @@ import org.openhab.binding.zwave.internal.protocol.serialmessage.AddNodeMessageC
 public class AddNodeMessageClassTest {
     @Test
     public void doRequest() {
-        byte[] expectedResponseStartLocal = { 1, 1 };
-        byte[] expectedResponseStartHigh = { -127, 1 };
-        byte[] expectedResponseStartNetwork = { -63, 1 };
-        byte[] expectedResponseStop = { 5, 1 };
-        byte[] expectedResponseStopComplete = { 5, 0 };
+        byte[] expectedResponseStartLocal = { 1, };
+        byte[] expectedResponseStartHigh = { -127 };
+        byte[] expectedResponseStartNetwork = { -63 };
+        byte[] expectedResponseStop = { 5 };
+        byte[] expectedResponseStopComplete = { 5 };
 
         ZWaveSerialPayload msg;
         AddNodeMessageClass handler = new AddNodeMessageClass();
@@ -38,21 +42,46 @@ public class AddNodeMessageClassTest {
         msg = handler.doRequestStart(false, false);
         assertEquals(msg.getSerialMessageClass(), SerialMessageClass.AddNodeToNetwork);
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseStartLocal));
+        assertTrue(msg.getSerialMessage().getCallbackId() != 0);
 
         msg = handler.doRequestStart(true, false);
         assertEquals(msg.getSerialMessageClass(), SerialMessageClass.AddNodeToNetwork);
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseStartHigh));
+        assertTrue(msg.getSerialMessage().getCallbackId() != 0);
 
         msg = handler.doRequestStart(true, true);
         assertEquals(msg.getSerialMessageClass(), SerialMessageClass.AddNodeToNetwork);
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseStartNetwork));
+        assertTrue(msg.getSerialMessage().getCallbackId() != 0);
 
         msg = handler.doRequestStop(false);
         assertEquals(msg.getSerialMessageClass(), SerialMessageClass.AddNodeToNetwork);
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseStop));
+        assertTrue(msg.getSerialMessage().getCallbackId() != 0);
 
         msg = handler.doRequestStop(true);
         assertEquals(msg.getSerialMessageClass(), SerialMessageClass.AddNodeToNetwork);
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseStopComplete));
+        assertTrue(msg.getSerialMessage().getCallbackId() == 0);
     }
+
+    @Test
+    public void rxNodeAdd() {
+        SerialMessage incomingMessage = new SerialMessage(
+                new byte[] { 0x01, 0x07, 0x00, 0x4A, 0x01, 0x06, 0x11, 0x00, (byte) 0xA4 });
+
+        System.out.println(incomingMessage);
+
+        ZWaveSerialPayload payload = new AddNodeMessageClass().doRequestStop(false);
+        payload.setCallbackId(1);
+        ZWaveTransaction transaction = new ZWaveTransaction(payload);
+        AddNodeMessageClass response = new AddNodeMessageClass();
+        try {
+            response.handleRequest(Mockito.mock(ZWaveController.class), transaction, incomingMessage);
+        } catch (ZWaveSerialMessageException e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
 }

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RemoveNodeMessageClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RemoveNodeMessageClassTest.java
@@ -14,7 +14,6 @@ import java.util.Arrays;
 import org.junit.Test;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
 import org.openhab.binding.zwave.internal.protocol.ZWaveSerialPayload;
-import org.openhab.binding.zwave.internal.protocol.serialmessage.RemoveNodeMessageClass;
 
 /**
  * Test cases for RemoveNodeMessageClass message.
@@ -26,9 +25,9 @@ import org.openhab.binding.zwave.internal.protocol.serialmessage.RemoveNodeMessa
 public class RemoveNodeMessageClassTest {
     @Test
     public void doRequest() {
-        byte[] expectedResponseStart = { 1, 1 };
-        byte[] expectedResponseStop = { 5, 1 };
-        byte[] expectedResponseStopComplete = { 5, 0 };
+        byte[] expectedResponseStart = { 1 };
+        byte[] expectedResponseStop = { 5 };
+        byte[] expectedResponseStopComplete = { 5 };
 
         RemoveNodeMessageClass handler = new RemoveNodeMessageClass();
         ZWaveSerialPayload msg;
@@ -36,13 +35,17 @@ public class RemoveNodeMessageClassTest {
         msg = handler.doRequestStart();
         assertEquals(msg.getSerialMessageClass(), SerialMessageClass.RemoveNodeFromNetwork);
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseStart));
+        assertTrue(msg.getSerialMessage().getCallbackId() != 0);
 
         msg = handler.doRequestStop(false);
         assertEquals(msg.getSerialMessageClass(), SerialMessageClass.RemoveNodeFromNetwork);
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseStop));
+        assertTrue(msg.getSerialMessage().getCallbackId() != 0);
 
         msg = handler.doRequestStop(true);
         assertEquals(msg.getSerialMessageClass(), SerialMessageClass.RemoveNodeFromNetwork);
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseStopComplete));
+        assertTrue(msg.getSerialMessage().getCallbackId() == 0);
+
     }
 }


### PR DESCRIPTION
Fixed a bug correlating the transaction at the completion of the inclusion. This may cause a delay of up to 10 seconds at the end of inclusion which can impact secure inclusion key exchange.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>