### PR TITLE
Ensure max polling period is consistent with configuration

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -108,7 +108,7 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
     private final Object pollingSync = new Object();
     private ScheduledFuture<?> pollingJob = null;
     private final long POLLING_PERIOD_MIN = 15;
-    private final long POLLING_PERIOD_MAX = 86400;
+    private final long POLLING_PERIOD_MAX = 864000;
     private final long POLLING_PERIOD_DEFAULT = 1800;
     private final long DELAYED_POLLING_PERIOD_MAX = 10;
     private final long REFRESH_POLL_DELAY = 50;


### PR DESCRIPTION
Ensure consistency with the max allowable value in the thing handler and configuration provider.
Closes #1217 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>