### PR TITLE
Updated handling of associations

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
+++ b/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
@@ -137,5 +137,7 @@ public class ZWaveBindingConstants {
     public final static String CONFIG_BINDING_CMDREPOLLPERIOD_LABEL = "Command Poll Period";
     public final static String CONFIG_BINDING_CMDREPOLLPERIOD_DESC = "Set the period to wait after a command is sent to a device before polling its state.";
 
+    public final static String GROUP_CONTROLLER = "controller";
+
     public final static Set<ThingTypeUID> SUPPORTED_BRIDGE_TYPES_UIDS = ImmutableSet.of(CONTROLLER_SERIAL);
 }

--- a/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
@@ -523,7 +523,7 @@ public class ZWaveConfigProvider implements ConfigDescriptionProvider, ConfigOpt
         List<ParameterOption> options = new ArrayList<ParameterOption>();
 
         // Add the controller (ie openHAB) to the top of the list
-        options.add(new ParameterOption("node_" + handler.getOwnNodeId() + "_1", "openHAB Controller"));
+        options.add(new ParameterOption(ZWaveBindingConstants.GROUP_CONTROLLER, "Controller"));
 
         // And iterate over all its nodes
         Collection<ZWaveNode> nodes = handler.getNodes();

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveAssociation.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveAssociation.java
@@ -16,17 +16,32 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("associationMember")
 public class ZWaveAssociation {
-    private int node;
-    private Integer endpoint;
+    private final int node;
+    private final Integer endpoint;
 
+    /**
+     * Creates an association linked to a node
+     *
+     * @param node
+     */
     public ZWaveAssociation(int node) {
         this.node = node;
         this.endpoint = null;
     }
 
+    /**
+     * Creates an association linked to an endpoint
+     *
+     * @param node
+     * @param endpoint
+     */
     public ZWaveAssociation(int node, Integer endpoint) {
         this.node = node;
         this.endpoint = endpoint;
+    }
+
+    public boolean isController() {
+        return node == 0;
     }
 
     public int getNode() {

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveAssociationGroup.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveAssociationGroup.java
@@ -33,6 +33,7 @@ import com.thoughtworks.xstream.annotations.XStreamConverter;
 @XStreamAlias("associationGroup")
 public class ZWaveAssociationGroup {
     private int index;
+    private int maxNodes;
     private String name;
 
     @XStreamConverter(HexToIntegerConverter.class)
@@ -41,7 +42,7 @@ public class ZWaveAssociationGroup {
     private Integer profile2;
     private Set<CommandClass> commands;
 
-    List<ZWaveAssociation> associations = new ArrayList<ZWaveAssociation>();
+    private final List<ZWaveAssociation> associations = new ArrayList<ZWaveAssociation>();
 
     public ZWaveAssociationGroup(int index) {
         this.index = index;
@@ -66,47 +67,17 @@ public class ZWaveAssociationGroup {
     }
 
     /**
-     * Adds an association node
-     *
-     * @param node
-     */
-    public void addAssociation(int node) {
-        addAssociation(node, null);
-    }
-
-    /**
      * Adds an association node and endpoint
-     *
-     * @param node
-     * @param endpoint
      */
-    public void addAssociation(int node, Integer endpoint) {
-        // Check if we're already associated
-        if (isAssociated(node, endpoint)) {
-            return;
+    public boolean addAssociation(ZWaveAssociation association) {
+        if (associations.contains(association)) {
+            return false;
         }
-
-        // No - add a new association
-        ZWaveAssociation newAssociation = new ZWaveAssociation(node, endpoint);
-        associations.add(newAssociation);
-    }
-
-    /**
-     * Removes an association node
-     *
-     * @param node
-     * @return
-     */
-    public boolean removeAssociation(int node) {
-        return removeAssociation(node, null);
+        return associations.add(association);
     }
 
     /**
      * Removes an association node and endpoint
-     *
-     * @param node
-     * @param endpoint
-     * @return
      */
     public boolean removeAssociation(int node, Integer endpoint) {
         int associationCnt = associations.size();
@@ -122,42 +93,20 @@ public class ZWaveAssociationGroup {
     }
 
     /**
+     * Removes an association node and endpoint
+     */
+    public void removeAssociation(ZWaveAssociation association) {
+        removeAssociation(association.getNode(), association.getEndpoint());
+    }
+
+    /**
      * Tests if a node is associated to this group
      *
      * @param node
      * @return
      */
     public boolean isAssociated(ZWaveAssociation association) {
-        return isAssociated(association.getNode(), association.getEndpoint());
-    }
-
-    /**
-     * Tests if a node is associated to this group
-     *
-     * @param node
-     * @return
-     */
-    public boolean isAssociated(int node) {
-        return isAssociated(node, null);
-    }
-
-    /**
-     * Tests if a node and endpoint are associated to this group
-     *
-     * @param node
-     * @param endpoint
-     * @return
-     */
-    public boolean isAssociated(int node, Integer endpoint) {
-        int associationCnt = associations.size();
-        for (int index = 0; index < associationCnt; index++) {
-            ZWaveAssociation association = associations.get(index);
-            if (association.getNode() == node && association.getEndpoint() == endpoint) {
-                return true;
-            }
-        }
-
-        return false;
+        return associations.contains(association);
     }
 
     /**
@@ -175,7 +124,8 @@ public class ZWaveAssociationGroup {
      * @param associations
      */
     public void setAssociations(List<ZWaveAssociation> associations) {
-        this.associations = associations;
+        this.associations.clear();
+        this.associations.addAll(associations);
     }
 
     /**
@@ -229,6 +179,14 @@ public class ZWaveAssociationGroup {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public void setMaxNodes(int maxNodes) {
+        this.maxNodes = maxNodes;
+    }
+
+    public int getMaxNodes() {
+        return maxNodes;
     }
 
     @Override

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -976,7 +976,7 @@ public class ZWaveNode {
      *
      * @param groupId the group to be set
      * @param member the {@link ZWaveAssociation} to be set to report to (receive)
-     * @return {@link ZWaveTransaction}
+     * @return {@link ZWaveCommandClassTransactionPayload}
      */
     public ZWaveCommandClassTransactionPayload removeAssociation(Integer groupId, ZWaveAssociation member) {
         if (endpoints.size() > 1) {

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionManager.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionManager.java
@@ -717,7 +717,9 @@ public class ZWaveTransactionManager {
         for (ZWaveTransaction tmp : queue) {
             ZWaveNode node = controller.getNode(tmp.getNodeId());
             if (node == null) {
-                logger.debug("NODE {}: Node not found - has this node been removed?!?", tmp.getNodeId());
+                logger.debug("NODE {}: Node not found - has this node been removed?!? Dropping transaction {}.",
+                        tmp.getNodeId(), tmp);
+                queue.remove(tmp);
                 continue;
             }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAssociationCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAssociationCommandClass.java
@@ -10,6 +10,7 @@ package org.openhab.binding.zwave.internal.protocol.commandclass;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import org.openhab.binding.zwave.internal.protocol.ZWaveAssociation;
 import org.openhab.binding.zwave.internal.protocol.ZWaveAssociationGroup;
 import org.openhab.binding.zwave.internal.protocol.ZWaveCommandClassPayload;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
@@ -127,7 +128,7 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass implements Z
                 logger.debug("Node {}", node);
 
                 // Add the node to the group
-                pendingAssociation.addAssociation(node);
+                pendingAssociation.addAssociation(new ZWaveAssociation(node));
             }
         }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiAssociationCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiAssociationCommandClass.java
@@ -11,6 +11,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import org.openhab.binding.zwave.internal.protocol.ZWaveAssociation;
 import org.openhab.binding.zwave.internal.protocol.ZWaveAssociationGroup;
 import org.openhab.binding.zwave.internal.protocol.ZWaveCommandClassPayload;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
@@ -136,7 +137,7 @@ public class ZWaveMultiAssociationCommandClass extends ZWaveCommandClass impleme
                 logger.debug("NODE {}: Associated with Node {} in group {}", getNode().getNodeId(), node, group);
 
                 // Add the node to the group
-                pendingAssociation.addAssociation(node);
+                pendingAssociation.addAssociation(new ZWaveAssociation(node));
             }
 
             // Process the multi instance associations
@@ -155,7 +156,7 @@ public class ZWaveMultiAssociationCommandClass extends ZWaveCommandClass impleme
                             endpointId, group);
 
                     // Add the node to the group
-                    pendingAssociation.addAssociation(node, endpointId);
+                    pendingAssociation.addAssociation(new ZWaveAssociation(node, endpointId));
                 }
             }
         }

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -698,8 +698,8 @@ public class ZWaveNodeInitStageAdvancer {
                 if (node.getEndpoint(endpoint) != null) {
                     logger.debug("NODE {}: Node advancer: UPDATE_DATABASE - endpoint found {}", node.getNodeId(),
                             endpoint);
-                    ZWaveCommandClass zwaveClass = node.getEndpoint(endpoint)
-                            .getCommandClass(CommandClass.getCommandClass(cmds[1]));
+                    CommandClass commandClass = CommandClass.getCommandClass(cmds[1]);
+                    ZWaveCommandClass zwaveClass = node.getEndpoint(endpoint).getCommandClass(commandClass);
 
                     // If we found the command class, then set its options
                     if (zwaveClass != null) {

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/ZWaveAssociationGroupTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/ZWaveAssociationGroupTest.java
@@ -10,44 +10,42 @@ package org.openhab.binding.zwave.internal.protocol;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
-import org.openhab.binding.zwave.internal.protocol.ZWaveAssociation;
-import org.openhab.binding.zwave.internal.protocol.ZWaveAssociationGroup;
 
 public class ZWaveAssociationGroupTest {
     @Test
     public void TestAssociationGroup() {
         ZWaveAssociationGroup group = new ZWaveAssociationGroup(1);
 
-        group.addAssociation(1);
+        group.addAssociation(new ZWaveAssociation(1));
         assertEquals(1, group.getAssociationCnt());
-        assertTrue(group.isAssociated(1));
-        assertFalse(group.isAssociated(1, 0));
+        assertTrue(group.isAssociated(new ZWaveAssociation(1)));
+        assertFalse(group.isAssociated(new ZWaveAssociation(1, 0)));
 
-        group.addAssociation(1);
+        group.addAssociation(new ZWaveAssociation(1));
         assertEquals(1, group.getAssociationCnt());
 
-        group.removeAssociation(1);
+        group.removeAssociation(new ZWaveAssociation(1));
         assertEquals(0, group.getAssociationCnt());
-        group.addAssociation(1);
+        group.addAssociation(new ZWaveAssociation(1));
 
-        group.addAssociation(1, 0);
+        group.addAssociation(new ZWaveAssociation(1, 0));
         assertEquals(2, group.getAssociationCnt());
 
-        group.addAssociation(3, 2);
+        group.addAssociation(new ZWaveAssociation(3, 2));
         assertEquals(3, group.getAssociationCnt());
 
-        group.removeAssociation(3, 2);
+        group.removeAssociation(new ZWaveAssociation(3, 2));
         assertEquals(2, group.getAssociationCnt());
     }
 
     @Test
     public void testIsAssociated() {
         ZWaveAssociationGroup group = new ZWaveAssociationGroup(1);
-        group.addAssociation(1);
-        assertTrue(group.isAssociated(1));
-        assertFalse(group.isAssociated(2));
-        assertFalse(group.isAssociated(1, 0));
-        assertFalse(group.isAssociated(1, 2));
+        group.addAssociation(new ZWaveAssociation(1));
+        assertTrue(group.isAssociated(new ZWaveAssociation(1)));
+        assertFalse(group.isAssociated(new ZWaveAssociation(2)));
+        assertFalse(group.isAssociated(new ZWaveAssociation(1, 0)));
+        assertFalse(group.isAssociated(new ZWaveAssociation(1, 2)));
 
         ZWaveAssociation association = new ZWaveAssociation(1);
         assertTrue(group.isAssociated(association));
@@ -55,7 +53,7 @@ public class ZWaveAssociationGroupTest {
         association = new ZWaveAssociation(1, 1);
         assertFalse(group.isAssociated(association));
 
-        group.addAssociation(1, 1);
+        group.addAssociation(new ZWaveAssociation(1, 1));
         association = new ZWaveAssociation(1, 1);
         assertTrue(group.isAssociated(association));
     }

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/ZWaveNodeTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/ZWaveNodeTest.java
@@ -13,11 +13,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
-import org.openhab.binding.zwave.internal.protocol.ZWaveAssociation;
-import org.openhab.binding.zwave.internal.protocol.ZWaveCommandClassPayload;
-import org.openhab.binding.zwave.internal.protocol.ZWaveController;
-import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
-import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAssociationCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiAssociationCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiInstanceCommandClass;
@@ -47,6 +42,13 @@ public class ZWaveNodeTest {
         msg = node.setAssociation(0, new ZWaveAssociation(5, 0));
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponse));
 
+        // Setting device endpoint null and receive endpoint 0 should use single instance when only 1 endpoint in the
+        // node
+        expectedResponse = new byte[] { -123, 1, 0, 5 };
+        msg = node.setAssociation(0, new ZWaveAssociation(5, 1));
+        byte[] a = msg.getPayloadBuffer();
+        assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponse));
+
         // Setting device endpoint null and receive endpoint 0 should use multi instance when more than 1 endpoint
         expectedResponse = new byte[] { -114, 1, 0, 5 };
         node.addEndpoint(1);
@@ -56,6 +58,12 @@ public class ZWaveNodeTest {
         // Setting device endpoint null and receive endpoint 1 should use multi instance
         expectedResponse = new byte[] { -114, 1, 0, 0, 5, 1 };
         msg = node.setAssociation(0, new ZWaveAssociation(5, 1));
+        assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponse));
+
+        // Setting device endpoint null and receive endpoint 0 should use single instance
+        expectedResponse = new byte[] { -114, 1, 0, 5 };
+        msg = node.setAssociation(0, new ZWaveAssociation(5));
+        byte[] x = msg.getPayloadBuffer();
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponse));
     }
 

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiAssociationCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiAssociationCommandClassTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 
 import org.junit.Test;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
-import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiAssociationCommandClass;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveAssociationEvent;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
 import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
@@ -127,7 +126,7 @@ public class ZWaveMultiAssociationCommandClassTest extends ZWaveCommandClassTest
         assertEquals(event.getEndpoint(), 0);
         assertEquals(event.getGroupId(), 2);
         assertEquals(event.getGroupMembers().size(), 1);
-        assertEquals(event.getGroupMembers().get(0).getNode(), 1);
-        assertEquals(event.getGroupMembers().get(0).getEndpoint(), Integer.valueOf(1));
+        assertEquals(event.getGroupMembers().iterator().next().getNode(), 1);
+        assertEquals(event.getGroupMembers().iterator().next().getEndpoint(), Integer.valueOf(1));
     }
 }


### PR DESCRIPTION
This introduces a proxy for the controller rather than specifying the node and endpoint. This then allows the binding to decide what endpoint to use, and therefore what command class to use.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>