### PR TITLE
update handling of association

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -724,7 +724,7 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
                             paramValues.add(strParam);
                         }
                     }
-                    logger.debug("NODE {}: Association {} consolidated to {}", nodeId,groupIndex, paramValues);
+                    logger.debug("NODE {}: Association {} consolidated to {}", nodeId, groupIndex, paramValues);
 
                     ZWaveAssociationGroup currentMembers = node.getAssociationGroup(groupIndex);
                     if (currentMembers == null) {
@@ -1673,8 +1673,14 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
 
             // Build the configuration value
             for (ZWaveAssociation groupMember : group.getAssociations()) {
-                logger.debug("NODE {}: Update ASSOCIATION group_{}: Adding {}", nodeId, group, groupMember);
-                members.add(groupMember.toString());
+                if (groupMember.getNode() == controllerHandler.getOwnNodeId()) {
+                    logger.debug("NODE {}: Update ASSOCIATION group_{}: Adding Controller ({})", nodeId, group,
+                            groupMember);
+                    members.add(ZWaveBindingConstants.GROUP_CONTROLLER);
+                } else {
+                    logger.debug("NODE {}: Update ASSOCIATION group_{}: Adding {}", nodeId, group, groupMember);
+                    members.add(groupMember.toString());
+                }
             }
 
             config.put("group_" + group.getIndex(), members);


### PR DESCRIPTION
fixes [#279](https://github.com/openhab/org.openhab.ui.habmin/issues/279)
there have been multiple reports that there are issues when displaying association groups in habmin (e.g [here](https://community.openhab.org/t/oh2-z-wave-refactoring-and-testing-and-security/21653/3003))

it was assumed that the used widget is at fault, but I think it is a consequence of pull [#953](https://github.com/openhab/org.openhab.binding.zwave/pull/953)

when synchronizing the group association configuration, the node id of the controller has to be replaced with the proxy constant as well, because the configuration in openhab expects it.
The field in habmin is empty, because there is no option for the reported node id as group member from the device if it is the controller.

Signed-off-by: James Tophoven <james.tophoven@gmail.com>