### PR TITLE
Polls device state after a command is sent

### DIFF
--- a/ESH-INF/i18n/config.properties
+++ b/ESH-INF/i18n/config.properties
@@ -1,2 +1,4 @@
-zwave.config.binding_pollingperiod_label=Polling Period
+binding_pollingperiod_label=Polling Period
 zwave.config.binding_pollingperiod_desc=Set the minimum polling period for this device (in seconds)<BR/>Note that the polling period may be longer than set since the binding treats polls as the lowest priority data within the network.
+zwave.config.binding_cmdrepollperiod_label=Command Poll Period
+zwave.config.binding_cmdrepollperiod_desc=Set the period to wait after a command is sent to a device before polling its state.

--- a/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
+++ b/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
@@ -51,6 +51,7 @@ public class ZWaveBindingConstants {
     public final static String CONFIGURATION_DOORLOCKTIMEOUT = "doorlock_timeout";
 
     public final static String CONFIGURATION_POLLPERIOD = "binding_pollperiod";
+    public final static String CONFIGURATION_CMDREPOLLPERIOD = "binding_cmdrepollperiod";
 
     public final static String ZWAVE_THING = BINDING_ID + ":device";
     public final static ThingTypeUID ZWAVE_THING_UID = new ThingTypeUID(ZWAVE_THING);
@@ -131,8 +132,10 @@ public class ZWaveBindingConstants {
     public final static String EVENT_HEAL_START = "@text/zwave.event.heal_start";
     public final static String EVENT_HEAL_DONE = "@text/zwave.event.heal_done";
 
-    public final static String CONFIG_BINDING_POLLINGPERIOD_LABEL = "@text/zwave.config.binding_pollingperiod_label";
-    public final static String CONFIG_BINDING_POLLINGPERIOD_DESC = "@text/zwave.config.binding_pollingperiod_desc";
+    public final static String CONFIG_BINDING_POLLINGPERIOD_LABEL = "Polling Period";
+    public final static String CONFIG_BINDING_POLLINGPERIOD_DESC = "Set the minimum polling period for this device (in seconds)<BR/>Note that the polling period may be longer than set since the binding treats polls as the lowest priority data within the network.";
+    public final static String CONFIG_BINDING_CMDPOLLPERIOD_LABEL = "Command Poll Period";
+    public final static String CONFIG_BINDING_CMDPOLLPERIOD_DESC = "Set the period to wait after a command is sent to a device before polling its state.";
 
     public final static Set<ThingTypeUID> SUPPORTED_BRIDGE_TYPES_UIDS = ImmutableSet.of(CONTROLLER_SERIAL);
 

--- a/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
@@ -198,6 +198,15 @@ public class ZWaveConfigProvider implements ConfigDescriptionProvider, ConfigOpt
                         .withMinimum(new BigDecimal(15)).withMaximum(new BigDecimal(86400)).withOptions(options)
                         .withLimitToOptions(false).withGroupName("thingcfg").build());
 
+        options = new ArrayList<ParameterOption>();
+        options.add(new ParameterOption("0", "Disable"));
+        parameters.add(ConfigDescriptionParameterBuilder
+                .create(ZWaveBindingConstants.CONFIGURATION_CMDREPOLLPERIOD, Type.INTEGER)
+                .withLabel(ZWaveBindingConstants.CONFIG_BINDING_CMDPOLLPERIOD_LABEL)
+                .withDescription(ZWaveBindingConstants.CONFIG_BINDING_CMDPOLLPERIOD_DESC).withDefault("1500")
+                .withMinimum(new BigDecimal(100)).withMaximum(new BigDecimal(15000)).withOptions(options)
+                .withLimitToOptions(false).withGroupName("thingcfg").build());
+
         // If we support the wakeup class, then add the configuration
         ZWaveWakeUpCommandClass wakeupCmdClass = (ZWaveWakeUpCommandClass) node
                 .getCommandClass(ZWaveCommandClass.CommandClass.COMMAND_CLASS_WAKE_UP);


### PR DESCRIPTION
This adds a delayed poll after a command is sent to a device. By default, the device state will be polled 1.5 seconds after a command is sent to the device - this time allows the device to complete its update and achieve a steady state.

The delay can be set between 100ms and 15 seconds, or the post command poll can be disabled by setting the value to 0.

This PR also avoids polling the BASIC command class if other command classes are configured for a thing - the assumption being that there is duplication with the other classes.

Closes #438 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>