### PR TITLE
Ignore any configuration updates that do not change values

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.ScheduledFuture;
@@ -567,6 +568,14 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
         Configuration configuration = editConfiguration();
         for (Entry<String, Object> configurationParameter : configurationParameters.entrySet()) {
             Object valueObject = configurationParameter.getValue();
+            // Ignore any configuration parameters that have not changed
+            if (Objects.equals(configurationParameter.getValue(), configuration.get(configurationParameter.getKey()))) {
+                logger.debug("NODE {}: Configuration update ignored {} to {} ({})", nodeId,
+                        configurationParameter.getKey(), valueObject,
+                        valueObject == null ? "null" : valueObject.getClass().getSimpleName());
+                continue;
+            }
+
             logger.debug("NODE {}: Configuration update set {} to {} ({})", nodeId, configurationParameter.getKey(),
                     valueObject, valueObject == null ? "null" : valueObject.getClass().getSimpleName());
             String[] cfg = configurationParameter.getKey().split("_");

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiAssociationCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiAssociationCommandClass.java
@@ -269,8 +269,8 @@ public class ZWaveMultiAssociationCommandClass extends ZWaveCommandClass impleme
         logger.debug("NODE {}: Creating new message for command MULTI_ASSOCIATIONCMD_REMOVE", getNode().getNodeId());
 
         return new ZWaveCommandClassTransactionPayloadBuilder(getNode().getNodeId(), getCommandClass(),
-                MULTI_ASSOCIATIONCMD_REMOVE).withPayload(group, 0, node, endpoint).withPriority(TransactionPriority.Get)
-                        .build();
+                MULTI_ASSOCIATIONCMD_REMOVE).withPayload(group, 0, node, endpoint)
+                        .withPriority(TransactionPriority.Config).build();
     }
 
     /**


### PR DESCRIPTION
This ignores any configuration updates that have a value that is the same as the current value. In this event, they will not be processed. This reduces the amount of network traffic.

This also fixes the priority of the MULTI_ASSOCIATIONCMD_REMOVE command which is set to Config to be inline with other commands in this class to avoid any issues with re-ordering.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>