### PR TITLE
Add channel & channel type for COMMAND_CLASS_BASIC

### DIFF
--- a/src/main/resources/ESH-INF/thing/eurotronic/spirit_0_0.xml
+++ b/src/main/resources/ESH-INF/thing/eurotronic/spirit_0_0.xml
@@ -68,11 +68,17 @@ Thermostatic Valve<br /><h1>Overview</h1><p>Spirit Z-Wave Plus is a Z-Wave radio
           <property name="binding:*:PercentType">COMMAND_CLASS_BATTERY</property>
         </properties>
       </channel>
+      <channel id="basic_mode" typeId="eurotronic_spirit_00_000_basic_mode">
+        <label>Basic mode</label>
+        <properties>
+          <property name="binding:*:DecimalType">COMMAND_CLASS_BASIC</property>
+        </properties>
+      </channel>      
     </channels>
 
     <!-- DEVICE PROPERTY DEFINITIONS -->
     <properties>
-      <property name="vendor">Eurotronics</property>
+      <property name="vendor">Eurotronic</property>
       <property name="modelId">Spirit</property>
       <property name="manufacturerId">0148</property>
       <property name="manufacturerRef">0003:0001,0003:0003</property>
@@ -231,6 +237,21 @@ Spirit Z-Wave Plus can only be associated with the Z-Wave controller.<br /><h1>O
         <option value="31">Manual</option>
       </options>
     </state>
+  </channel-type>
+  
+  <channel-type id="eurotronic_spirit_00_000_basic_mode">
+    <item-type>Number</item-type>
+    <label>Basic Mode</label>
+    <description>Sets the Basic mode</description>
+    <category>Temperature</category>
+    <state pattern="%s">
+      <options>
+        <option value="15">Off</option>
+        <option value="0">Economy Heat</option>
+        <option value="255">Heat</option>
+        <option value="240">Full Power</option>
+        <option value="254">Manual</option>
+      </options>
   </channel-type>
 
 </thing:thing-descriptions>


### PR DESCRIPTION
This PR refers to: [Eurotronic Spirit - Unsupported mode type 31](https://community.openhab.org/t/eurotronic-spirit-unsupported-mode-type-31/57265)
In order to directly control the Spirit's valve a channel linked to the COMMAND_CLASS_BASIC is required. 

Currently selecting _MANUAL_ (Manufacturer Specific mode) of COMMAND_CLASS_THERMOSTAT_MODE leads to the following error:
`2018-11-19 19:13:08.108 [DEBUG] [ding.zwave.handler.ZWaveThingHandler] - NODE 13: Command received zwave:device:512:node13:thermostat_mode --> 31 [DecimalType]`
`2018-11-19 19:13:08.116 [DEBUG] [lass.ZWaveThermostatModeCommandClass] - NODE 13: setValueMessage 31, modeType empty false`
`2018-11-19 19:13:08.121 [ERROR] [lass.ZWaveThermostatModeCommandClass] - NODE 13: Unsupported mode type 31`
`2018-11-19 19:13:08.125 [WARN ] [nverter.ZWaveThermostatModeConverter] - NODE 13: Generating message failed for command class = COMMAND_CLASS_THERMOSTAT_MODE, endpoint = 0`
`2018-11-19 19:13:08.128 [DEBUG] [ding.zwave.handler.ZWaveThingHandler] - NODE 13: No messages returned from converter`

[Jeremys explanation:](https://community.openhab.org/t/eurotronic-spirit-unsupported-mode-type-31/57265/72?u=frapi)
> Yes, the Manual mode is already available on the device as a Thermostat Mode. However it needs to be sent the value ‘0xFE’ (‘Manufacturer Specific’) via the Basic command class first before it will recognise it. Once that has been sent, the device will respond to the ‘0x1F’ (‘Manufacturer Specific’) command via the existing ‘thermostat_mode’ Channel. At that point, direct control of the valve position will be available via the existing ‘switch_dimmer’ Channel.

Signed-off-by: Frank Pille <f.pille@gmail.com>