### PR TITLE
Improve error handling at node initialization (Issue 1121)

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSecurityCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSecurityCommandClass.java
@@ -395,7 +395,7 @@ public class ZWaveSecurityCommandClass extends ZWaveCommandClass {
 
         byte[] keyBytes = parseNetworkKeyAsHexString(value);
 
-        if(keyBytes!=null) {
+        if (keyBytes != null) {
             networkKey = new SecretKeySpec(keyBytes, AES);
             logger.debug("NODE {}: Updated networkKey", getNode().getNodeId());
 
@@ -423,7 +423,7 @@ public class ZWaveSecurityCommandClass extends ZWaveCommandClass {
             }
             return keyBytes;
         } catch (NumberFormatException e) {
-            throw new RuntimeException("Error parsing network key as an hex string. Parsed string was "+hexString,e);
+            throw new RuntimeException("Error parsing network key as an hex string. Parsed string was " + hexString, e);
         }
     }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -209,7 +209,7 @@ public class ZWaveNodeInitStageAdvancer {
 
                     setCurrentStage(ZWaveNodeInitStage.DONE);
                 } catch (Exception e) {
-                    logger.error("NODE {}: Error in initialization thread",node.getNodeId(),e);
+                    logger.error("NODE {}: Error in initialization thread", node.getNodeId(), e);
                 }
             }
         };

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -172,41 +172,45 @@ public class ZWaveNodeInitStageAdvancer {
         initialisationThread = new Thread() {
             @Override
             public void run() {
-                if (node.getInclusionTimer() < INCLUSION_TIMER) {
-                    logger.debug("NODE {}: Node advancer: Node just included ({})", node.getNodeId(),
-                            node.getInclusionTimer());
-                    doInitialInclusionStages();
-                } else if (currentStage == ZWaveNodeInitStage.HEAL_START) {
-                    doHealStages();
+                try {
+                    if (node.getInclusionTimer() < INCLUSION_TIMER) {
+                        logger.debug("NODE {}: Node advancer: Node just included ({})", node.getNodeId(),
+                                node.getInclusionTimer());
+                        doInitialInclusionStages();
+                    } else if (currentStage == ZWaveNodeInitStage.HEAL_START) {
+                        doHealStages();
+                        setCurrentStage(ZWaveNodeInitStage.DONE);
+                        return;
+                    } else {
+                        doInitialStages();
+                    }
+
+                    if (currentStage == ZWaveNodeInitStage.DONE) {
+                        return;
+                    }
+
+                    // If restored from a config file, jump to the dynamic node stage.
+                    if (isRestoredFromConfigfile()) {
+                        logger.debug("NODE {}: Node advancer: Restored from file - skipping static initialisation",
+                                node.getNodeId());
+                        currentStage = ZWaveNodeInitStage.SESSION_START;
+                    }
+                    if (currentStage.ordinal() <= ZWaveNodeInitStage.INCLUSION_START.ordinal()) {
+                        doSecureStages();
+                    }
+                    if (currentStage.ordinal() <= ZWaveNodeInitStage.STATIC_VALUES.ordinal()) {
+                        doStaticStages();
+                    }
+                    setCurrentStage(ZWaveNodeInitStage.STATIC_END);
+                    if (currentStage.ordinal() <= ZWaveNodeInitStage.DYNAMIC_VALUES.ordinal()) {
+                        doDynamicStages();
+                    }
+                    setCurrentStage(ZWaveNodeInitStage.DYNAMIC_END);
+
                     setCurrentStage(ZWaveNodeInitStage.DONE);
-                    return;
-                } else {
-                    doInitialStages();
+                } catch (Exception e) {
+                    logger.error("NODE {}: Error in initialization thread",node.getNodeId(),e);
                 }
-
-                if (currentStage == ZWaveNodeInitStage.DONE) {
-                    return;
-                }
-
-                // If restored from a config file, jump to the dynamic node stage.
-                if (isRestoredFromConfigfile()) {
-                    logger.debug("NODE {}: Node advancer: Restored from file - skipping static initialisation",
-                            node.getNodeId());
-                    currentStage = ZWaveNodeInitStage.SESSION_START;
-                }
-                if (currentStage.ordinal() <= ZWaveNodeInitStage.INCLUSION_START.ordinal()) {
-                    doSecureStages();
-                }
-                if (currentStage.ordinal() <= ZWaveNodeInitStage.STATIC_VALUES.ordinal()) {
-                    doStaticStages();
-                }
-                setCurrentStage(ZWaveNodeInitStage.STATIC_END);
-                if (currentStage.ordinal() <= ZWaveNodeInitStage.DYNAMIC_VALUES.ordinal()) {
-                    doDynamicStages();
-                }
-                setCurrentStage(ZWaveNodeInitStage.DYNAMIC_END);
-
-                setCurrentStage(ZWaveNodeInitStage.DONE);
             }
         };
         initialisationThread.setName("ZWaveNode" + node.getNodeId() + "Init"


### PR DESCRIPTION
Closes #1121 
- A try/catch block was added to catch any non controlled error in initialization thread
- A friendly user is logged if network key isn't parseable

Sample output
![image](https://user-images.githubusercontent.com/920260/51772035-3def3100-20eb-11e9-9211-324cf8ff9ec0.png)


Signed-off-by: Joan Pujol <joanpujol@gmail.com> 