### PR TITLE
Several improvements on serial port stability

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/ZWaveHandlerFactory.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/ZWaveHandlerFactory.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
+import org.eclipse.smarthome.core.scheduler.CronScheduler;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
@@ -52,6 +53,7 @@ public class ZWaveHandlerFactory extends BaseThingHandlerFactory {
     private Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
 
     private @NonNullByDefault({}) SerialPortManager serialPortManager;
+    private @NonNullByDefault({}) CronScheduler cronScheduler;
 
     @Reference
     protected void setSerialPortManager(final SerialPortManager serialPortManager) {
@@ -60,6 +62,15 @@ public class ZWaveHandlerFactory extends BaseThingHandlerFactory {
 
     protected void unsetSerialPortManager(final SerialPortManager serialPortManager) {
         this.serialPortManager = null;
+    }
+
+    @Reference
+    protected void setCronScheduler(final CronScheduler cronScheduler) {
+        this.cronScheduler = cronScheduler;
+    }
+
+    protected void unsetCronScheduler(final CronScheduler cronScheduler) {
+        this.cronScheduler = null;
     }
 
     @Override
@@ -81,7 +92,7 @@ public class ZWaveHandlerFactory extends BaseThingHandlerFactory {
 
         // Handle controllers here
         if (thingTypeUID.equals(CONTROLLER_SERIAL)) {
-            controller = new ZWaveSerialHandler((Bridge) thing, serialPortManager);
+            controller = new ZWaveSerialHandler((Bridge) thing, serialPortManager, cronScheduler);
         }
 
         if (controller != null) {

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -19,8 +19,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -153,21 +151,6 @@ public class ZWaveController {
         logger.info("ZWave timeout is set to {}ms. Soft reset is {}.", zWaveResponseTimeout, softReset);
 
         ioHandler = handler;
-
-        // We have a delay in running the initialisation sequence to allow any frames queued in the controller to be
-        // received before sending the init sequence. This avoids protocol errors (CAN errors).
-        Timer initTimer = new Timer();
-        initTimer.schedule(new InitializeDelayTask(), 3000);
-    }
-
-    private class InitializeDelayTask extends TimerTask {
-        private final Logger logger = LoggerFactory.getLogger(InitializeDelayTask.class);
-
-        @Override
-        public void run() {
-            logger.debug("Initialising network");
-            initialize();
-        }
     }
 
     // Incoming message handlers
@@ -611,6 +594,7 @@ public class ZWaveController {
      *
      */
     public void initialize() {
+        logger.debug("Initialising network");
         enqueue(new GetVersionMessageClass().doRequest());
         enqueue(new MemoryGetIdMessageClass().doRequest());
         enqueue(new SerialApiGetCapabilitiesMessageClass().doRequest());


### PR DESCRIPTION
- Added watchdog to handle serial port initialization. This makes serial port more stable as it can handle when the serial port goes down or isn't available yet.
- Improved localized status messages by adding portId as parameter argument.
- In ZwaveControllerHandler the listeners added externally are not added directly to the controller anymore. This improves stability because it removed the dependency of the availability of the controller.
- Used cron scheduler for healing task

Closes #979, supersedes #980
 
**NOTE:** In #980 comments it was mentioned the whole network management might be affected by a change like this and might need some rework. I didn't fully tested it, so that part might still be blocking for this pr. But I think this pr might be a starting point on improving stability.
**NOTE 2:** It also mentioned to create a pr against development, but that branch seems out-of-date. So I created it against master.
**NOTE 3:** I just noticed this pr covers some changes suggested in #1209 (I probably need to update some logging here :slightly_smiling_face:)