### PR TITLE
Add command class protection to support device lock

### DIFF
--- a/ESH-INF/thing/fibaro/fgkf601_0_0.xml
+++ b/ESH-INF/thing/fibaro/fgkf601_0_0.xml
@@ -25,6 +25,12 @@ Keyfob<br /><h1>Overview</h1><p>FIBARO KeyFob is a Z-Wave Plus compatible, batte
           <property name="binding:*:PercentType">COMMAND_CLASS_BATTERY</property>
         </properties>
       </channel>
+      <channel id="protection_local" typeId="protection_local">
+        <label>Local Device Protection</label>
+        <properties>
+        <property name="binding:*:DecimalType">COMMAND_CLASS_PROTECTION;type=PROTECTION_LOCAL</property>
+        </properties>
+      </channel>
     </channels>
 
     <!-- DEVICE PROPERTY DEFINITIONS -->


### PR DESCRIPTION
Command class protection is needed to enable device lock.

In the manual:

> To enable Lock Mode:
• set sequence in parameter 1,
• set time and/or locking button in parameter 2 (60 seconds by default),
• set PROTECTION Command Class to Local Protection by Sequence (done automatically by home Center controller)