### PR TITLE
Add all available event parameters to alarm_raw JSON data.

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
@@ -313,6 +313,12 @@ public class ZWaveAlarmConverter extends ZWaveCommandClassConverter {
                                 object.put("code", eventAlarm.getParameters()[0]);
                                 break;
                             default:
+                                // Include any parameters present.
+                                // Expand array since propertiesToJson does not support arrays.
+                                int[] params = eventAlarm.getParameters();
+                                for (int i = 0; i < params.length; i++) {
+                                    object.put("parameter-" + (i + 1), params[i]);
+                                }
                                 break;
                         }
                     }

--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
@@ -307,18 +307,21 @@ public class ZWaveAlarmConverter extends ZWaveCommandClassConverter {
                 if (notificationEvent != null) {
                     object.put("notification", notificationEvent.toString());
                     if (eventAlarm.getParameters() != null) {
+
+                        // Include any parameters present.
+                        // Expand array since propertiesToJson does not support arrays.
+                        int[] params = eventAlarm.getParameters();
+                        for (int i = 0; i < params.length; i++) {
+                            object.put("parameter-" + (i + 1), params[i]);
+                        }
+
+                        // Special cases kept for backwards compatibility.
                         switch (notificationEvent) {
                             case ACCESS_CONTROL__KEYPAD_LOCK:
                             case ACCESS_CONTROL__KEYPAD_UNLOCK:
                                 object.put("code", eventAlarm.getParameters()[0]);
                                 break;
                             default:
-                                // Include any parameters present.
-                                // Expand array since propertiesToJson does not support arrays.
-                                int[] params = eventAlarm.getParameters();
-                                for (int i = 0; i < params.length; i++) {
-                                    object.put("parameter-" + (i + 1), params[i]);
-                                }
                                 break;
                         }
                     }


### PR DESCRIPTION
Generalized handling of event parameter data.
This way any parameter values that are present on an event gets included in the alarm_raw JSON.
(ACCESS_CONTROL__KEYPAD_LOCK and UNLOCK will still only include the first parameter value as "code")

Signed-off-by: Jesper Weissglas <jesper@journeyman.se>