### PR TITLE
Fixed typo in ZW4006 documentation

### DIFF
--- a/doc/ge/zw4006_0_0.md
+++ b/doc/ge/zw4006_0_0.md
@@ -27,7 +27,7 @@ The switch enables wireless control of On/OFF functions of incandescent, LED, xe
 ### Exclusion Information
 
   1. Follow the instructions for your Z-Wave certified controller to exclude a device from the Z-Wave network.
-  2. 2. Once the controller is ready to exclude your device, press and release the top or bottom button on the smart switch to exclude it from the network. 
+  2. Once the controller is ready to exclude your device, press and release the top or bottom button on the smart switch to exclude it from the network. 
 
 ## Channels
 


### PR DESCRIPTION
Fixed a typo in the documentation for the Jasco ZW4006 PIR motion switch where there was an extra '2.' in the exclusion section