### PR TITLE
Force associations in specific circumstances

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
@@ -767,6 +767,10 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
         return true;
     }
 
+    public boolean isControllerMaster() {
+        return isMaster;
+    }
+
     private void updateNeighbours() {
         if (controller == null) {
             return;

--- a/src/test/java/org/openhab/binding/zwave/handler/ZWaveThingHandlerTest.java
+++ b/src/test/java/org/openhab/binding/zwave/handler/ZWaveThingHandlerTest.java
@@ -71,6 +71,8 @@ public class ZWaveThingHandlerTest {
         ZWaveController controller = Mockito.mock(ZWaveController.class);
         ZWaveControllerHandler controllerHandler = Mockito.mock(ZWaveControllerHandler.class);
 
+        Mockito.when(controllerHandler.isControllerMaster()).thenReturn(false);
+
         ThingHandlerCallback thingCallback = Mockito.mock(ThingHandlerCallback.class);
         ZWaveThingHandler thingHandler = new ZWaveThingHandlerForTest(thing);
         thingHandler.setCallback(thingCallback);
@@ -82,7 +84,6 @@ public class ZWaveThingHandlerTest {
             ZWaveNodeNamingCommandClass namingClass = new ZWaveNodeNamingCommandClass(node, controller, null);
 
             Mockito.doNothing().when(node).sendMessage(payloadCaptor.capture());
-            Mockito.doNothing().when(thingCallback).thingUpdated(Matchers.any(Thing.class));
 
             fieldControllerHandler = ZWaveThingHandler.class.getDeclaredField("controllerHandler");
             fieldControllerHandler.setAccessible(true);
@@ -224,5 +225,16 @@ public class ZWaveThingHandlerTest {
         // Check that there are only 2 requests - the SET and GET
         // Note that these are currently null due to mocking
         assertEquals(2, response.size());
+    }
+
+    @Test
+    public void testConfigurationAssociationStringArray() {
+        List<ZWaveCommandClassTransactionPayload> response = doConfigurationUpdateCommands("group_1", "[node_1]");
+
+        // Check that there are only 2 requests - the SET and GET
+        // Note that these are currently null due to mocking
+        assertEquals(2, response.size());
+
+        response = doConfigurationUpdateCommands("group_1", "[node_1, node_2_1, node_2]");
     }
 }


### PR DESCRIPTION
This will prevent associations being removed if the system needs them, and the controller is configured as ```master```. The PR searches to see if the database has an association configured, or if the association is the ZWave Plus ```Lifeline``` group. If so, it will set the association - thus preventing the user from removing it.

This is to avoid the system becoming unusable due to either lack of knowledge by users, or, through UI problems causing associations to be removed.

It also transpired that somewhere in the system (either in the UI, or in ESH) the arrays/lists are not being parsed correctly and the array is being presented as a string (eg ```[node_1, node_2]```). Code has now been added to handle this format!

Signed-off-by: Chris Jackson <chris@cd-jackson.com>