### PR TITLE
Don't provide NodeID configuration for controllers

### DIFF
--- a/ESH-INF/thing/controller_serial.xml
+++ b/ESH-INF/thing/controller_serial.xml
@@ -197,13 +197,6 @@ In this mode, only <i>Entry Control Devices</i> such as locks will be securely i
                 <default></default>
             </parameter>
 
-            <parameter name="node_id" type="integer" groupName="network" min="0" max="0">
-                <label>Node ID</label>
-                <description>Controller is SUC or SIS and will receive updates from other controllers in the network</description>
-                <default>0</default>
-                <advanced>true</advanced>
-            </parameter>
-
         </config-description>
     </bridge-type>
 

--- a/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
@@ -128,6 +128,9 @@ public class ZWaveConfigProvider implements ConfigDescriptionProvider, ConfigOpt
         List<ConfigDescriptionParameter> parameters = new ArrayList<ConfigDescriptionParameter>();
 
         if ("thing-type".equals(uri.getScheme())) {
+            if (uri.getSchemeSpecificPart().equals(ZWaveBindingConstants.CONTROLLER_SERIAL.toString())) {
+                return null;
+            }
             parameters.add(
                     ConfigDescriptionParameterBuilder.create(ZWaveBindingConstants.CONFIGURATION_NODEID, Type.INTEGER)
                             .withLabel("Node ID").withMinimum(new BigDecimal("1")).withMaximum(new BigDecimal("232"))


### PR DESCRIPTION
Don't provide the nodeid configuration option to controllers since it's not applicable.
Closes #899 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>