### PR TITLE
Support for disabling energy reports on Fibaro FGD212

### DIFF
--- a/ESH-INF/thing/fibaro/fgd212_0_0.xml
+++ b/ESH-INF/thing/fibaro/fgd212_0_0.xml
@@ -658,7 +658,7 @@ Time period between consecutive reports.<br /><h1>Overview</h1><p>Parameter 52 d
       </parameter>
 
       <parameter name="config_53_2" type="integer" groupName="configuration"
-                 min="1" max="255">
+                 min="0" max="255">
         <label>53: Energy reports</label>
         <description><![CDATA[
 Energy level change resulting in sending a new energy report.<br /><h1>Overview</h1><p>Energy level change which will result in sending a new energy report. Available settings: 1-255 (0,01 - 2,55 kWh). 0 disables the function.</p>

--- a/ESH-INF/thing/fibaro/fgd212_3_5.xml
+++ b/ESH-INF/thing/fibaro/fgd212_3_5.xml
@@ -654,7 +654,7 @@ Time period between consecutive reports<br /><h1>Overview</h1><p>Parameter 52 de
       </parameter>
 
       <parameter name="config_53_2" type="integer" groupName="configuration"
-                 min="1" max="255">
+                 min="0" max="255">
         <label>53: Energy reports</label>
         <description><![CDATA[
 Energy level change resulting in energy report sent<br /><h1>Overview</h1><p>Energy level change which will result in sending a new energy report. Available settings: 1-255 (0,01 - 2,55 kWh). 0 disables the function.</p>


### PR DESCRIPTION
Currently it's not possible to completely disable energy reports on the Fibaro FGD212 module, since this parameter can not be set to 0 in the GUI. The documentation states however that this value of 0 is valid. This PR changes the minimum value for the parameter. 