### PR TITLE
Upgrade INDICATOR command class to support V2/V3

### DIFF
--- a/ESH-INF/thing/channels.xml
+++ b/ESH-INF/thing/channels.xml
@@ -368,6 +368,38 @@
         <category></category>
     </channel-type>
 
+    <!-- Indicator Command Class - Multichannel -->
+    <channel-type id="indicator_level">
+        <item-type>Dimmer</item-type>
+        <label>Indicator Level</label>
+        <description>Sets the indicator brightness</description>
+        <category></category>
+    </channel-type>
+
+    <!-- Indicator Command Class - Period -->
+    <channel-type id="indicator_period">
+        <item-type>Decimal</item-type>
+        <label>Indicator Period</label>
+        <description>Sets the indicator On/Off period</description>
+        <category></category>
+    </channel-type>
+
+    <!-- Indicator Command Class - Period -->
+    <channel-type id="indicator_flash">
+        <item-type>Decimal</item-type>
+        <label>Indicator Period</label>
+        <description>Sets the number of indicator flash cycles</description>
+        <category></category>
+    </channel-type>
+
+    <!-- Indicator Command Class - Raw -->
+    <channel-type id="indicator_raw">
+        <item-type>String</item-type>
+        <label>Indicator Raw Setting</label>
+        <description>Sets the indicator properties as a JSON string</description>
+        <category></category>
+    </channel-type>
+
     <!-- Color Temperature Channel -->
     <channel-type id="lock_door">
         <item-type>Switch</item-type>

--- a/ESH-INF/thing/cooper/rf9540n_0_0.xml
+++ b/ESH-INF/thing/cooper/rf9540n_0_0.xml
@@ -7,7 +7,9 @@
 
   <thing-type id="cooper_rf9540n_00_000" listed="false">
     <label>RF9540-N All Load Dimmer Light Switch</label>
-    <description>All Load Dimmer Light Switch</description>
+    <description><![CDATA[
+All Load Dimmer Light Switch<br /><h1>Overview</h1><p><strong>OPERATION INSTRUCTIONS</strong></p> <ul><li>Press once to turn lights ON at previously selected level.</li> <li>Press again to turn lights OFF.</li> <li>When lights are OFF, press and hold for 2 seconds for full brightness.</li> <li>When lights are ON, press and hold for 2 seconds until the blue LED blinks. After the preset delay, the lights will begin fading to OFF (up to 4 minutes).</li> <li>Amber ON/OFF LED indicates that dimmer is turned on.</li> </ul><br /><h2>Inclusion Information</h2><ol><li>This product may be added to a new or existing Z-Wave network. A Cooper Wiring Devices Z-Wave device has a blue LED, which will blink when the device is not included in a Z-Wave network. The LED stops blinking when the device is in a network.</li> <li>To include this device in a Z-Wave network, select the command on your Z Wave controller for inclusion (Install, Add Device, Add Node, Include Device, etc.). Then press the device switch one time to include it in the network. The LED will stop blinking.</li> <li>To exclude this device from a Z-Wave network, select the command on your Z-Wave controller for exclusion (Uninstall, Remove Device, Remove Node, Exclude Device, etc.). Then press the device switch one time to exclude it from the network. The LED will start blinking.</li> <li>This product works with other Z-Wave products from different vendors and product categories as part of the same network.</li> <li>This product is a listening node and it will act as a repeater in the Z-Wave network. It will perform the repeater function with Z-Wave products from Cooper and from other Z-Wave vendors</li> </ol>
+    ]]></description>
     <category>WallSwitch</category>
 
     <!-- CHANNEL DEFINITIONS -->

--- a/ESH-INF/thing/logic/zhc5010_2_0.xml
+++ b/ESH-INF/thing/logic/zhc5010_2_0.xml
@@ -8,7 +8,7 @@
   <thing-type id="logic_zhc5010_02_000" listed="false">
     <label>ZHC5010 FUGA Wall 4-way Switch with LED + Relay</label>
     <description><![CDATA[
-FUGA Wall 4-way Switch with LED + Relay<br /><h1>Overview</h1><p>ZHC5010 is a wall switch module with Z-Wave communication. The module contains four buttons, four LEDs, a built-in relay switch and is designed to fit into a standard LK FUGA® wall box (one-module format). The ZHC5010 Wall Switch allows you to control the local load as well as Z-Wave connected devices in up to four additional Z-Wave groups.</p> <p>Configuration updated: 2017-12-10, firmware 2.03</p> <br /><h2>Inclusion Information</h2><p>Place your primary controller in Adding Mode by following the manufacturer's instructions, then activate the add mode on the device by triple-clicking the upper left button on the module, or by triple-clicking the little button in the middle of the module (hidden behind the small plastic cover). Adding Mode is indicated by blinking of upper left LED until the timeout occurs after 10 seconds or the module has been added in the network. </p> <br /><h2>Exclusion Information</h2><p>Follow the inclusion procedures; the device is removed in the same manner, when the controller is in Removing Mode.</p> <p>Factory reset:</p> <p>ZHC5010 can be factory reset by pressing the small button in the middle of the module (normally covered by small plastic cover) for at least 10 seconds. Remove the middle plastic cover by means of a small screwdriver, and press the small button for at least 10 seconds, until all the LEDs lights up. Please use this procedure only when the network primary controller is missing or otherwise inoperable.</p>
+FUGA Wall 4-way Switch with LED + Relay<br /><h1>Overview</h1><p>ZHC5010 is a wall switch module with Z-Wave communication. The module contains four buttons, four LEDs, a built-in relay switch and is designed to fit into a standard LK FUGA® wall box (one-module format). The ZHC5010 Wall Switch allows you to control the local load as well as Z-Wave connected devices in up to four additional Z-Wave groups.</p> <p>Configuration updated: 2017-12-10, firmware 2.03</p> <br /><h2>Inclusion Information</h2><p>Place your primary controller in Adding Mode by following the manufacturer's instructions, then activate the add mode on the device by triple-clicking the upper left button on the module, or by triple-clicking the little button in the middle of the module (hidden behind the small plastic cover). Adding Mode is indicated by blinking of upper left LED until the timeout occurs after 10 seconds or the module has been added in the network. </p> <br /><h2>Exclusion Information</h2><p>Follow the inclusion procedures; the device is removed in the same manner, when the controller is in Removing Mode.</p> <p>Factory reset:</p> <p>ZHC5010 can be factory reset by pressing the small button in the middle of the module (normally covered by small plastic cover) for at least 10 seconds. Remove the middle plastic cover by means of a small screwdriver, and press the small button for at least 10 seconds, until all the LEDs lights up. Please use this procedure only when the network primary controller is missing or otherwise inoperable.</p>
     ]]></description>
     <category>WallSwitch</category>
 
@@ -122,7 +122,7 @@ FUGA Wall 4-way Switch with LED + Relay<br /><h1>Overview</h1><p>ZHC5010 is a wa
       <parameter name="config_1_1" type="integer" groupName="configuration">
         <label>1: Upper paddle buttons mode</label>
         <description><![CDATA[
-Pair Mode, upper two buttons<br /><h1>Overview</h1><p>Configuration of Pair Mode for the upper two buttons (button #1 and #2) </p>
+Pair Mode, upper two buttons<br /><h1>Overview</h1><p>Configuration of Pair Mode for the upper two buttons (button #1 and #2) </p>
         ]]></description>
         <default>0</default>
         <options>
@@ -294,7 +294,7 @@ How built-in relay is controlled<br /><h1>Overview</h1><p>This parameter configu
       <parameter name="config_16_1" type="integer" groupName="configuration">
         <label>16: Indicator mode.</label>
         <description><![CDATA[
-set the current light level for the actual LED or the level value can be stored<br /><h1>Overview</h1><p>When ZHC5010 receives an Indicator Set message, then the received value can be used only to set the current light level for the actual LED or the level value can be stored and will then be used for subsequent internal activations. </p>
+set the current light level for the actual LED or the level value can be stored<br /><h1>Overview</h1><p>When ZHC5010 receives an Indicator Set message, then the received value can be used only to set the current light level for the actual LED or the level value can be stored and will then be used for subsequent internal activations. </p>
         ]]></description>
         <default>1</default>
         <options>
@@ -491,7 +491,7 @@ Control of association groups for device 4 (button #4).<br /><h1>Overview</h1><p
                  min="0" max="255">
         <label>28: Threshold time for long-press</label>
         <description><![CDATA[
-Decides the time for when a button is detected as long-pressed<br /><h1>Overview</h1><p>Decides the time for when a button is detected as long-pressed.</p> <p>0     : Detection disabled. This is not recommended.</p> <p>1-255 : Long-press detection time in 0.01 seconds, 50 equals 0.5 seconds.</p>
+Decides the time for when a button is detected as long-pressed<br /><h1>Overview</h1><p>Decides the time for when a button is detected as long-pressed.</p> <p>0     : Detection disabled. This is not recommended.</p> <p>1-255 : Long-press detection time in 0.01 seconds, 50 equals 0.5 seconds.</p>
         ]]></description>
         <default>50</default>
       </parameter>
@@ -500,7 +500,7 @@ Decides the time for when a button is detected as long-pressed<br /><h1>Overview
                  min="0" max="255">
         <label>29: Threshold time for keypress detection of button 1</label>
         <description><![CDATA[
-Specifies the detection time for single-press, double-press, etc. for button 1.<br /><h1>Overview</h1><p>Specifies the detection time for single-press, double-press, etc. for button 1.</p> <p>0       : Detection disabled. This is not recommended.</p> <p>1 - 255 : Detection time in 0.01 seconds, 30 equals 0.3 seconds.</p>
+Specifies the detection time for single-press, double-press, etc. for button 1.<br /><h1>Overview</h1><p>Specifies the detection time for single-press, double-press, etc. for button 1.</p> <p>0       : Detection disabled. This is not recommended.</p> <p>1 - 255 : Detection time in 0.01 seconds, 30 equals 0.3 seconds.</p>
         ]]></description>
         <default>30</default>
       </parameter>
@@ -509,7 +509,7 @@ Specifies the detection time for single-press, double-press, etc. for button 1.<
                  min="0" max="255">
         <label>30: Threshold time for keypress detection of button 2</label>
         <description><![CDATA[
-Specifies the detection time for single-press, double-press, etc. for button 2<br /><h1>Overview</h1><p>Specifies the detection time for single-press, double-press, etc. for button 2.</p> <p>0       : Detection disabled. This is not recommended.</p> <p>1 - 255 : Detection time in 0.01 seconds, 30 equals 0.3 seconds.</p>
+Specifies the detection time for single-press, double-press, etc. for button 2<br /><h1>Overview</h1><p>Specifies the detection time for single-press, double-press, etc. for button 2.</p> <p>0       : Detection disabled. This is not recommended.</p> <p>1 - 255 : Detection time in 0.01 seconds, 30 equals 0.3 seconds.</p>
         ]]></description>
         <default>30</default>
       </parameter>
@@ -518,7 +518,7 @@ Specifies the detection time for single-press, double-press, etc. for button 2<b
                  min="0" max="255">
         <label>31: Threshold time for keypress detection of button 3</label>
         <description><![CDATA[
-Specifies the detection time for single-press, double-press, etc. for button 3<br /><h1>Overview</h1><p>Specifies the detection time for single-press, double-press, etc. for button 3.</p> <p>0       : Detection disabled. This is not recommended.</p> <p>1 - 255 : Detection time in 0.01 seconds, 30 equals 0.3 seconds.</p>
+Specifies the detection time for single-press, double-press, etc. for button 3<br /><h1>Overview</h1><p>Specifies the detection time for single-press, double-press, etc. for button 3.</p> <p>0       : Detection disabled. This is not recommended.</p> <p>1 - 255 : Detection time in 0.01 seconds, 30 equals 0.3 seconds.</p>
         ]]></description>
         <default>30</default>
       </parameter>
@@ -527,7 +527,7 @@ Specifies the detection time for single-press, double-press, etc. for button 3<b
                  min="0" max="255">
         <label>32: Threshold time for keypress detection of button 4</label>
         <description><![CDATA[
-Specifies the detection time for single-press, double-press, etc. for button 4<br /><h1>Overview</h1><p>Specifies the detection time for single-press, double-press, etc. for button 4.</p> <p>0       : Detection disabled. This is not recommended.</p> <p>1 - 255 : Detection time in 0.01 seconds, 30 equals 0.3 seconds.</p>
+Specifies the detection time for single-press, double-press, etc. for button 4<br /><h1>Overview</h1><p>Specifies the detection time for single-press, double-press, etc. for button 4.</p> <p>0       : Detection disabled. This is not recommended.</p> <p>1 - 255 : Detection time in 0.01 seconds, 30 equals 0.3 seconds.</p>
         ]]></description>
         <default>30</default>
       </parameter>
@@ -536,7 +536,7 @@ Specifies the detection time for single-press, double-press, etc. for button 4<b
                  min="0" max="255">
         <label>33: Non-secure commands for AG in logical device 1</label>
         <description><![CDATA[
-Allow sending non-secure commands to association members if added securely<br /><h1>Overview</h1><p>If ZHC5010 is included secure, this parameter allows sending messages on keypresses to non-secure devices (e.g. pre-gen5 relays).</p> <p>If ZHC5010 is included non-secure, this parameter has no function.</p> <p>0         : No commands sent unencrypted (default)</p> <p>1  (0x01) : Bit#1. Not used.</p> <p>2  (0x02) : Bit#2. Send BASICREPORT to association group 2 unencrypted.</p> <p>4  (0x04) : Bit#3. Send BASICSET to association group 3 unencrypted.</p> <p>8  (0x08) : Bit#4. Send BINARYSWITCHSET to association group 4 unencrypted.</p> <p>16 (0x10) : Bit#5. Send BINARYTOGGLESWITCHSET to association group 5 unencrypted.</p> <p>32 (0x20) : Bit#6. Send MULTILEVELSWITCH to association group 6 unencrypted.</p>
+Allow sending non-secure commands to association members if added securely<br /><h1>Overview</h1><p>If ZHC5010 is included secure, this parameter allows sending messages on keypresses to non-secure devices (e.g. pre-gen5 relays).</p> <p>If ZHC5010 is included non-secure, this parameter has no function.</p> <p>0         : No commands sent unencrypted (default)</p> <p>1  (0x01) : Bit#1. Not used.</p> <p>2  (0x02) : Bit#2. Send BASICREPORT to association group 2 unencrypted.</p> <p>4  (0x04) : Bit#3. Send BASICSET to association group 3 unencrypted.</p> <p>8  (0x08) : Bit#4. Send BINARYSWITCHSET to association group 4 unencrypted.</p> <p>16 (0x10) : Bit#5. Send BINARYTOGGLESWITCHSET to association group 5 unencrypted.</p> <p>32 (0x20) : Bit#6. Send MULTILEVELSWITCH to association group 6 unencrypted.</p>
         ]]></description>
         <default>0</default>
       </parameter>
@@ -545,7 +545,7 @@ Allow sending non-secure commands to association members if added securely<br />
                  min="0" max="255">
         <label>34: Non-secure commands for AG in logical device 2</label>
         <description><![CDATA[
-Allow sending non-secure commands to association members if added securely<br /><h1>Overview</h1><p>If ZHC5010 is included secure, this parameter allows sending messages on keypresses to non-secure devices (e.g. pre-gen5 relays).</p> <p>If ZHC5010 is included non-secure, this parameter has no function.</p> <p>0         : No commands sent unencrypted (default)</p> <p>1  (0x01) : Bit#1. Not used.</p> <p>2  (0x02) : Bit#2. Send BASICREPORT to association group 2 unencrypted.</p> <p>4  (0x04) : Bit#3. Send BASICSET to association group 3 unencrypted.</p> <p>8  (0x08) : Bit#4. Send BINARYSWITCHSET to association group 4 unencrypted.</p> <p>16 (0x10) : Bit#5. Send BINARYTOGGLESWITCHSET to association group 5 unencrypted.</p> <p>32 (0x20) : Bit#6. Send MULTILEVELSWITCH to association group 6 unencrypted.</p>
+Allow sending non-secure commands to association members if added securely<br /><h1>Overview</h1><p>If ZHC5010 is included secure, this parameter allows sending messages on keypresses to non-secure devices (e.g. pre-gen5 relays).</p> <p>If ZHC5010 is included non-secure, this parameter has no function.</p> <p>0         : No commands sent unencrypted (default)</p> <p>1  (0x01) : Bit#1. Not used.</p> <p>2  (0x02) : Bit#2. Send BASICREPORT to association group 2 unencrypted.</p> <p>4  (0x04) : Bit#3. Send BASICSET to association group 3 unencrypted.</p> <p>8  (0x08) : Bit#4. Send BINARYSWITCHSET to association group 4 unencrypted.</p> <p>16 (0x10) : Bit#5. Send BINARYTOGGLESWITCHSET to association group 5 unencrypted.</p> <p>32 (0x20) : Bit#6. Send MULTILEVELSWITCH to association group 6 unencrypted.</p>
         ]]></description>
         <default>0</default>
       </parameter>
@@ -554,7 +554,7 @@ Allow sending non-secure commands to association members if added securely<br />
                  min="0" max="255">
         <label>35: Non-secure commands for AG in logical device 3</label>
         <description><![CDATA[
-Allow sending non-secure commands to association members if added securely<br /><h1>Overview</h1><p>If ZHC5010 is included secure, this parameter allows sending messages on keypresses to non-secure devices (e.g. pre-gen5 relays).</p> <p>If ZHC5010 is included non-secure, this parameter has no function.</p> <p>0         : No commands sent unencrypted (default)</p> <p>1  (0x01) : Bit#1. Not used.</p> <p>2  (0x02) : Bit#2. Send BASICREPORT to association group 2 unencrypted.</p> <p>4  (0x04) : Bit#3. Send BASICSET to association group 3 unencrypted.</p> <p>8  (0x08) : Bit#4. Send BINARYSWITCHSET to association group 4 unencrypted.</p> <p>16 (0x10) : Bit#5. Send BINARYTOGGLESWITCHSET to association group 5 unencrypted.</p> <p>32 (0x20) : Bit#6. Send MULTILEVELSWITCH to association group 6 unencrypted.</p>
+Allow sending non-secure commands to association members if added securely<br /><h1>Overview</h1><p>If ZHC5010 is included secure, this parameter allows sending messages on keypresses to non-secure devices (e.g. pre-gen5 relays).</p> <p>If ZHC5010 is included non-secure, this parameter has no function.</p> <p>0         : No commands sent unencrypted (default)</p> <p>1  (0x01) : Bit#1. Not used.</p> <p>2  (0x02) : Bit#2. Send BASICREPORT to association group 2 unencrypted.</p> <p>4  (0x04) : Bit#3. Send BASICSET to association group 3 unencrypted.</p> <p>8  (0x08) : Bit#4. Send BINARYSWITCHSET to association group 4 unencrypted.</p> <p>16 (0x10) : Bit#5. Send BINARYTOGGLESWITCHSET to association group 5 unencrypted.</p> <p>32 (0x20) : Bit#6. Send MULTILEVELSWITCH to association group 6 unencrypted.</p>
         ]]></description>
         <default>0</default>
       </parameter>
@@ -563,7 +563,7 @@ Allow sending non-secure commands to association members if added securely<br />
                  min="0" max="255">
         <label>36: Non-secure commands for AG in logical device 4</label>
         <description><![CDATA[
-Allow sending non-secure commands to association members if added securely<br /><h1>Overview</h1><p>If ZHC5010 is included secure, this parameter allows sending messages on keypresses to non-secure devices (e.g. pre-gen5 relays).</p> <p>If ZHC5010 is included non-secure, this parameter has no function.</p> <p>0         : No commands sent unencrypted (default)</p> <p>1  (0x01) : Bit#1. Not used.</p> <p>2  (0x02) : Bit#2. Send BASICREPORT to association group 2 unencrypted.</p> <p>4  (0x04) : Bit#3. Send BASICSET to association group 3 unencrypted.</p> <p>8  (0x08) : Bit#4. Send BINARYSWITCHSET to association group 4 unencrypted.</p> <p>16 (0x10) : Bit#5. Send BINARYTOGGLESWITCHSET to association group 5 unencrypted.</p> <p>32 (0x20) : Bit#6. Send MULTILEVELSWITCH to association group 6 unencrypted.</p>
+Allow sending non-secure commands to association members if added securely<br /><h1>Overview</h1><p>If ZHC5010 is included secure, this parameter allows sending messages on keypresses to non-secure devices (e.g. pre-gen5 relays).</p> <p>If ZHC5010 is included non-secure, this parameter has no function.</p> <p>0         : No commands sent unencrypted (default)</p> <p>1  (0x01) : Bit#1. Not used.</p> <p>2  (0x02) : Bit#2. Send BASICREPORT to association group 2 unencrypted.</p> <p>4  (0x04) : Bit#3. Send BASICSET to association group 3 unencrypted.</p> <p>8  (0x08) : Bit#4. Send BINARYSWITCHSET to association group 4 unencrypted.</p> <p>16 (0x10) : Bit#5. Send BINARYTOGGLESWITCHSET to association group 5 unencrypted.</p> <p>32 (0x20) : Bit#6. Send MULTILEVELSWITCH to association group 6 unencrypted.</p>
         ]]></description>
         <default>0</default>
       </parameter>
@@ -682,3 +682,4 @@ Allow sending non-secure commands to association members if added securely<br />
   </thing-type>
 
 </thing:thing-descriptions>
+ 

--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveCommandClassConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveCommandClassConverter.java
@@ -55,6 +55,7 @@ public abstract class ZWaveCommandClassConverter {
         temp.put(CommandClass.COMMAND_CLASS_SWITCH_COLOR, ZWaveColorConverter.class);
         temp.put(CommandClass.COMMAND_CLASS_CONFIGURATION, ZWaveConfigurationConverter.class);
         temp.put(CommandClass.COMMAND_CLASS_DOOR_LOCK, ZWaveDoorLockConverter.class);
+        temp.put(CommandClass.COMMAND_CLASS_INDICATOR, ZWaveIndicatorConverter.class);
         temp.put(CommandClass.COMMAND_CLASS_MANUFACTURER_PROPRIETARY, ZWaveManufacturerProprietaryConverter.class);
         temp.put(CommandClass.COMMAND_CLASS_METER, ZWaveMeterConverter.class);
         temp.put(CommandClass.COMMAND_CLASS_METER_TBL_MONITOR, ZWaveMeterTblMonitorConverter.class);

--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveIndicatorConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveIndicatorConverter.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.internal.converter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+import org.openhab.binding.zwave.handler.ZWaveControllerHandler;
+import org.openhab.binding.zwave.handler.ZWaveThingChannel;
+import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveIndicatorCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveIndicatorCommandClass.IndicatorProperty;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveIndicatorCommandClass.IndicatorType;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveIndicatorCommandClass.ZWaveIndicator;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
+import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Chris Jackson
+ */
+public class ZWaveIndicatorConverter extends ZWaveCommandClassConverter {
+
+    private final Logger logger = LoggerFactory.getLogger(ZWaveIndicatorConverter.class);
+
+    /**
+     * Constructor. Creates a new instance of the {@link ZWaveIndicatorConverter} class.
+     *
+     */
+    public ZWaveIndicatorConverter(ZWaveControllerHandler controller) {
+        super(controller);
+    }
+
+    @Override
+    public State handleEvent(ZWaveThingChannel channel, ZWaveCommandClassValueEvent event) {
+        String indicatorType = channel.getArguments().get("type");
+
+        List<ZWaveIndicator> indicators = (List<ZWaveIndicator>) event.getValue();
+        State state = null;
+
+        ZWaveIndicator indicator = null;
+
+        for (ZWaveIndicator indicatorCheck : indicators) {
+            if (indicatorCheck.type.equals(IndicatorType.valueOf(indicatorType))) {
+                indicator = indicatorCheck;
+                break;
+            }
+        }
+
+        if (indicator == null) {
+            return null;
+        }
+
+        switch (channel.getUID().getId()) {
+            case "indicator_level":
+                if (indicator.property != IndicatorProperty.MULTILEVEL) {
+                    return null;
+                }
+                state = new PercentType(indicator.value);
+                break;
+            case "indicator_period":
+                if (indicator.property != IndicatorProperty.ON_OFF_PERIOD) {
+                    return null;
+                }
+                state = new DecimalType(indicator.value);
+                break;
+            case "indicator_flash":
+                if (indicator.property != IndicatorProperty.ON_OFF_CYCLES) {
+                    return null;
+                }
+                state = new DecimalType(indicator.value);
+                break;
+            default:
+                logger.warn("Unknown INDICATOR channel type {}", channel.getUID().getId());
+                return null;
+        }
+
+        return state;
+    }
+
+    @Override
+    public List<ZWaveCommandClassTransactionPayload> receiveCommand(ZWaveThingChannel channel, ZWaveNode node,
+            Command command) {
+
+        String indicatorStringType = channel.getArguments().get("type");
+
+        ZWaveIndicatorCommandClass commandClass = (ZWaveIndicatorCommandClass) node
+                .resolveCommandClass(ZWaveCommandClass.CommandClass.COMMAND_CLASS_INDICATOR, channel.getEndpoint());
+        if (commandClass == null) {
+            logger.warn("NODE {}: Command class COMMAND_CLASS_INDICATOR not found", node.getNodeId());
+            return null;
+        }
+
+        IndicatorProperty property = null;
+
+        switch (channel.getUID().getId()) {
+            case "indicator_level":
+                property = IndicatorProperty.MULTILEVEL;
+                break;
+            case "indicator_period":
+                property = IndicatorProperty.ON_OFF_PERIOD;
+                break;
+            case "indicator_flash":
+                property = IndicatorProperty.ON_OFF_CYCLES;
+                break;
+            default:
+                logger.warn("Unknown INDICATOR channel type {}", channel.getUID().getId());
+                return null;
+        }
+
+        Integer value = null;
+        if (command instanceof OnOffType) {
+            value = ((OnOffType) command) == OnOffType.ON ? 0xff : 0x00;
+        } else if (command instanceof DecimalType) {
+            value = ((DecimalType) command).intValue();
+        }
+
+        if (value == null) {
+            return null;
+        }
+
+        ZWaveCommandClassTransactionPayload transaction;
+
+        if (commandClass.getVersion() == 1) {
+            transaction = commandClass.setValueMessage(value);
+        } else {
+            ZWaveIndicator indicator = new ZWaveIndicator();
+            indicator.type = IndicatorType.valueOf(indicatorStringType);
+            indicator.property = property;
+            indicator.value = value;
+            List<ZWaveIndicator> indicators = new ArrayList<>();
+            indicators.add(indicator);
+            transaction = commandClass.setValueMessage(indicators);
+        }
+
+        if (transaction == null) {
+            logger.warn("NODE {}: Generating message failed for command class = {}, endpoint = {}", node.getNodeId(),
+                    commandClass.getCommandClass(), channel.getEndpoint());
+            return null;
+        }
+
+        transaction = node.encapsulate(transaction, channel.getEndpoint());
+
+        List<ZWaveCommandClassTransactionPayload> messages = new ArrayList<ZWaveCommandClassTransactionPayload>();
+        messages.add(transaction);
+        return messages;
+    }
+}

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
@@ -246,9 +246,9 @@ public abstract class ZWaveCommandClass {
         } catch (InvocationTargetException e) {
             // Handle exceptions from the command class processing
             if (e.getCause() instanceof ArrayIndexOutOfBoundsException) {
-                logger.debug("NODE {}: ArrayIndexOutOfBoundsException {} V{} {} {}: {}", getNode().getNodeId(),
+                logger.debug("NODE {}: ArrayIndexOutOfBoundsException {} V{} {} {}", getNode().getNodeId(),
                         getCommandClass(), getVersion(), commands.get(payload.getCommandClassCommand()).name,
-                        SerialMessage.bb2hex(payload.getPayloadBuffer()), e.getMessage());
+                        SerialMessage.bb2hex(payload.getPayloadBuffer()));
             }
         } catch (IllegalAccessException | IllegalArgumentException e) {
             logger.error("NODE {}: Error in handleApplicationCommandRequest", getNode().getNodeId(), e);

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveIndicatorCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveIndicatorCommandClass.java
@@ -7,8 +7,11 @@
  */
 package org.openhab.binding.zwave.internal.protocol.commandclass;
 
+import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.openhab.binding.zwave.internal.protocol.ZWaveCommandClassPayload;
@@ -37,21 +40,28 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
  * @author Pedro Paixao
  */
 @XStreamAlias("COMMAND_CLASS_INDICATOR")
-public class ZWaveIndicatorCommandClass extends ZWaveCommandClass implements ZWaveCommandClassDynamicState {
+public class ZWaveIndicatorCommandClass extends ZWaveCommandClass
+        implements ZWaveCommandClassDynamicState, ZWaveCommandClassInitialization {
 
     @XStreamOmitField
     private static final Logger logger = LoggerFactory.getLogger(ZWaveIndicatorCommandClass.class);
 
+    private static final int MAX_SUPPORTED_VERSION = 3;
+
     private static final int INDICATOR_SET = 0x01;
     private static final int INDICATOR_GET = 0x02;
     private static final int INDICATOR_REPORT = 0x03;
-
-    private int indicator;
+    private static final int INDICATOR_SUPPORTED_GET = 0x04;
+    private static final int INDICATOR_SUPPORTED_REPORT = 0x05;
 
     @XStreamOmitField
     private boolean dynamicDone = false;
 
     private boolean isGetSupported = true;
+
+    private boolean supportedIndicatorsInitialised = false;
+
+    List<ZWaveIndicator> supportedIndicators = new ArrayList<ZWaveIndicator>();
 
     /**
      * Creates a new instance of the ZWaveIndicatorCommandClass class.
@@ -62,7 +72,7 @@ public class ZWaveIndicatorCommandClass extends ZWaveCommandClass implements ZWa
      */
     public ZWaveIndicatorCommandClass(ZWaveNode node, ZWaveController controller, ZWaveEndpoint endpoint) {
         super(node, controller, endpoint);
-        indicator = 0;
+        versionMax = MAX_SUPPORTED_VERSION;
     }
 
     @Override
@@ -80,32 +90,106 @@ public class ZWaveIndicatorCommandClass extends ZWaveCommandClass implements ZWa
      */
     @ZWaveResponseHandler(id = INDICATOR_REPORT, name = "INDICATOR_REPORT")
     public void handleIndicatorReport(ZWaveCommandClassPayload payload, int endpoint) {
-        int newIndicator = payload.getPayloadByte(2);
+        List<ZWaveIndicator> indicators = new ArrayList<ZWaveIndicator>();
+        ZWaveIndicator indicator = new ZWaveIndicator();
+        indicator.type = IndicatorType.NA;
+        indicator.property = null;
+        indicator.value = payload.getPayloadByte(2);
+        indicators.add(indicator);
 
-        logger.debug("NODE {}: Indicator report, value={}", this.getNode().getNodeId(), newIndicator);
+        if (getVersion() >= 2) {
+            int indicatorCnt = payload.getPayloadByte(3) & 0x1F;
+            int offset = 3;
+            for (int cnt = 0; cnt < indicatorCnt; cnt++) {
+                indicator = new ZWaveIndicator();
+                indicator.type = IndicatorType.getIndicatorType(payload.getPayloadByte(offset++));
+                indicator.property = IndicatorProperty.getIndicatorProperty(payload.getPayloadByte(offset++));
+                indicator.value = payload.getPayloadByte(offset++);
+                indicators.add(indicator);
+            }
+        }
 
-        ZWaveIndicatorCommandClassChangeEvent zEvent = new ZWaveIndicatorCommandClassChangeEvent(getNode().getNodeId(),
-                endpoint, getCommandClass(), newIndicator, indicator);
+        logger.debug("NODE {}: Indicator report={}", getNode().getNodeId(), indicators);
 
-        indicator = newIndicator;
+        ZWaveCommandClassValueEvent zEvent = new ZWaveCommandClassValueEvent(getNode().getNodeId(), endpoint,
+                getCommandClass(), indicators);
+
         getController().notifyEventListeners(zEvent);
     }
 
     /**
-     * Gets a SerialMessage with the INDICATOR GET command
+     * Processes a INDICATOR_SUPPORTED_REPORT message.
+     *
+     * @param serialMessage the incoming message to process.
+     * @param offset the offset position from which to start message processing.
+     * @param endpoint the endpoint or instance number this message is meant for.
+     * @throws ZWaveSerialMessageException
+     */
+    @ZWaveResponseHandler(id = INDICATOR_SUPPORTED_REPORT, name = "INDICATOR_SUPPORTED_REPORT")
+    public void handleIndicatorSupportedReport(ZWaveCommandClassPayload payload, int endpoint) {
+        IndicatorType type = IndicatorType.getIndicatorType(payload.getPayloadByte(2));
+        int properties = payload.getPayloadByte(4) & 0x1F;
+
+        for (int cnt = 0; cnt < properties; cnt++) {
+            ZWaveIndicator indicator = new ZWaveIndicator();
+            indicator.type = type;
+            indicator.property = IndicatorProperty.getIndicatorProperty(payload.getPayloadByte(5 + cnt));
+
+            supportedIndicators.add(indicator);
+        }
+
+        if (payload.getPayloadByte(3) == 0) {
+            logger.debug("NODE {}: Indicator supported initialisation complete", getNode().getNodeId());
+            supportedIndicatorsInitialised = true;
+        } else {
+            ZWaveCommandClassTransactionPayload outputMessage = getSupportedIndicators(
+                    IndicatorType.getIndicatorType(payload.getPayloadByte(3)));
+            if (outputMessage != null) {
+                getNode().sendMessage(getNode().encapsulate(outputMessage, getEndpoint().getEndpointId()));
+            }
+        }
+    }
+
+    /**
+     * Gets a SerialMessage with the INDICATOR_GET command
      *
      * @return the serial message
      */
     public ZWaveCommandClassTransactionPayload getValueMessage() {
         if (isGetSupported == false) {
+            logger.debug("NODE {}: Node doesn't support get requests", getNode().getNodeId());
+            return null;
+        }
+
+        logger.debug("NODE {}: Creating new message for application command INDICATOR_GET", getNode().getNodeId());
+
+        return new ZWaveCommandClassTransactionPayloadBuilder(getNode().getNodeId(), getCommandClass(), INDICATOR_GET)
+                .withExpectedResponseCommand(INDICATOR_REPORT).withPriority(TransactionPriority.Get).build();
+    }
+
+    /**
+     * Gets a SerialMessage with the INDICATOR_SUPPORTED_GET command
+     *
+     * @param type the indicator to get the list of supported properties. Set to null to get the list of indicator types
+     * @return the serial message
+     */
+    public ZWaveCommandClassTransactionPayload getSupportedIndicators(IndicatorType type) {
+        if (isGetSupported == false) {
             logger.debug("NODE {}: Node doesn't support get requests", this.getNode().getNodeId());
             return null;
         }
 
-        logger.debug("NODE {}: Creating new message for application command INDICATOR_GET", this.getNode().getNodeId());
+        logger.debug("NODE {}: Creating new message for application command INDICATOR_SUPPORTED_GET for {}",
+                getNode().getNodeId(), type);
 
-        return new ZWaveCommandClassTransactionPayloadBuilder(getNode().getNodeId(), getCommandClass(), INDICATOR_GET)
-                .withExpectedResponseCommand(INDICATOR_REPORT).withPriority(TransactionPriority.Get).build();
+        int value = 0;
+        if (type != null) {
+            value = type.getKey();
+        }
+
+        return new ZWaveCommandClassTransactionPayloadBuilder(getNode().getNodeId(), getCommandClass(),
+                INDICATOR_SUPPORTED_GET).withPayload(value).withExpectedResponseCommand(INDICATOR_SUPPORTED_REPORT)
+                        .withPriority(TransactionPriority.Config).build();
     }
 
     @Override
@@ -118,25 +202,41 @@ public class ZWaveIndicatorCommandClass extends ZWaveCommandClass implements ZWa
     }
 
     /**
-     * Gets a SerialMessage with the INDICATOR SET command
+     * Gets a SerialMessage with the INDICATOR SET command (V1)
      *
      * @param the level to set.
      * @return the serial message
      */
     public ZWaveCommandClassTransactionPayload setValueMessage(int newIndicator) {
-        logger.debug("NODE {}: Creating new message for application command INDICATOR_SET", this.getNode().getNodeId());
+        logger.debug("NODE {}: Creating new message for application command INDICATOR_SET {}", getNode().getNodeId(),
+                newIndicator);
 
         return new ZWaveCommandClassTransactionPayloadBuilder(getNode().getNodeId(), getCommandClass(), INDICATOR_SET)
                 .withPayload(newIndicator).withPriority(TransactionPriority.Set).build();
     }
 
     /**
-     * Get current indicator value
+     * Gets a SerialMessage with the INDICATOR SET command (V2 / V3)
      *
-     * @return indicator
+     * @param the level to set.
+     * @return the serial message
      */
-    public int getValue() {
-        return indicator;
+    public ZWaveCommandClassTransactionPayload setValueMessage(List<ZWaveIndicator> indicators) {
+        logger.debug("NODE {}: Creating new message for application command INDICATOR_SET {}", getNode().getNodeId(),
+                indicators);
+
+        ByteArrayOutputStream outputData = new ByteArrayOutputStream();
+        outputData.write(0);
+        outputData.write(indicators.size());
+
+        for (ZWaveIndicator indicator : indicators) {
+            outputData.write(indicator.type.getKey());
+            outputData.write(indicator.property.getKey());
+            outputData.write(indicator.value);
+        }
+
+        return new ZWaveCommandClassTransactionPayloadBuilder(getNode().getNodeId(), getCommandClass(), INDICATOR_SET)
+                .withPayload(outputData.toByteArray()).withPriority(TransactionPriority.Set).build();
     }
 
     @Override
@@ -154,55 +254,165 @@ public class ZWaveIndicatorCommandClass extends ZWaveCommandClass implements ZWa
         return result;
     }
 
-    public class ZWaveIndicatorCommandClassChangeEvent extends ZWaveCommandClassValueEvent {
-        private int currentIndicator;
+    @Override
+    public Collection<ZWaveCommandClassTransactionPayload> initialize(boolean refresh) {
+        ArrayList<ZWaveCommandClassTransactionPayload> result = new ArrayList<ZWaveCommandClassTransactionPayload>();
+
+        if (refresh == true) {
+            supportedIndicatorsInitialised = false;
+        }
+
+        if (getVersion() >= 2) {
+            supportedIndicators.clear();
+            if (supportedIndicatorsInitialised == false) {
+                result.add(getSupportedIndicators(null));
+            }
+        } else {
+            supportedIndicatorsInitialised = true;
+        }
+        return result;
+    }
+
+    @XStreamAlias("indicatorType")
+    public enum IndicatorType {
+        NA(0x00),
+        ARMED(0x01),
+        NOT_ARMED(0x02),
+        READY(0x03),
+        FAULT(0x04),
+        BUSY(0x05),
+        ENTER_ID(0x06),
+        ENTER_PIN(0x07),
+        OK(0x08),
+        NOT_OK(0x09),
+        ZONE1_ARMED(0x20),
+        ZONE2_ARMED(0x21),
+        ZONE3_ARMED(0x22),
+        ZONE4_ARMED(0x23),
+        ZONE5_ARMED(0x24),
+        ZONE6_ARMED(0x25),
+        LCD_BACKLIGHT(0x30),
+        BUTTON_BACKLIGHT_LETTERS(0x40),
+        BUTTON_BACKLIGHT_DIGITS(0x41),
+        BUTTON_BACKLIGHT_COMMAND(0x42),
+        BUTTON1_INDICATION(0x43),
+        BUTTON2_INDICATION(0x44),
+        BUTTON3_INDICATION(0x45),
+        BUTTON4_INDICATION(0x46),
+        BUTTON5_INDICATION(0x47),
+        BUTTON6_INDICATION(0x48),
+        BUTTON7_INDICATION(0x49),
+        BUTTON8_INDICATION(0x4A),
+        BUTTON9_INDICATION(0x4B),
+        BUTTON10_INDICATION(0x4C),
+        BUTTON11_INDICATION(0x4D),
+        BUTTON12_INDICATION(0x4E),
+        NODE_IDENTIFY(0x50),
+        BUZZER(0xF0);
 
         /**
-         * Constructor. Creates a new instance of the ZWaveCommandClassValueEvent class.
-         *
-         * @param nodeId the nodeId of the event
-         * @param endpoint the endpoint of the event.
-         * @param commandClass the command class that fired the ZWaveCommandClassValueEvent;
-         * @param the new indicator value for the event.
-         * @param the value currently held by indicator for the event.
+         * A mapping between the integer code and its corresponding type to facilitate lookup by code.
          */
-        public ZWaveIndicatorCommandClassChangeEvent(int nodeId, int endpoint, CommandClass commandClass, int newValue,
-                int oldValue) {
-            super(nodeId, endpoint, commandClass, newValue);
-            this.currentIndicator = oldValue;
+        private static Map<Integer, IndicatorType> codeToTypeMapping;
+
+        private int key;
+
+        private IndicatorType(int key) {
+            this.key = key;
+        }
+
+        private static void initMapping() {
+            codeToTypeMapping = new HashMap<Integer, IndicatorType>();
+            for (IndicatorType s : values()) {
+                codeToTypeMapping.put(s.key, s);
+            }
         }
 
         /**
-         * Gets the value for the event.
+         * Lookup function based on the alarm type code.
+         * Returns null if the code does not exist.
          *
-         * @return the value.
+         * @param i the code to lookup
+         * @return enumeration value of the alarm type.
          */
-        public int getOldValue() {
-            return currentIndicator;
-        }
-
-        public ArrayList<Integer> changes() {
-            ArrayList<Integer> changesList = new ArrayList<Integer>();
-
-            int newIndicator = ((Integer) this.getValue()).intValue();
-
-            int changes = currentIndicator ^ newIndicator;
-
-            for (int i = 0; i < 8; i++) {
-                if ((changes & 0x01) == 0x01) {
-                    changesList.add(i);
-                }
-                changes = changes >> 1;
+        public static IndicatorType getIndicatorType(int i) {
+            if (codeToTypeMapping == null) {
+                initMapping();
             }
-            return changesList;
+
+            return codeToTypeMapping.get(i);
         }
 
-        public boolean isBitOn(int n) {
-            byte newIndicator = ((Integer) this.getValue()).byteValue();
-            if (((newIndicator >> (n - 1)) & 0x01) == 1) {
-                return true;
-            }
-            return false;
+        /**
+         * @return the key
+         */
+        public int getKey() {
+            return key;
         }
+    }
+
+    @XStreamAlias("ZWaveIndicatorProperty")
+    public enum IndicatorProperty {
+        MULTILEVEL(0x01),
+        BINARY(0x02),
+        ON_OFF_PERIOD(0x03),
+        ON_OFF_CYCLES(0x04),
+        ON_TIME_WITH_OFF_PERIOD(0x05),
+        INDICATOR6(0x06),
+        INDICATOR7(0x07),
+        LOW_POWER(0x10);
+
+        /**
+         * A mapping between the integer code and its corresponding type to facilitate lookup by code.
+         */
+        private static Map<Integer, IndicatorProperty> codeToTypeMapping;
+
+        private int key;
+
+        private IndicatorProperty(int key) {
+            this.key = key;
+        }
+
+        private static void initMapping() {
+            codeToTypeMapping = new HashMap<Integer, IndicatorProperty>();
+            for (IndicatorProperty s : values()) {
+                codeToTypeMapping.put(s.key, s);
+            }
+        }
+
+        /**
+         * Lookup function based on the alarm type code.
+         * Returns null if the code does not exist.
+         *
+         * @param i the code to lookup
+         * @return enumeration value of the alarm type.
+         */
+        public static IndicatorProperty getIndicatorProperty(int i) {
+            if (codeToTypeMapping == null) {
+                initMapping();
+            }
+
+            return codeToTypeMapping.get(i);
+        }
+
+        /**
+         * @return the key
+         */
+        public int getKey() {
+            return key;
+        }
+    }
+
+    @XStreamAlias("ZWaveIndicator")
+    public static class ZWaveIndicator {
+        public IndicatorType type;
+        public IndicatorProperty property;
+        public Integer value;
+
+        @Override
+        public String toString() {
+            return "ZWaveIndicator [type=" + type + ", property=" + property + ", value=" + value + "]";
+        }
+
     }
 }

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSwitchCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSwitchCommandClass.java
@@ -204,13 +204,6 @@ public class ZWaveMultiLevelSwitchCommandClass extends ZWaveCommandClass
         return new ZWaveCommandClassTransactionPayloadBuilder(getNode().getNodeId(), getCommandClass(),
                 SWITCH_MULTILEVEL_SUPPORTED_GET).withPriority(TransactionPriority.Config)
                         .withExpectedResponseCommand(SWITCH_MULTILEVEL_SUPPORTED_REPORT).build();
-
-        // SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessageClass.SendData,
-        // SerialMessageType.Request, SerialMessageClass.SendData, SerialMessagePriority.Set);
-        // byte[] newPayload = { (byte) getNode().getNodeId(), 2, (byte) getCommandClass().getKey(),
-        // (byte) SWITCH_MULTILEVEL_SUPPORTED_GET };
-        // result.setMessagePayload(newPayload);
-        // return result;
     }
 
     @Override

--- a/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveIndicatorConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveIndicatorConverterTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.internal.converter;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
+import org.eclipse.smarthome.core.types.State;
+import org.junit.Test;
+import org.openhab.binding.zwave.handler.ZWaveThingChannel;
+import org.openhab.binding.zwave.handler.ZWaveThingChannel.DataType;
+import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveIndicatorCommandClass.IndicatorProperty;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveIndicatorCommandClass.IndicatorType;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveIndicatorCommandClass.ZWaveIndicator;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
+import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZWaveIndicatorConverterTest extends ZWaveCommandClassConverterTest {
+    private ZWaveThingChannel createChannel(String channelType, DataType dataType, String type) {
+        ChannelUID uid = new ChannelUID("zwave:node:bridge:" + channelType);
+        ChannelTypeUID typeUid = new ChannelTypeUID("zwave:" + channelType);
+
+        Map<String, String> args = new HashMap<String, String>();
+        if (type != null) {
+            args.put("type", type);
+        }
+
+        return new ZWaveThingChannel(null, typeUid, uid, dataType, CommandClass.COMMAND_CLASS_INDICATOR.toString(), 0,
+                args);
+    }
+
+    private ZWaveCommandClassValueEvent createEvent(IndicatorType type, IndicatorProperty property, Integer value) {
+        List<ZWaveIndicator> indicators = new ArrayList<ZWaveIndicator>();
+        ZWaveIndicator indicator = new ZWaveIndicator();
+        indicator.type = type;
+        indicator.property = property;
+        indicator.value = value;
+        indicators.add(indicator);
+
+        return new ZWaveCommandClassValueEvent(1, 0, CommandClass.COMMAND_CLASS_INDICATOR, indicators);
+    }
+
+    @Test
+    public void indicatorEventMultiLevel() {
+        ZWaveIndicatorConverter converter = new ZWaveIndicatorConverter(null);
+        ZWaveThingChannel channel = createChannel("indicator_level", DataType.DecimalType,
+                IndicatorType.BUTTON1_INDICATION.toString());
+
+        ZWaveCommandClassValueEvent event = createEvent(IndicatorType.BUTTON1_INDICATION,
+                IndicatorProperty.ON_OFF_CYCLES, 0);
+        State state = converter.handleEvent(channel, event);
+        assertNull(state);
+
+        event = createEvent(IndicatorType.BUTTON1_INDICATION, IndicatorProperty.MULTILEVEL, 42);
+        state = converter.handleEvent(channel, event);
+
+        assertEquals(state.getClass(), PercentType.class);
+        assertEquals(state, new DecimalType(42));
+    }
+
+    @Test
+    public void indicatorSetMultiLevelV1() {
+        ZWaveThingChannel channel = createChannel("indicator_level", DataType.DecimalType,
+                IndicatorType.BUTTON1_INDICATION.toString());
+
+        Map<String, String> options = new HashMap<String, String>();
+        ZWaveNode node = CreateMockedNode(1, options);
+
+        ZWaveIndicatorConverter converter = new ZWaveIndicatorConverter(null);
+        List<ZWaveCommandClassTransactionPayload> transactions = converter.receiveCommand(channel, node,
+                new DecimalType(42));
+
+        assertEquals(1, transactions.size());
+        ZWaveCommandClassTransactionPayload transaction = transactions.get(0);
+
+        assertTrue(Arrays.equals(new byte[] { -121, 1, 42 }, transaction.getPayloadBuffer()));
+    }
+
+    @Test
+    public void indicatorSetMultiLevelV2() {
+        ZWaveThingChannel channel = createChannel("indicator_level", DataType.DecimalType,
+                IndicatorType.BUTTON1_INDICATION.toString());
+
+        Map<String, String> options = new HashMap<String, String>();
+        ZWaveNode node = CreateMockedNode(2, options);
+
+        ZWaveIndicatorConverter converter = new ZWaveIndicatorConverter(null);
+        List<ZWaveCommandClassTransactionPayload> transactions = converter.receiveCommand(channel, node,
+                new DecimalType(42));
+
+        assertEquals(1, transactions.size());
+        ZWaveCommandClassTransactionPayload transaction = transactions.get(0);
+
+        byte[] x = transaction.getPayloadBuffer();
+        assertTrue(Arrays.equals(new byte[] { -121, 1, 0, 1, 67, 1, 42 }, transaction.getPayloadBuffer()));
+    }
+}

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveIndicatorCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveIndicatorCommandClassTest.java
@@ -10,10 +10,11 @@ package org.openhab.binding.zwave.internal.protocol.commandclass;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Test;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
-import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveIndicatorCommandClass;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
 import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
 
 /**
@@ -45,5 +46,26 @@ public class ZWaveIndicatorCommandClassTest extends ZWaveCommandClassTest {
         cls.setVersion(1);
         msg = cls.setValueMessage(34);
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void getSupportedIndicators() {
+        ZWaveIndicatorCommandClass cls = (ZWaveIndicatorCommandClass) getCommandClass(
+                CommandClass.COMMAND_CLASS_INDICATOR);
+        ZWaveCommandClassTransactionPayload msg;
+
+        byte[] expectedResponseV1 = { -121, 4, 0 };
+        cls.setVersion(1);
+        msg = cls.getSupportedIndicators(null);
+        assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void Notification_Burglar_Motion() {
+        byte[] packetData = { 0x01, 0x0C, 0x00, 0x04, 0x00, 0x11, 0x06, (byte) 0x87, 0x05, 0x43, 0x44, 0x01, 0x07,
+                0x63 };
+
+        List<ZWaveEvent> events = processCommandClassMessage(packetData, 2);
+
     }
 }


### PR DESCRIPTION
This adds initial support for the INDICATOR class V2/V3

This adds support for 3 channel types
* *indicator_level* - a dimmer channel to set the level or turn the indicator on/off
* *indicator_period* - a decimal channel to set the flash period
* *indicator_flash* - a decimal channel to set the number of flashes

The database needs to have these channels added, and for V2/V3 there should be an option ```type=XXX``` where ```XXX``` is one of the indicator types supported by the device. These should be found in the XML file after the device is initialised. For V1 of the command class, no option is necessary as the indicators don't provide such properties.

Note that you will need to delete the XML to allow discovery to take place again to discover the indicators and their properties.

Indicator types are as follows -:
```
        NA(0x00),
        ARMED(0x01),
        NOT_ARMED(0x02),
        READY(0x03),
        FAULT(0x04),
        BUSY(0x05),
        ENTER_ID(0x06),
        ENTER_PIN(0x07),
        OK(0x08),
        NOT_OK(0x09),
        ZONE1_ARMED(0x20),
        ZONE2_ARMED(0x21),
        ZONE3_ARMED(0x22),
        ZONE4_ARMED(0x23),
        ZONE5_ARMED(0x24),
        ZONE6_ARMED(0x25),
        LCD_BACKLIGHT(0x30),
        BUTTON_BACKLIGHT_LETTERS(0x40),
        BUTTON_BACKLIGHT_DIGITS(0x41),
        BUTTON_BACKLIGHT_COMMAND(0x42),
        BUTTON1_INDICATION(0x43),
        BUTTON2_INDICATION(0x44),
        BUTTON3_INDICATION(0x45),
        BUTTON4_INDICATION(0x46),
        BUTTON5_INDICATION(0x47),
        BUTTON6_INDICATION(0x48),
        BUTTON7_INDICATION(0x49),
        BUTTON8_INDICATION(0x4A),
        BUTTON9_INDICATION(0x4B),
        BUTTON10_INDICATION(0x4C),
        BUTTON11_INDICATION(0x4D),
        BUTTON12_INDICATION(0x4E),
        NODE_IDENTIFY(0x50),
        BUZZER(0xF0);
```

#690 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>