### PR TITLE
Remove FAILED check and use failed transactions for DEAD nodes

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
@@ -201,14 +201,12 @@ public class ZWaveConfigProvider implements ConfigDescriptionProvider, ConfigOpt
                         .withMinimum(new BigDecimal(15)).withMaximum(new BigDecimal(86400)).withOptions(options)
                         .withLimitToOptions(false).withGroupName("thingcfg").build());
 
-        options = new ArrayList<ParameterOption>();
-        options.add(new ParameterOption("0", "Disable"));
         parameters.add(ConfigDescriptionParameterBuilder
                 .create(ZWaveBindingConstants.CONFIGURATION_CMDREPOLLPERIOD, Type.INTEGER)
                 .withLabel(ZWaveBindingConstants.CONFIG_BINDING_CMDREPOLLPERIOD_LABEL)
                 .withDescription(ZWaveBindingConstants.CONFIG_BINDING_CMDREPOLLPERIOD_DESC).withDefault("1500")
-                .withMinimum(new BigDecimal(100)).withMaximum(new BigDecimal(15000)).withOptions(options)
-                .withLimitToOptions(false).withGroupName("thingcfg").build());
+                .withMinimum(new BigDecimal(100)).withMaximum(new BigDecimal(15000)).withLimitToOptions(false)
+                .withGroupName("thingcfg").build());
 
         // If we support the wakeup class, then add the configuration
         ZWaveWakeUpCommandClass wakeupCmdClass = (ZWaveWakeUpCommandClass) node

--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
@@ -69,6 +69,18 @@ public class ZWaveAlarmConverter extends ZWaveCommandClassConverter {
         events.put(NotificationEvent.ACCESS_CONTROL__DOOR_WINDOW_CLOSED, OpenClosedType.CLOSED);
         notifications.put("sensor_door", events);
 
+        // Entry alarms
+        events = new HashMap<NotificationEvent, State>();
+        events.put(NotificationEvent.ACCESS_CONTROL__NONE, OnOffType.ON);
+        events.put(NotificationEvent.ACCESS_CONTROL__AUTO_LOCK, OnOffType.ON);
+        events.put(NotificationEvent.ACCESS_CONTROL__REMOTE_LOCK, OnOffType.ON);
+        events.put(NotificationEvent.ACCESS_CONTROL__KEYPAD_LOCK, OnOffType.ON);
+        events.put(NotificationEvent.ACCESS_CONTROL__MANUAL_LOCK, OnOffType.ON);
+        events.put(NotificationEvent.ACCESS_CONTROL__REMOTE_UNLOCK, OnOffType.OFF);
+        events.put(NotificationEvent.ACCESS_CONTROL__KEYPAD_UNLOCK, OnOffType.OFF);
+        events.put(NotificationEvent.ACCESS_CONTROL__MANUAL_UNLOCK, OnOffType.OFF);
+        notifications.put("alarm_entry", events);
+
         // Heat alarms
         events = new HashMap<NotificationEvent, State>();
         events.put(NotificationEvent.HEAT__NONE, OnOffType.OFF);

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -480,8 +480,7 @@ public class ZWaveController {
      * Queues a message for sending on the send queue.
      * This does not wait for a response.
      *
-     * @param transaction
-     *            the {@link ZWaveMessagePayloadTransaction} message to enqueue.
+     * @param transaction the {@link ZWaveMessagePayloadTransaction} message to enqueue.
      */
     public void enqueue(ZWaveMessagePayloadTransaction transaction) {
         // Sanity check!
@@ -491,9 +490,9 @@ public class ZWaveController {
         }
 
         // Since this method doesn't wait for a response, we tell the transaction handler not to wait for DATA
-        if (transaction instanceof ZWaveCommandClassTransactionPayload) {
-            ((ZWaveCommandClassTransactionPayload) transaction).setRequiresResponse(false);
-        }
+        // if (transaction instanceof ZWaveCommandClassTransactionPayload) {
+        // ((ZWaveCommandClassTransactionPayload) transaction).setRequiresResponse(false);
+        // }
 
         transactionManager.queueTransactionForSend(transaction);
     }

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -489,11 +489,6 @@ public class ZWaveController {
             return;
         }
 
-        // Since this method doesn't wait for a response, we tell the transaction handler not to wait for DATA
-        // if (transaction instanceof ZWaveCommandClassTransactionPayload) {
-        // ((ZWaveCommandClassTransactionPayload) transaction).setRequiresResponse(false);
-        // }
-
         transactionManager.queueTransactionForSend(transaction);
     }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -1267,6 +1267,13 @@ public class ZWaveNode {
             return null;
         }
         for (ZWaveCommandClassPayload command : commands) {
+            // Check for WAKEUP_NOTIFICATION
+            if (payload.getCommandClassId() == CommandClass.COMMAND_CLASS_WAKE_UP.getKey()
+                    && payload.getCommandClassCommand() == 0x07) {
+                setAwake(true);
+                continue;
+            }
+
             CommandClass commandClass = CommandClass.getCommandClass(command.getCommandClassId());
             if (commandClass == null) {
                 logger.debug("NODE {}: Unknown command class 0x{}", getNodeId(),

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -1353,12 +1353,12 @@ public class ZWaveNode {
             return;
         }
 
-        ZWaveWakeUpCommandClass wakeUpCommandClass = (ZWaveWakeUpCommandClass) getEndpoint(0)
-                .getCommandClass(ZWaveCommandClass.CommandClass.COMMAND_CLASS_WAKE_UP);
-        if (wakeUpCommandClass == null) {
-            logger.debug("NODE {}: Node doesn't support WAKEUP - ignore wakeup", getNodeId());
-            return;
-        }
+        // ZWaveWakeUpCommandClass wakeUpCommandClass = (ZWaveWakeUpCommandClass) getEndpoint(0)
+        // .getCommandClass(ZWaveCommandClass.CommandClass.COMMAND_CLASS_WAKE_UP);
+        // if (wakeUpCommandClass == null) {
+        // logger.debug("NODE {}: Node doesn't support WAKEUP - ignore wakeup", getNodeId());
+        // return;
+        // }
 
         // Create the timer if this is our first call
         if (timer == null) {
@@ -1411,7 +1411,7 @@ public class ZWaveNode {
             wakeUpCommandClass = (ZWaveWakeUpCommandClass) getEndpoint(0)
                     .getCommandClass(ZWaveCommandClass.CommandClass.COMMAND_CLASS_WAKE_UP);
             if (wakeUpCommandClass == null) {
-                logger.debug("NODE {}: COMMAND_CLASS_WAKE_UP not found", getNodeId());
+                logger.debug("NODE {}: COMMAND_CLASS_WAKE_UP not found - setting AWAKE", getNodeId());
                 awake = true;
             }
 
@@ -1440,12 +1440,13 @@ public class ZWaveNode {
 
             // Tell the device to go back to sleep.
             logger.debug("NODE {}: No more messages, go back to sleep", getNodeId());
-            ZWaveTransactionResponse response = sendTransaction(wakeUpCommandClass.getNoMoreInformationMessage(), 0);
-
+            if (wakeUpCommandClass != null) {
+                ZWaveTransactionResponse response = sendTransaction(wakeUpCommandClass.getNoMoreInformationMessage(),
+                        0);
+                logger.debug("NODE {}: Went to sleep {}", getNodeId(), response.getState());
+            }
             // When this transaction completes, assume we're asleep
             setAwake(false);
-
-            logger.debug("NODE {}: Went to sleep {}", getNodeId(), response.getState());
 
             // Stop the timer
             resetSleepTimer();

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -368,23 +368,10 @@ public class ZWaveNodeInitStageAdvancer {
         }
 
         setCurrentStage(ZWaveNodeInitStage.FAILED_CHECK);
-        // do {
         processTransaction(new IsFailedNodeMessageClass().doRequest(node.getNodeId()));
         if (initRunning == false) {
             return;
         }
-
-        // If the node is dead, sleep for 30 seconds then try again
-        // if (node.isDead()) {
-        // try {
-        // Thread.sleep(30000);
-        // } catch (InterruptedException e) {
-        // break;
-        // }
-        // } else {
-        // break;
-        // }
-        // } while (true);
 
         // Only perform the PING stage on devices that should be listening.
         // Battery (ie non-Listening) devices will only be communicated with when they send a WAKEUP_NOTIFICATION

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -397,11 +397,7 @@ public class ZWaveNodeInitStageAdvancer {
 
             // We only send out a single PING - no retries at controller level!
             // This is to try and reduce network congestion during initialisation.
-            // For battery devices, the PING will time-out. This takes up to 5 seconds and if there are retries,
-            // it will be 15 seconds!
-            // This will block the network for a considerable time if there are a lot of battery devices
-            // (eg. 2 minutes for 8 battery devices!).
-            msg.setMaxAttempts(1);
+            // msg.setMaxAttempts(1);
             processTransaction(msg);
         }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -386,19 +386,23 @@ public class ZWaveNodeInitStageAdvancer {
         // }
         // } while (true);
 
-        setCurrentStage(ZWaveNodeInitStage.PING);
-        ZWaveNoOperationCommandClass noOpCommandClass = (ZWaveNoOperationCommandClass) node
-                .getCommandClass(CommandClass.COMMAND_CLASS_NO_OPERATION);
-        if (noOpCommandClass != null) {
-            ZWaveCommandClassTransactionPayload msg = noOpCommandClass.getNoOperationMessage();
-            if (msg == null) {
-                return;
-            }
+        // Only perform the PING stage on devices that should be listening.
+        // Battery (ie non-Listening) devices will only be communicated with when they send a WAKEUP_NOTIFICATION
+        if (node.isListening()) {
+            setCurrentStage(ZWaveNodeInitStage.PING);
+            ZWaveNoOperationCommandClass noOpCommandClass = (ZWaveNoOperationCommandClass) node
+                    .getCommandClass(CommandClass.COMMAND_CLASS_NO_OPERATION);
+            if (noOpCommandClass != null) {
+                ZWaveCommandClassTransactionPayload msg = noOpCommandClass.getNoOperationMessage();
+                if (msg == null) {
+                    return;
+                }
 
-            // We only send out a single PING - no retries at controller level!
-            // This is to try and reduce network congestion during initialisation.
-            // msg.setMaxAttempts(1);
-            processTransaction(msg);
+                // We only send out a single PING - no retries at controller level!
+                // This is to try and reduce network congestion during initialisation.
+                // msg.setMaxAttempts(1);
+                processTransaction(msg);
+            }
         }
 
         setCurrentStage(ZWaveNodeInitStage.REQUEST_NIF);

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/IsFailedNodeMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/IsFailedNodeMessageClass.java
@@ -49,7 +49,7 @@ public class IsFailedNodeMessageClass extends ZWaveCommandProcessor {
 
         if (incomingMessage.getMessagePayloadByte(0) != 0x00) {
             logger.debug("NODE {}: Is currently marked as failed by the controller!", nodeId);
-            node.setNodeState(ZWaveNodeState.FAILED);
+            // node.setNodeState(ZWaveNodeState.FAILED);
         } else {
             logger.debug("NODE {}: Is currently marked as healthy by the controller", nodeId);
             node.setNodeState(ZWaveNodeState.ALIVE);

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SendDataMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SendDataMessageClass.java
@@ -94,6 +94,7 @@ public class SendDataMessageClass extends ZWaveCommandProcessor {
                 // If the transaction needs data, then it will continue to wait for this data
                 transaction.setTransactionComplete();
                 return true;
+
             case COMPLETE_NO_ACK:
                 // Handle WAKE_UP_NO_MORE_INFORMATION differently
                 // Since the system can time out if the node goes to sleep before
@@ -110,13 +111,10 @@ public class SendDataMessageClass extends ZWaveCommandProcessor {
             case COMPLETE_FAIL:
             case COMPLETE_NOT_IDLE:
             case COMPLETE_NOROUTE:
-                try {
-                    // handleFailedSendDataRequest(zController, lastSentMessage);
-                } finally {
-                    // transactionComplete = true;
-                }
+                // handleFailedSendDataRequest(zController, transaction);
                 transaction.setTransactionCanceled();
                 break;
+
             default:
                 break;
         }
@@ -124,50 +122,9 @@ public class SendDataMessageClass extends ZWaveCommandProcessor {
         return false;
     }
 
-    /*
-     * public boolean handleFailedSendDataRequest(ZWaveController zController, SerialMessage originalMessage) {
-     * ZWaveNode node = zController.getNode(originalMessage.getMessageNode());
-     * if (node == null) {
-     * logger.error("Unknown node in handleFailedSendDataRequest");
-     * return false;
-     * }
-     *
-     * logger.debug("NODE {}: Handling failed message.", node.getNodeId());
-     *
-     * // Increment the resend count.
-     * // This will set the node to DEAD if we've exceeded the retries.
-     * node.incrementResendCount();
-     *
-     * // No retries if the node is DEAD or FAILED
-     * if (node.isDead()) {
-     * logger.error("NODE {}: Node is DEAD. Dropping message.", node.getNodeId());
-     * return false;
-     * }
-     *
-     * // If this device isn't listening, queue the message in the wakeup class
-     * if (!node.isListening() && !node.isFrequentlyListening()) {
-     * ZWaveWakeUpCommandClass wakeUpCommandClass = (ZWaveWakeUpCommandClass) node
-     * .getCommandClass(CommandClass.COMMAND_CLASS_WAKE_UP);
-     *
-     * if (wakeUpCommandClass != null) {
-     * // It's a battery operated device, place in wake-up queue.
-     * // As this message failed, we assume the device is asleep
-     * wakeUpCommandClass.setAwake(false);
-     * // wakeUpCommandClass.processOutgoingWakeupMessage(originalMessage);
-     * return false;
-     * }
-     * }
-     *
-     * logger.error("NODE {}: Got an error while sending data. Resending message.", node.getNodeId());
-     * // zController.sendData(originalMessage);
-     * return true;
-     * }
-     */
-
     /**
      * Transmission state enumeration. Indicates the transmission state of the message to the node.
      *
-     * @author Jan-Willem Spuij
      */
     public enum TransmissionState {
         COMPLETE_OK(0x00, "Transmission complete and ACK received"),

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SerialApiGetInitDataMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SerialApiGetInitDataMessageClass.java
@@ -57,7 +57,7 @@ public class SerialApiGetInitDataMessageClass extends ZWaveCommandProcessor {
                 int b1 = incomingByte & (int) Math.pow(2.0D, j);
                 int b2 = (int) Math.pow(2.0D, j);
                 if (b1 == b2) {
-                    logger.info("NODE {}: Node found", nodeId);
+                    logger.debug("NODE {}: Node found", nodeId);
 
                     zwaveNodes.add(nodeId);
                 }
@@ -65,13 +65,13 @@ public class SerialApiGetInitDataMessageClass extends ZWaveCommandProcessor {
             }
         }
 
-        logger.info("ZWave Controller using {} API",
+        logger.debug("ZWave Controller using {} API",
                 ((incomingMessage.getMessagePayloadByte(1) & 0x01) == 1) ? "Slave" : "Controller");
-        logger.info("ZWave Controller is {} Controller",
+        logger.debug("ZWave Controller is {} Controller",
                 ((incomingMessage.getMessagePayloadByte(1) & 0x04) == 1) ? "Secondary" : "Primary");
-        logger.info("------------Number of Nodes Found Registered to ZWave Controller------------");
-        logger.info("# Nodes = {}", zwaveNodes.size());
-        logger.info("----------------------------------------------------------------------------");
+        logger.debug("------------Number of Nodes Found Registered to ZWave Controller------------");
+        logger.debug("# Nodes = {}", zwaveNodes.size());
+        logger.debug("----------------------------------------------------------------------------");
 
         transaction.setTransactionComplete();
         return true;


### PR DESCRIPTION
This removes the FAILED check to determine if a node is considered DEAD since this seems unreliable. Instead failed transactions are used (as per the OH1 and OH2 master code).

This also adds an ```alarm_entry``` channel for door locks.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>