### PR TITLE
Add door_sensor channel from door lock command class

### DIFF
--- a/ESH-INF/thing/august/asl03_0_0.xml
+++ b/ESH-INF/thing/august/asl03_0_0.xml
@@ -14,6 +14,12 @@ August Smart Lock Pro 3rd Gen<br /><h1>Overview</h1><p>Give your customer total 
 
     <!-- CHANNEL DEFINITIONS -->
     <channels>
+      <channel id="sensor_door" typeId="sensor_door">
+        <label>Door State Sensor</label>
+        <properties>
+          <property name="binding:*:OpenClosedType">COMMAND_CLASS_DOOR_LOCK</property>
+        </properties>
+      </channel>
       <channel id="lock_door" typeId="lock_door">
         <label>Door State Sensor</label>
         <properties>

--- a/ESH-INF/thing/channels.xml
+++ b/ESH-INF/thing/channels.xml
@@ -414,12 +414,18 @@
         <category></category>
     </channel-type>
 
-    <!-- Color Temperature Channel -->
+    <!-- Door Lock Channel -->
     <channel-type id="lock_door">
         <item-type>Switch</item-type>
         <label>Door Lock</label>
         <description>Lock and unlock the door</description>
         <category>Door</category>
+        <state>
+            <options>
+                <option value="ON">Locked</option>
+                <option value="OFF">Unlocked</option>
+            </options>
+        </state>
     </channel-type>
 
     <!-- Energy - Current Consumption -->

--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -1428,7 +1428,9 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
                 case SUC_ROUTE:
                 case DELETE_ROUTES:
                 case RETURN_ROUTES:
+                    break;
                 case DONE:
+                    updateStatus(ThingStatus.ONLINE);
                     break;
                 default:
                     if (finalTypeSet) {

--- a/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveDoorLockConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveDoorLockConverterTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.internal.converter;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.OpenClosedType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
+import org.eclipse.smarthome.core.types.State;
+import org.junit.Test;
+import org.openhab.binding.zwave.handler.ZWaveThingChannel;
+import org.openhab.binding.zwave.handler.ZWaveThingChannel.DataType;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveDoorLockCommandClass;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZWaveDoorLockConverterTest extends ZWaveCommandClassConverterTest {
+    final ChannelUID uidLockDoor = new ChannelUID("zwave:node:bridge:lock_door");
+    final ChannelTypeUID typeUidLockDoor = new ChannelTypeUID("zwave:lock_door");
+    final ChannelUID uidSensorDoor = new ChannelUID("zwave:node:bridge:sensor_door");
+    final ChannelTypeUID typeUidSensorDoor = new ChannelTypeUID("zwave:sensor_door");
+
+    @Test
+    public void Event_DoorLockState() {
+        ZWaveDoorLockConverter converter = new ZWaveDoorLockConverter(null);
+        ZWaveThingChannel channel = new ZWaveThingChannel(null, typeUidLockDoor, uidLockDoor, DataType.OnOffType,
+                CommandClass.COMMAND_CLASS_DOOR_LOCK.toString(), 0, new HashMap<String, String>());
+
+        State state;
+        ZWaveCommandClassValueEvent event;
+
+        event = new ZWaveCommandClassValueEvent(1, 0, CommandClass.COMMAND_CLASS_DOOR_LOCK, 0,
+                ZWaveDoorLockCommandClass.Type.DOOR_LOCK_STATE);
+        state = converter.handleEvent(channel, event);
+        assertEquals(OnOffType.class, state.getClass());
+        assertEquals(state, OnOffType.OFF);
+
+        event = new ZWaveCommandClassValueEvent(1, 0, CommandClass.COMMAND_CLASS_DOOR_LOCK, 1,
+                ZWaveDoorLockCommandClass.Type.DOOR_LOCK_STATE);
+        state = converter.handleEvent(channel, event);
+        assertEquals(OnOffType.class, state.getClass());
+        assertEquals(state, OnOffType.ON);
+    }
+
+    @Test
+    public void Event_DoorLockCondition() {
+        ZWaveDoorLockConverter converter = new ZWaveDoorLockConverter(null);
+        ZWaveThingChannel channel = new ZWaveThingChannel(null, typeUidSensorDoor, uidSensorDoor,
+                DataType.OpenClosedType, CommandClass.COMMAND_CLASS_DOOR_LOCK.toString(), 0,
+                new HashMap<String, String>());
+
+        State state;
+        ZWaveCommandClassValueEvent event;
+
+        event = new ZWaveCommandClassValueEvent(1, 0, CommandClass.COMMAND_CLASS_DOOR_LOCK, 0,
+                ZWaveDoorLockCommandClass.Type.DOOR_CONDITION);
+        state = converter.handleEvent(channel, event);
+        assertEquals(OpenClosedType.class, state.getClass());
+        assertEquals(state, OpenClosedType.OPEN);
+
+        event = new ZWaveCommandClassValueEvent(1, 0, CommandClass.COMMAND_CLASS_DOOR_LOCK, 1,
+                ZWaveDoorLockCommandClass.Type.DOOR_CONDITION);
+        state = converter.handleEvent(channel, event);
+        assertEquals(OpenClosedType.class, state.getClass());
+        assertEquals(state, OpenClosedType.CLOSED);
+    }
+}


### PR DESCRIPTION
Adds a ```door_sensor``` channel that is activated from the door lock command class.

Closes #1034 

@mhilbush please can you test this.

https://www.cd-jackson.com/downloads/openhab2/org.openhab.binding.zwave_2.4.0.201810200955.jar

Signed-off-by: Chris Jackson <chris@cd-jackson.com>