### PR TITLE
Fix: Actually set node to failed, proper logging for remove node

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
@@ -742,7 +742,7 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
         if (controller == null) {
             return;
         }
-        controller.requestRemoveFailedNode(nodeId);
+        controller.requestSetFailedNode(nodeId);
     }
 
     public void reinitialiseNode(int nodeId) {

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RemoveFailedNodeMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RemoveFailedNodeMessageClass.java
@@ -54,7 +54,7 @@ public class RemoveFailedNodeMessageClass extends ZWaveCommandProcessor {
     }
 
     public ZWaveSerialPayload doRequest(int nodeId) {
-        logger.debug("NODE {}: Marking node as having failed.", nodeId);
+        logger.debug("NODE {}: Removing failed node.", nodeId);
 
         // Create the request
         return new ZWaveTransactionMessageBuilder(SerialMessageClass.RemoveFailedNodeID).withPayload(nodeId, 1).build();


### PR DESCRIPTION
Issue: I am having trouble deleting a node that is no longer on my zwave network. When debugging what is happening, I found these two small obvious bugs.

Note: I still cannot confirm that this fixes my root issue (removing dead nodes), but at least now the code does what is requested (setting to failed, printing proper debug message). Unfortunately I now need to wait for my zwave network to quit down before I can investigate further.


