### PR TITLE
Change registration of discovery to handler factory

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveSerialHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveSerialHandler.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.zwave.ZWaveBindingConstants.*;
 import java.io.IOException;
 import java.util.TooManyListenersException;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
@@ -68,7 +69,7 @@ public class ZWaveSerialHandler extends ZWaveControllerHandler {
         super(bridge);
     }
 
-    public ZWaveSerialHandler(Bridge thing, SerialPortManager serialPortManager) {
+    public ZWaveSerialHandler(@NonNull Bridge thing, SerialPortManager serialPortManager) {
         super(thing);
         this.serialPortManager = serialPortManager;
     }

--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -501,6 +501,10 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
         } else {
             switch (node.getNodeState()) {
                 case INITIALIZING:
+                    updateStatus(ThingStatus.INITIALIZING);
+                    break;
+                case ASLEEP:
+                case AWAKE:
                 case ALIVE:
                     updateStatus(ThingStatus.ONLINE);
                     break;
@@ -724,7 +728,7 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
                             paramValues.add(strParam);
                         }
                     }
-                    logger.debug("NODE {}: Association {} consolidated to {}", nodeId,groupIndex, paramValues);
+                    logger.debug("NODE {}: Association {} consolidated to {}", nodeId, groupIndex, paramValues);
 
                     ZWaveAssociationGroup currentMembers = node.getAssociationGroup(groupIndex);
                     if (currentMembers == null) {

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -337,11 +337,6 @@ public class ZWaveController {
         ZWaveEvent zEvent = new ZWaveInitializationStateEvent(nodeId, ZWaveNodeInitStage.EMPTYNODE);
         notifyEventListeners(zEvent);
 
-        // if (nodeId != 6) {
-        // return;
-        // }
-
-        ioHandler.deviceDiscovered(nodeId);
         ZWaveInitNodeThread thread = new ZWaveInitNodeThread(this, nodeId);
         thread.setName("Node_" + nodeId + "_init");
         thread.start();

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveIoHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveIoHandler.java
@@ -18,7 +18,5 @@ package org.openhab.binding.zwave.internal.protocol;
  *
  */
 public interface ZWaveIoHandler {
-    void deviceDiscovered(int node);
-
     void sendPacket(SerialMessage message);
 }


### PR DESCRIPTION
I'm trying to get to know the code base and stumbled upon a deprecated access to bundleContext in the BaseThingHandler.
I saw the already fixed issue for the ZigBeeBinding ([#31](https://github.com/openhab/org.openhab.binding.zigbee/issues/31)) and the corresponding pull. [#34](https://github.com/openhab/org.openhab.binding.zigbee/pull/34)

So I tried to do the same here, though I'm not quite sure if I got everything right. (Particularly adding a DiscoveryService for the ZWaveSerialHandler in ZWaveHandlerFactory)

I'm still reading and learning, so if I'm way off track with this pull request, please say so.

Hope, I can contribute somewhat.

Signed-off-by: James Tophoven <james.tophoven@gmail.com>