### PR TITLE
Fix for issue #1297, failed update neighbors

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionManager.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionManager.java
@@ -169,7 +169,7 @@ public class ZWaveTransactionManager {
     /**
      * Timeout in which we expect the request from the controller
      */
-    private final long timer2 = 5000;
+    private final long timer2 = 10000;
 
     /**
      * Timeout waiting to cancel a transaction once we've aborted it


### PR DESCRIPTION
Just increased the Z-Wave transaction manager's timeout for report requests to 10000ms instead of 5000ms.