### PR TITLE
Fix for issue with EzMultiPli color output (#939)

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveColorConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveColorConverter.java
@@ -116,38 +116,34 @@ public class ZWaveColorConverter extends ZWaveCommandClassConverter {
             // Command must be color - convert to zwave format
             HSBType color = (HSBType) command;
             logger.debug("NODE {}: Converted command '{}' to value {} {} {} for channel = {}, endpoint = {}.",
-                    node.getNodeId(), command.toString(), color.getRed().intValue(), color.getGreen().intValue(),
-                    color.getBlue().intValue(), channel.getUID(), channel.getEndpoint());
+                    node.getNodeId(), command.toString(), scaleColor(color.getRed()), scaleColor(color.getGreen()),
+                    scaleColor(color.getBlue()), channel.getUID(), channel.getEndpoint());
 
             // Queue the command
-            if (color.getSaturation().equals(PercentType.ZERO)) {
-                rawMessages = commandClass.setColor(0, 0, 0, 255, 0);
-            } else {
-                rawMessages = commandClass.setColor(scaleColor(color.getRed()), scaleColor(color.getGreen()),
-                        scaleColor(color.getBlue()), 0, 0);
-            }
+            rawMessages = commandClass.setColor(scaleColor(color.getRed()), scaleColor(color.getGreen()),
+                        scaleColor(color.getBlue()));
         } else if ("COLD_WHITE".equals(channel.getArguments().get("colorMode"))) {
             PercentType color = (PercentType) command;
             logger.debug("NODE {}: Converted command '{}' to value {} for channel = {}, endpoint = {}.",
-                    node.getNodeId(), command.toString(), color.intValue(), channel.getUID(), channel.getEndpoint());
+                    node.getNodeId(), command.toString(), scaleColor(color), channel.getUID(), channel.getEndpoint());
 
             // Queue the command
-            rawMessages = commandClass.setColor(0, 0, 0, scaleColor(color), 0);
+            rawMessages = commandClass.setColor(scaleColor(color), 0);
         } else if ("WARM_WHITE".equals(channel.getArguments().get("colorMode"))) {
             PercentType color = (PercentType) command;
             logger.debug("NODE {}: Converted command '{}' to value {} for channel = {}, endpoint = {}.",
-                    node.getNodeId(), command.toString(), color.intValue(), channel.getUID(), channel.getEndpoint());
+                    node.getNodeId(), command.toString(), scaleColor(color), channel.getUID(), channel.getEndpoint());
 
             // Queue the command
-            rawMessages = commandClass.setColor(0, 0, 0, 0, scaleColor(color));
+            rawMessages = commandClass.setColor(0, scaleColor(color));
         } else if ("DIFF_WHITE".equals(channel.getArguments().get("colorMode"))) {
             PercentType color = (PercentType) command;
             logger.debug("NODE {}: Converted command '{}' to value {} for channel = {}, endpoint = {}.",
-                    node.getNodeId(), command.toString(), color.intValue(), channel.getUID(), channel.getEndpoint());
+                    node.getNodeId(), command.toString(), scaleColor(color), channel.getUID(), channel.getEndpoint());
 
             // Queue the command
             int value = scaleColor(color);
-            rawMessages = commandClass.setColor(0, 0, 0, 255 - value, value);
+            rawMessages = commandClass.setColor(255 - value, value);
         } else {
             logger.debug("NODE {}: Unknown color mode {}.", node.getNodeId(), channel.getArguments().get("colorMode"));
         }

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveColorCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveColorCommandClass.java
@@ -235,12 +235,44 @@ public class ZWaveColorCommandClass extends ZWaveCommandClass implements ZWaveCo
     }
 
     /**
-     * Set the state (all colors) of the device
+     * Set the state (CW and WW) of the device
      *
      * @return collection of requests
      */
-    public Collection<ZWaveCommandClassTransactionPayload> setColor(int red, int green, int blue, int coldWhite,
-            int warmWhite) {
+    public Collection<ZWaveCommandClassTransactionPayload> setColor(int coldWhite, int warmWhite) {
+        ArrayList<ZWaveCommandClassTransactionPayload> result = new ArrayList<ZWaveCommandClassTransactionPayload>();
+
+        if (warmWhite > 255) {
+            warmWhite = 255;
+        }
+        if (coldWhite > 255) {
+            coldWhite = 255;
+        }
+
+        ByteArrayOutputStream outputData = new ByteArrayOutputStream();
+        outputData.write(2);
+        outputData.write((byte) ZWaveColorType.WARM_WHITE.getKey());
+        outputData.write((byte) warmWhite);
+        outputData.write((byte) ZWaveColorType.COLD_WHITE.getKey());
+        outputData.write((byte) coldWhite);
+
+        if (getVersion() > 1) {
+            // Add the transition duration
+            outputData.write((byte) 255);
+        }
+
+        result.add(new ZWaveCommandClassTransactionPayloadBuilder(getNode().getNodeId(), getCommandClass(),
+                SWITCH_COLOR_SET).withPayload(outputData.toByteArray()).withPriority(TransactionPriority.Set).build());
+
+        return result;
+    }
+
+    /**
+     * Set the state (R,G,B) of the device
+     *
+     * @return collection of requests
+     */
+    public Collection<ZWaveCommandClassTransactionPayload> setColor(int red, int green, int blue) {
         ArrayList<ZWaveCommandClassTransactionPayload> result = new ArrayList<ZWaveCommandClassTransactionPayload>();
 
         if (red > 255) {
@@ -252,25 +284,15 @@ public class ZWaveColorCommandClass extends ZWaveCommandClass implements ZWaveCo
         if (green > 255) {
             green = 255;
         }
-        if (warmWhite > 255) {
-            warmWhite = 255;
-        }
-        if (coldWhite > 255) {
-            coldWhite = 255;
-        }
 
         ByteArrayOutputStream outputData = new ByteArrayOutputStream();
-        outputData.write(5);
+        outputData.write(3);
         outputData.write((byte) ZWaveColorType.RED.getKey());
         outputData.write((byte) red);
         outputData.write((byte) ZWaveColorType.GREEN.getKey());
         outputData.write((byte) green);
         outputData.write((byte) ZWaveColorType.BLUE.getKey());
         outputData.write((byte) blue);
-        outputData.write((byte) ZWaveColorType.WARM_WHITE.getKey());
-        outputData.write((byte) warmWhite);
-        outputData.write((byte) ZWaveColorType.COLD_WHITE.getKey());
-        outputData.write((byte) coldWhite);
 
         if (getVersion() > 1) {
             // Add the transition duration

--- a/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveColorConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveColorConverterTest.java
@@ -85,6 +85,6 @@ public class ZWaveColorConverterTest extends ZWaveCommandClassConverterTest {
         ZWaveCommandClassTransactionPayload transaction = transactions.get(0);
 
         assertTrue(
-                Arrays.equals(new byte[] { 51, 5, 5, 2, -1, 3, 0, 4, 0, 0, 0, 1, 0 }, transaction.getPayloadBuffer()));
+                Arrays.equals(new byte[] { 51, 5, 3, 2, -1, 3, 0, 4, 0 }, transaction.getPayloadBuffer()));
     }
 }


### PR DESCRIPTION
Fixed as suggested by @cdjackson: refactor color commands to sepearate sending of R,G,B and CW,WW

Signed-off-by: Aaron Hexamer <hexamer@comcast.net>