### PR TITLE
Fix for MULTI_INSTANCE_ENCAP

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -1198,7 +1198,6 @@ public class ZWaveNode {
         }
 
         int endpointNumber = 0;
-        int instanceNumber = 0;
 
         if (payload.getCommandClassId() == CommandClass.COMMAND_CLASS_MULTI_CHANNEL.getKey()
                 && (payload.getCommandClassCommand() == 6 || payload.getCommandClassCommand() == 13)) {
@@ -1218,7 +1217,7 @@ public class ZWaveNode {
             // Check that the length is long enough for the encapsulated command to be included
             if (payload.getCommandClassCommand() == 6 && payload.getPayloadLength() > 5) {
                 // MULTI_INSTANCE_ENCAP
-                instanceNumber = payload.getPayloadByte(1);
+                endpointNumber = payload.getPayloadByte(2);
 
                 payload = new ZWaveCommandClassPayload(payload, 3);
             } else if (payload.getCommandClassCommand() == 13 && payload.getPayloadLength() > 6) {


### PR DESCRIPTION
This is a fix for multi instance encapsultation, mainly used by Qubino devices (additional binary sensors, temperature sensor, individual control of relays in Flush 2 Relays module and others).

Signed-off-by: Krzysztof Goworek <krzysztof.goworek@gmail.com>