### PR TITLE
Kick the queue when a NIF is received

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -127,9 +127,9 @@ public class ZWaveController {
      * Constructor. Creates a new instance of the ZWave controller class.
      *
      * @param handler the io handler to use for communication with the ZWave controller stick.
-     * @param config  a map of configuration parameters
+     * @param config a map of configuration parameters
      * @throws SerialInterfaceException
-     *                                      when a connection error occurs.
+     *             when a connection error occurs.
      */
     public ZWaveController(ZWaveIoHandler handler, Map<String, String> config) {
         masterController = "true".equals(config.get("masterController"));
@@ -182,7 +182,7 @@ public class ZWaveController {
      * that are a response to our own requests, or the stick asking us information.
      *
      * @param incomingMessage
-     *                            the incoming message to process.
+     *            the incoming message to process.
      */
     public void handleIncomingMessage(ZWaveTransaction currentTransaction, SerialMessage incomingMessage) {
         logger.debug("Incoming Message: {}", incomingMessage.toString());
@@ -208,9 +208,9 @@ public class ZWaveController {
      * message initiated by a node or the controller.
      *
      * @param transaction
-     *                            the transaction associated with this message
+     *            the transaction associated with this message
      * @param incomingMessage
-     *                            the incoming message to process.
+     *            the incoming message to process.
      */
     private void handleIncomingRequestMessage(ZWaveTransaction transaction, SerialMessage incomingMessage) {
         logger.trace("Incoming Message type = REQUEST");
@@ -236,9 +236,9 @@ public class ZWaveController {
      * response, based one of our own requests.
      *
      * @param transaction
-     *                            the transaction associated with this message
+     *            the transaction associated with this message
      * @param incomingMessage
-     *                            the response message to process.
+     *            the response message to process.
      */
     private void handleIncomingResponseMessage(ZWaveTransaction transaction, SerialMessage incomingMessage)
             throws ZWaveSerialMessageException {
@@ -331,7 +331,7 @@ public class ZWaveController {
      * Add a node to the controller
      *
      * @param nodeId
-     *                   the node number to add
+     *            the node number to add
      */
     private ZWaveInitNodeThread addNode(int nodeId) {
         ZWaveEvent zEvent = new ZWaveInitializationStateEvent(nodeId, ZWaveNodeInitStage.EMPTYNODE);
@@ -504,7 +504,7 @@ public class ZWaveController {
      * This does not wait for a response.
      *
      * @param transaction
-     *                        the {@link ZWaveMessagePayloadTransaction} message to enqueue.
+     *            the {@link ZWaveMessagePayloadTransaction} message to enqueue.
      */
     public void enqueueNonce(ZWaveMessagePayloadTransaction transaction) {
         // Sanity check!
@@ -520,10 +520,18 @@ public class ZWaveController {
      * Queues a message for sending and returns the response once received.
      *
      * @param transaction
-     *                        the {@link ZWaveMessagePayloadTransaction} message to enqueue.
+     *            the {@link ZWaveMessagePayloadTransaction} message to enqueue.
      */
     public @Nullable ZWaveTransactionResponse sendTransaction(ZWaveMessagePayloadTransaction transaction) {
         return transactionManager.sendTransaction(transaction);
+    }
+
+    /**
+     * Kicks the transaction queue. This may be used if the system has been waiting for an event that has now occurred
+     * and we now need to get things moving even if not new transactions have been added to the send queue.
+     */
+    public void kickQueue() {
+        transactionManager.kickQueue();
     }
 
     /**
@@ -549,7 +557,7 @@ public class ZWaveController {
      * Notify our own event listeners of a ZWave event.
      *
      * @param event
-     *                  the event to send.
+     *            the event to send.
      */
     public void notifyEventListeners(ZWaveEvent event) {
         logger.trace("Notifying event listeners: {}", event.getClass().getSimpleName());
@@ -622,7 +630,7 @@ public class ZWaveController {
      * Send Identify Node message to the controller.
      *
      * @param nodeId
-     *                   the nodeId of the node to identify
+     *            the nodeId of the node to identify
      *
      */
     public void identifyNode(int nodeId) {
@@ -633,7 +641,7 @@ public class ZWaveController {
      * Request the node routing information.
      *
      * @param nodeId
-     *                   The address of the node to update
+     *            The address of the node to update
      *
      */
     public void requestNodeRoutingInfo(int nodeId) {
@@ -646,7 +654,7 @@ public class ZWaveController {
      * to update the data in the binding.
      *
      * @param nodeId
-     *                   The address of the node to update
+     *            The address of the node to update
      *
      */
     public void requestNodeNeighborUpdate(int nodeId) {
@@ -657,12 +665,12 @@ public class ZWaveController {
      * Puts the controller into inclusion mode to add new nodes
      *
      * @param inclusionMode the mode to use for inclusion.
-     *                          <br>
-     *                          0=Low Power Inclusion
-     *                          <br>
-     *                          1=High Power Inclusion
-     *                          <br>
-     *                          2=Network Wide Inclusion
+     *            <br>
+     *            0=Low Power Inclusion
+     *            <br>
+     *            1=High Power Inclusion
+     *            <br>
+     *            2=Network Wide Inclusion
      *
      */
     public void requestAddNodesStart(int inclusionMode) {
@@ -802,7 +810,7 @@ public class ZWaveController {
      * Request if the node is currently marked as failed by the controller.
      *
      * @param nodeId
-     *                   The address of the node to check
+     *            The address of the node to check
      */
     public void requestIsFailedNode(int nodeId) {
         enqueue(new IsFailedNodeMessageClass().doRequest(nodeId));
@@ -813,7 +821,7 @@ public class ZWaveController {
      * that have not failed.
      *
      * @param nodeId
-     *                   The address of the node to remove
+     *            The address of the node to remove
      */
     public void requestRemoveFailedNode(int nodeId) {
         enqueue(new RemoveFailedNodeMessageClass().doRequest(nodeId));
@@ -823,7 +831,7 @@ public class ZWaveController {
      * Marks a node as failed
      *
      * @param nodeId
-     *                   The address of the node to set failed
+     *            The address of the node to set failed
      */
     public void requestSetFailedNode(int nodeId) {
         enqueue(new ReplaceFailedNodeMessageClass().doRequest(nodeId));
@@ -843,9 +851,9 @@ public class ZWaveController {
      * Request the controller to set the return route between two nodes
      *
      * @param nodeId
-     *                          Source node
+     *            Source node
      * @param destinationId
-     *                          Destination node
+     *            Destination node
      */
     public void requestAssignReturnRoute(int nodeId, int destinationId) {
         enqueue(new AssignReturnRouteMessageClass().doRequest(nodeId, destinationId));
@@ -856,7 +864,7 @@ public class ZWaveController {
      * controller
      *
      * @param nodeId
-     *                   Source node
+     *            Source node
      */
     public void requestAssignSucReturnRoute(int nodeId) {
         enqueue(new AssignSucReturnRouteMessageClass().doRequest(nodeId));
@@ -866,7 +874,7 @@ public class ZWaveController {
      * Transmits the {@link ZWaveCommandClassTransactionPayload} to a single ZWave Node.
      *
      * @param payload
-     *                    the {@link ZWaveCommandClassTransactionPayload} message to send.
+     *            the {@link ZWaveCommandClassTransactionPayload} message to send.
      */
     public void sendData(ZWaveCommandClassTransactionPayload transaction) {
         if (transaction == null) {
@@ -879,7 +887,7 @@ public class ZWaveController {
      * Add a listener for ZWave events to this controller.
      *
      * @param eventListener
-     *                          the event listener to add.
+     *            the event listener to add.
      */
     public void addEventListener(ZWaveEventListener eventListener) {
         synchronized (zwaveEventListeners) {
@@ -897,7 +905,7 @@ public class ZWaveController {
      * Remove a listener for ZWave events to this controller.
      *
      * @param eventListener
-     *                          the event listener to remove.
+     *            the event listener to remove.
      */
     public void removeEventListener(ZWaveEventListener eventListener) {
         synchronized (zwaveEventListeners) {
@@ -991,7 +999,7 @@ public class ZWaveController {
      * Checks if the serial API supports the given capability.
      *
      * @param capability
-     *                       the capability to check
+     *            the capability to check
      * @return true if the controller API support the capability
      */
     public boolean hasApiCapability(SerialMessageClass capability) {
@@ -1013,7 +1021,7 @@ public class ZWaveController {
      * Gets the node object using it's node ID as key. Returns null if the node is not found
      *
      * @param nodeId
-     *                   the Node ID of the node to get.
+     *            the Node ID of the node to get.
      * @return node object
      */
     public ZWaveNode getNode(int nodeId) {

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -1413,6 +1413,7 @@ public class ZWaveNode {
 
         // Create the timer if this is our first call
         if (timer == null) {
+            controller.kickQueue();
             logger.trace("NODE {}: Creating wakeup timer", getNodeId());
             timer = new Timer();
         }

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionManager.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionManager.java
@@ -316,6 +316,13 @@ public class ZWaveTransactionManager {
         return transaction.getTransactionId();
     }
 
+    /**
+     * Restarts the queue if it is currently waiting
+     */
+    public void kickQueue() {
+        sendNextMessage();
+    }
+
     private void addTransactionToQueue(ZWaveTransaction transaction) {
         synchronized (sendQueue) {
             PriorityBlockingQueue<ZWaveTransaction> queue;

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ReplaceFailedNodeMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ReplaceFailedNodeMessageClass.java
@@ -95,7 +95,7 @@ public class ReplaceFailedNodeMessageClass extends ZWaveCommandProcessor {
                 break;
             case FAILED_NODE_NOT_FOUND:
                 // The replacing process aborted because the node was found, thereby not a failing node.
-                logger.error("NODE {}: Replace failed node failed as node if functioning!", nodeId);
+                logger.error("NODE {}: Replace failed node failed as node is functioning!", nodeId);
                 transaction.setTransactionCanceled();
                 report = Report.FAILED_NODE_NOT_FOUND;
                 break;


### PR DESCRIPTION
When a NIF is received, it is used to mark a device as AWAKE if it is a sleeping device. However, in order to manage devices that also send the WAKEUP_NOTIFICATION, there is a 250mS delay before setting the device AWAKE, and this delay may prevent messages being sent.
This PR kicks the queue to get things moving when the wakeup is set.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>