### PR TITLE
Add start stop channel for Aeotec swipe

### DIFF
--- a/ESH-INF/thing/aeon/zw130_0_0.xml
+++ b/ESH-INF/thing/aeon/zw130_0_0.xml
@@ -31,10 +31,20 @@ WallMote Quad<br /><h1>Overview</h1><p>Aeotec WallMote Quad is an intelligent Z-
           <property name="binding:*:PercentType">COMMAND_CLASS_BATTERY</property>
         </properties>
       </channel>
+      <channel id="switch_startstop1" typeId="switch_startstop">
+        <label>Swipe Switch 1</label>
+        <properties>
+        </properties>
+      </channel>
       <channel id="scene_number1" typeId="scene_number">
         <label>Scene Number 1</label>
         <properties>
           <property name="binding:*:DecimalType">COMMAND_CLASS_CENTRAL_SCENE:1</property>
+        </properties>
+      </channel>
+      <channel id="switch_startstop2" typeId="switch_startstop">
+        <label>Swipe Switch 2</label>
+        <properties>
         </properties>
       </channel>
       <channel id="scene_number2" typeId="scene_number">
@@ -43,10 +53,20 @@ WallMote Quad<br /><h1>Overview</h1><p>Aeotec WallMote Quad is an intelligent Z-
           <property name="binding:*:DecimalType">COMMAND_CLASS_CENTRAL_SCENE:2</property>
         </properties>
       </channel>
+      <channel id="switch_startstop3" typeId="switch_startstop">
+        <label>Swipe Switch 3</label>
+        <properties>
+        </properties>
+      </channel>
       <channel id="scene_number3" typeId="scene_number">
         <label>Scene Number 3</label>
         <properties>
           <property name="binding:*:DecimalType">COMMAND_CLASS_CENTRAL_SCENE:3</property>
+        </properties>
+      </channel>
+      <channel id="switch_startstop4" typeId="switch_startstop">
+        <label>Swipe Switch 4</label>
+        <properties>
         </properties>
       </channel>
       <channel id="scene_number4" typeId="scene_number">

--- a/ESH-INF/thing/channels.xml
+++ b/ESH-INF/thing/channels.xml
@@ -1126,6 +1126,14 @@
         <category>Switch</category>
     </channel-type>
 
+    <!-- Switch Start/Stop Channel -->
+    <channel-type id="switch_startstop">
+        <item-type>String</item-type>
+        <label>StartStop Switch</label>
+        <description>Switch indicating direction</description>
+        <category>Switch</category>
+    </channel-type>
+
     <!-- Brightness (Dimmer) Channel -->
     <channel-type id="switch_dimmer">
         <item-type>Dimmer</item-type>

--- a/doc/aeon/zw130_0_0.md
+++ b/doc/aeon/zw130_0_0.md
@@ -59,15 +59,18 @@ The following table summarises the channels available for the ZW130 -:
 | Channel | Channel Id | Category | Item Type |
 |---------|------------|----------|-----------|
 | Scene Number | scene_number |  | Number | 
-| Alarm (power) | alarm_power | Door | Switch | 
+| Alarm (power) | alarm_power | Energy | Switch | 
 | Battery Level | battery-level | Battery | Number |
+| Swipe Switch 1 | switch_startstop1 | Switch | String | 
 | Scene Number 1 | scene_number1 |  | Number | 
+| Swipe Switch 2 | switch_startstop2 | Switch | String | 
 | Scene Number 2 | scene_number2 |  | Number | 
+| Swipe Switch 3 | switch_startstop3 | Switch | String | 
 | Scene Number 3 | scene_number3 |  | Number | 
+| Swipe Switch 4 | switch_startstop4 | Switch | String | 
 | Scene Number 4 | scene_number4 |  | Number | 
 
 ### Scene Number
-
 Triggers when a scene button is pressed.
 
 The ```scene_number``` channel supports the ```Number``` item.
@@ -84,10 +87,9 @@ This channel provides the scene, and the event as a decimal value in the form ``
 | 6        | 5 x keypress       |
 
 ### Alarm (power)
-
 Indicates if a power alarm is triggered.
 
-The ```alarm_power``` channel supports the ```Switch``` item and is in the ```Door``` category. This is a read only channel so will only be updated following state changes from the device.
+The ```alarm_power``` channel supports the ```Switch``` item and is in the ```Energy``` category. This is a read only channel so will only be updated following state changes from the device.
 
 The following state translation is provided for this channel to the ```Switch``` item type -:
 
@@ -97,13 +99,16 @@ The following state translation is provided for this channel to the ```Switch```
 | ON | Alarm |
 
 ### Battery Level
-
 Represents the battery level as a percentage (0-100%). Bindings for things supporting battery level in a different format (e.g. 4 levels) should convert to a percentage to provide a consistent battery level reading.
 
 The ```battery-level``` channel supports the ```Number``` item and is in the ```Battery``` category.
 
-### Scene Number 1
+### Swipe Switch 1
+Switch indicating direction.
 
+The ```switch_startstop1``` channel supports the ```String``` item and is in the ```Switch``` category.
+This channel provides the start/stop state of a switch as a JSON string. It is designed for use in rules and will indicate the direction of travel of the switch as INCREASE, DECREASE, STOP.
+### Scene Number 1
 Triggers when a scene button is pressed.
 
 The ```scene_number1``` channel supports the ```Number``` item.
@@ -119,8 +124,12 @@ This channel provides the scene, and the event as a decimal value in the form ``
 | 5        | 4 x keypress       |
 | 6        | 5 x keypress       |
 
-### Scene Number 2
+### Swipe Switch 2
+Switch indicating direction.
 
+The ```switch_startstop2``` channel supports the ```String``` item and is in the ```Switch``` category.
+This channel provides the start/stop state of a switch as a JSON string. It is designed for use in rules and will indicate the direction of travel of the switch as INCREASE, DECREASE, STOP.
+### Scene Number 2
 Triggers when a scene button is pressed.
 
 The ```scene_number2``` channel supports the ```Number``` item.
@@ -136,8 +145,12 @@ This channel provides the scene, and the event as a decimal value in the form ``
 | 5        | 4 x keypress       |
 | 6        | 5 x keypress       |
 
-### Scene Number 3
+### Swipe Switch 3
+Switch indicating direction.
 
+The ```switch_startstop3``` channel supports the ```String``` item and is in the ```Switch``` category.
+This channel provides the start/stop state of a switch as a JSON string. It is designed for use in rules and will indicate the direction of travel of the switch as INCREASE, DECREASE, STOP.
+### Scene Number 3
 Triggers when a scene button is pressed.
 
 The ```scene_number3``` channel supports the ```Number``` item.
@@ -153,8 +166,12 @@ This channel provides the scene, and the event as a decimal value in the form ``
 | 5        | 4 x keypress       |
 | 6        | 5 x keypress       |
 
-### Scene Number 4
+### Swipe Switch 4
+Switch indicating direction.
 
+The ```switch_startstop4``` channel supports the ```String``` item and is in the ```Switch``` category.
+This channel provides the start/stop state of a switch as a JSON string. It is designed for use in rules and will indicate the direction of travel of the switch as INCREASE, DECREASE, STOP.
+### Scene Number 4
 Triggers when a scene button is pressed.
 
 The ```scene_number4``` channel supports the ```Number``` item.

--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMultiLevelSwitchConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMultiLevelSwitchConverter.java
@@ -8,11 +8,14 @@
 package org.openhab.binding.zwave.internal.converter;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.StopMoveType;
+import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
@@ -22,6 +25,7 @@ import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveBatteryCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiLevelSwitchCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiLevelSwitchCommandClass.ZWaveStartStopEvent;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
 import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
 import org.slf4j.Logger;
@@ -68,6 +72,9 @@ public class ZWaveMultiLevelSwitchConverter extends ZWaveCommandClassConverter {
         boolean configInvertControl = "true".equalsIgnoreCase(channel.getArguments().get("config_invert_control"));
         boolean configInvertPercent = "true".equalsIgnoreCase(channel.getArguments().get("config_invert_percent"));
 
+        if (event instanceof ZWaveStartStopEvent) {
+            return handleStartStopEvent(channel, (ZWaveStartStopEvent) event);
+        }
         int value = (int) event.getValue();
 
         // A value of 254 means the device doesn't know it's current position
@@ -120,6 +127,17 @@ public class ZWaveMultiLevelSwitchConverter extends ZWaveCommandClassConverter {
         }
 
         return state;
+    }
+
+    private State handleStartStopEvent(ZWaveThingChannel channel, ZWaveStartStopEvent event) {
+        if (channel.getUID().getId().equals("switch_startstop")) {
+            Map<String, Object> object = new HashMap<String, Object>();
+            object.put("direction", event.direction);
+
+            return new StringType(propertiesToJson(object));
+        }
+
+        return null;
     }
 
     @Override

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveInclusionController.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveInclusionController.java
@@ -52,7 +52,7 @@ public class ZWaveInclusionController implements ZWaveEventListener {
     /**
      * Create the inclusion controller
      *
-     * @param controller the {@link ZWaveController} to include a device into
+     * @param controller         the {@link ZWaveController} to include a device into
      * @param networkSecurityKey the network security key
      */
     public ZWaveInclusionController(ZWaveController controller, String networkSecurityKey) {
@@ -63,7 +63,7 @@ public class ZWaveInclusionController implements ZWaveEventListener {
     /**
      * Starts a network inclusion process.
      *
-     * @param highPower use high power inclusion
+     * @param highPower   use high power inclusion
      * @param networkWide use network wide inclusion
      */
     public void startInclusion(boolean highPower, boolean networkWide) {
@@ -367,6 +367,7 @@ public class ZWaveInclusionController implements ZWaveEventListener {
     private void stopTimer() {
         if (timerTask != null) {
             timerTask.cancel();
+            timerTask = null;
         }
     }
 }

--- a/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveMultiLevelSwitchConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveMultiLevelSwitchConverterTest.java
@@ -16,16 +16,20 @@ import java.util.Map;
 
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Before;
 import org.junit.Test;
 import org.openhab.binding.zwave.handler.ZWaveControllerHandler;
 import org.openhab.binding.zwave.handler.ZWaveThingChannel;
 import org.openhab.binding.zwave.handler.ZWaveThingChannel.DataType;
-import org.openhab.binding.zwave.internal.converter.ZWaveMultiLevelSwitchConverter;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiLevelSwitchCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiLevelSwitchCommandClass.StartStopDirection;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiLevelSwitchCommandClass.ZWaveStartStopEvent;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
 import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
 
@@ -42,6 +46,16 @@ public class ZWaveMultiLevelSwitchConverterTest {
     private ZWaveNode node;
     private PercentType percentType;
     private ZWaveMultiLevelSwitchCommandClass commandClass;
+
+    private ZWaveThingChannel createChannel(String channelType, DataType dataType) {
+        ChannelUID uid = new ChannelUID("zwave:node:bridge:" + channelType);
+        ChannelTypeUID typeUid = new ChannelTypeUID("zwave:" + channelType);
+
+        Map<String, String> args = new HashMap<String, String>();
+
+        return new ZWaveThingChannel(null, typeUid, uid, dataType, CommandClass.COMMAND_CLASS_MULTI_CMD.toString(), 0,
+                args);
+    }
 
     @Before
     public void setup() {
@@ -228,6 +242,36 @@ public class ZWaveMultiLevelSwitchConverterTest {
                 .thenReturn(commandClass);
         when(node.encapsulate(any(ZWaveCommandClassTransactionPayload.class), anyInt()))
                 .thenReturn(new ZWaveCommandClassTransactionPayload(0, null, null, null, 0));
+    }
+
+    @Test
+    public void handleEvent_Decrease() {
+        ZWaveMultiLevelSwitchConverter sut = new ZWaveMultiLevelSwitchConverter(controller);
+        event = new ZWaveStartStopEvent(0, 0, null, StartStopDirection.DECREASE);
+
+        channel = createChannel("switch_startstop", DataType.StringType);
+        State state = sut.handleEvent(channel, event);
+        assertEquals(new StringType("{\"direction\":\"DECREASE\"}"), state);
+    }
+
+    @Test
+    public void handleEvent_Increase() {
+        ZWaveMultiLevelSwitchConverter sut = new ZWaveMultiLevelSwitchConverter(controller);
+        event = new ZWaveStartStopEvent(0, 0, null, StartStopDirection.INCREASE);
+
+        channel = createChannel("switch_startstop", DataType.StringType);
+        State state = sut.handleEvent(channel, event);
+        assertEquals(new StringType("{\"direction\":\"INCREASE\"}"), state);
+    }
+
+    @Test
+    public void handleEvent_Stop() {
+        ZWaveMultiLevelSwitchConverter sut = new ZWaveMultiLevelSwitchConverter(controller);
+        event = new ZWaveStartStopEvent(0, 0, null, StartStopDirection.STOP);
+
+        channel = createChannel("switch_startstop", DataType.StringType);
+        State state = sut.handleEvent(channel, event);
+        assertEquals(new StringType("{\"direction\":\"STOP\"}"), state);
     }
 
 }

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSwitchCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSwitchCommandClassTest.java
@@ -11,10 +11,13 @@ import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.junit.Test;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
-import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiLevelSwitchCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiLevelSwitchCommandClass.StartStopDirection;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiLevelSwitchCommandClass.ZWaveStartStopEvent;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
 import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
 
 /**
@@ -96,5 +99,49 @@ public class ZWaveMultiLevelSwitchCommandClassTest extends ZWaveCommandClassTest
         cls.setVersion(3);
         msgs = cls.initialize(true);
         assertEquals(1, msgs.size());
+    }
+
+    @Test
+    public void startStop_Stop() {
+        byte[] packetData = { 0x01, 0x0C, 0x00, 0x04, 0x00, 0x11, 0x02, 0x26, 0x05, (byte) 0xC7 };
+
+        List<ZWaveEvent> events = processCommandClassMessage(packetData);
+
+        assertEquals(1, events.size());
+
+        ZWaveStartStopEvent event = (ZWaveStartStopEvent) events.get(0);
+
+        assertEquals(CommandClass.COMMAND_CLASS_SWITCH_MULTILEVEL, event.getCommandClass());
+        assertEquals(StartStopDirection.STOP, event.direction);
+    }
+
+    @Test
+    public void startStop_Increase() {
+        byte[] packetData = { 0x01, 0x0C, 0x00, 0x04, 0x00, 0x11, 0x06, 0x26, 0x04, 0x38, 0x00, (byte) 0xFF, 0x00,
+                (byte) 0x05 };
+
+        List<ZWaveEvent> events = processCommandClassMessage(packetData);
+
+        assertEquals(1, events.size());
+
+        ZWaveStartStopEvent event = (ZWaveStartStopEvent) events.get(0);
+
+        assertEquals(CommandClass.COMMAND_CLASS_SWITCH_MULTILEVEL, event.getCommandClass());
+        assertEquals(StartStopDirection.INCREASE, event.direction);
+    }
+
+    @Test
+    public void startStop_Decrease() {
+        byte[] packetData = { 0x01, 0x0C, 0x00, 0x04, 0x00, 0x11, 0x06, 0x26, 0x04, 0x78, 0x00, (byte) 0xFF, 0x00,
+                (byte) 0x45 };
+
+        List<ZWaveEvent> events = processCommandClassMessage(packetData);
+
+        assertEquals(1, events.size());
+
+        ZWaveStartStopEvent event = (ZWaveStartStopEvent) events.get(0);
+
+        assertEquals(CommandClass.COMMAND_CLASS_SWITCH_MULTILEVEL, event.getCommandClass());
+        assertEquals(StartStopDirection.DECREASE, event.direction);
     }
 }


### PR DESCRIPTION
This adds a new ```switch_startstop``` channel and makes it available for the ZW130 swipe commands.
Closes #598 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>