### PR TITLE
Update vision_zm1602_0_0.xml

### DIFF
--- a/ESH-INF/thing/vision_zm1602_0_0.xml
+++ b/ESH-INF/thing/vision_zm1602_0_0.xml
@@ -25,7 +25,7 @@
       <property name="vendor">Vision Security</property>
       <property name="modelId">ZM1602</property>
       <property name="manufacturerId">0109</property>
-      <property name="manufacturerRef">2009:0903,2009:0908</property>
+      <property name="manufacturerRef">2005:0503,2009:0903,2009:0908</property>
       <property name="versionMax">14.0</property>
       <property name="dbReference">109</property>
     </properties>


### PR DESCRIPTION
Include manufacturerID 2005:0503 (early version of this device - which I have).  Required for use of device with OpenHAB2.