### PR TITLE
Ensure the command repoll option takes immediate effect

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
+++ b/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
@@ -134,8 +134,8 @@ public class ZWaveBindingConstants {
 
     public final static String CONFIG_BINDING_POLLINGPERIOD_LABEL = "Polling Period";
     public final static String CONFIG_BINDING_POLLINGPERIOD_DESC = "Set the minimum polling period for this device (in seconds)<BR/>Note that the polling period may be longer than set since the binding treats polls as the lowest priority data within the network.";
-    public final static String CONFIG_BINDING_CMDPOLLPERIOD_LABEL = "Command Poll Period";
-    public final static String CONFIG_BINDING_CMDPOLLPERIOD_DESC = "Set the period to wait after a command is sent to a device before polling its state.";
+    public final static String CONFIG_BINDING_CMDREPOLLPERIOD_LABEL = "Command Poll Period";
+    public final static String CONFIG_BINDING_CMDREPOLLPERIOD_DESC = "Set the period to wait after a command is sent to a device before polling its state.";
 
     public final static Set<ThingTypeUID> SUPPORTED_BRIDGE_TYPES_UIDS = ImmutableSet.of(CONTROLLER_SERIAL);
 }

--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -118,6 +118,10 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
     private final long REFRESH_POLL_DELAY = 50;
     private long pollingPeriod = POLLING_PERIOD_DEFAULT;
 
+    private final long REPOLL_PERIOD_MIN = 100;
+    private final long REPOLL_PERIOD_MAX = 15000;
+    private final long REPOLL_PERIOD_DEFAULT = 1500;
+
     private long commandPollDelay = 1500;
 
     public ZWaveThingHandler(Thing zwaveDevice) {
@@ -871,6 +875,22 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
 
                         // Restart polling so we use the new value
                         startPolling();
+                    }
+                    if ("cmdrepollperiod".equals(cfg[1])) {
+                        commandPollDelay = REPOLL_PERIOD_DEFAULT;
+                        try {
+                            commandPollDelay = ((BigDecimal) configurationParameter.getValue()).intValue();
+                        } catch (final NumberFormatException ex) {
+                            logger.debug("NODE {}: commandPollDelay ({}) cannot be set - using default", nodeId,
+                                    configurationParameter.getValue().toString());
+                        }
+                        if (commandPollDelay < REPOLL_PERIOD_MIN) {
+                            commandPollDelay = REPOLL_PERIOD_MIN;
+                        }
+                        if (commandPollDelay > REPOLL_PERIOD_MAX) {
+                            commandPollDelay = REPOLL_PERIOD_MAX;
+                        }
+                        valueObject = new BigDecimal(commandPollDelay);
                     }
                     break;
 

--- a/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
@@ -202,8 +202,8 @@ public class ZWaveConfigProvider implements ConfigDescriptionProvider, ConfigOpt
         options.add(new ParameterOption("0", "Disable"));
         parameters.add(ConfigDescriptionParameterBuilder
                 .create(ZWaveBindingConstants.CONFIGURATION_CMDREPOLLPERIOD, Type.INTEGER)
-                .withLabel(ZWaveBindingConstants.CONFIG_BINDING_CMDPOLLPERIOD_LABEL)
-                .withDescription(ZWaveBindingConstants.CONFIG_BINDING_CMDPOLLPERIOD_DESC).withDefault("1500")
+                .withLabel(ZWaveBindingConstants.CONFIG_BINDING_CMDREPOLLPERIOD_LABEL)
+                .withDescription(ZWaveBindingConstants.CONFIG_BINDING_CMDREPOLLPERIOD_DESC).withDefault("1500")
                 .withMinimum(new BigDecimal(100)).withMaximum(new BigDecimal(15000)).withOptions(options)
                 .withLimitToOptions(false).withGroupName("thingcfg").build());
 


### PR DESCRIPTION
Processes the command repoll setting immediately the configuration change is set and adds test for this configuration.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>