### PR TITLE
Use S0 when S2 is announced

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveInclusionController.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveInclusionController.java
@@ -57,7 +57,7 @@ public class ZWaveInclusionController implements ZWaveEventListener {
     /**
      * Create the inclusion controller
      *
-     * @param controller         the {@link ZWaveController} to include a device into
+     * @param controller the {@link ZWaveController} to include a device into
      * @param networkSecurityKey the network security key
      */
     public ZWaveInclusionController(ZWaveController controller, String networkSecurityKey) {
@@ -68,7 +68,7 @@ public class ZWaveInclusionController implements ZWaveEventListener {
     /**
      * Starts a network inclusion process.
      *
-     * @param highPower   use high power inclusion
+     * @param highPower use high power inclusion
      * @param networkWide use network wide inclusion
      */
     public void startInclusion(boolean highPower, boolean networkWide) {
@@ -237,8 +237,14 @@ public class ZWaveInclusionController implements ZWaveEventListener {
                         continue;
                     }
 
-                    ZWaveCommandClass zwaveCommandClass = ZWaveCommandClass.getInstance(commandClass.getKey(), newNode,
-                            controller);
+                    ZWaveCommandClass zwaveCommandClass;
+                    if (commandClass == CommandClass.COMMAND_CLASS_SECURITY_2) {
+                        // S0 is mandatory when S2 is supported, so we add that instead for now
+                        zwaveCommandClass = ZWaveCommandClass.getInstance(CommandClass.COMMAND_CLASS_SECURITY.getKey(),
+                                newNode, controller);
+                    } else {
+                        zwaveCommandClass = ZWaveCommandClass.getInstance(commandClass.getKey(), newNode, controller);
+                    }
                     if (zwaveCommandClass != null) {
                         logger.debug("NODE {}: Inclusion is adding command class {}.", incEvent.getNodeId(),
                                 commandClass);

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -141,10 +141,8 @@ public class ZWaveNodeInitStageAdvancer {
     /**
      * Constructor. Creates a new instance of the ZWaveNodeStageAdvancer class.
      *
-     * @param node
-     *                       the node this advancer belongs to.
-     * @param controller
-     *                       the controller to use
+     * @param node the node this advancer belongs to.
+     * @param controller the controller to use
      */
     public ZWaveNodeInitStageAdvancer(ZWaveNode node, ZWaveController controller) {
         this.node = node;
@@ -231,7 +229,7 @@ public class ZWaveNodeInitStageAdvancer {
     }
 
     private boolean processTransaction(ZWaveMessagePayloadTransaction transaction) {
-        return processTransaction(transaction, 0, 10);
+        return processTransaction(transaction, 0, 5);
     }
 
     private boolean processTransaction(ZWaveMessagePayloadTransaction transaction, long timeout, int retries) {
@@ -306,8 +304,7 @@ public class ZWaveNodeInitStageAdvancer {
     /**
      * Move all the messages in a collection to the queue
      *
-     * @param transactions
-     *                         the message collection
+     * @param transactions the message collection
      */
     private void processTransactions(Collection<ZWaveCommandClassTransactionPayload> transactions) {
         if (transactions == null) {
@@ -324,10 +321,8 @@ public class ZWaveNodeInitStageAdvancer {
     /**
      * Move all the messages in a collection to the queue and encapsulates them
      *
-     * @param transactions
-     *                         the message collection
-     * @param endpointId
-     *                         the endpoint number
+     * @param transactions the message collection
+     * @param endpointId the endpoint number
      */
     private void processTransactions(Collection<ZWaveCommandClassTransactionPayload> transactions, int endpointId) {
         if (transactions == null) {
@@ -1159,8 +1154,7 @@ public class ZWaveNodeInitStageAdvancer {
     /**
      * Sets the time stamp the node was last queried.
      *
-     * @param queryStageTimeStamp
-     *                                the queryStageTimeStamp to set
+     * @param queryStageTimeStamp the queryStageTimeStamp to set
      */
     public Date getQueryStageTimeStamp() {
         return queryStageTimeStamp;


### PR DESCRIPTION
Since S0 is mandatory when S2 is used, we add S0 command class on inclusion.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>