### PR TITLE
Add Property Type BINARY to INDICATOR_COMMAND_CLASS

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveIndicatorConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveIndicatorConverter.java
@@ -68,7 +68,7 @@ public class ZWaveIndicatorConverter extends ZWaveCommandClassConverter {
             return null;
         }
 
-        switch (channel.getUID().getId()) {
+        switch (channel.getChannelTypeUID().getId()) {
             case "indicator_level":
                 if (indicator.property != IndicatorProperty.MULTILEVEL) {
                     return null;
@@ -88,7 +88,7 @@ public class ZWaveIndicatorConverter extends ZWaveCommandClassConverter {
                 state = new DecimalType(indicator.value);
                 break;
             default:
-                logger.warn("Unknown INDICATOR channel type {}", channel.getUID().getId());
+                logger.warn("Unknown INDICATOR channel type {}", channel.getChannelTypeUID().getId());
                 return null;
         }
 
@@ -110,7 +110,7 @@ public class ZWaveIndicatorConverter extends ZWaveCommandClassConverter {
 
         IndicatorProperty property = null;
 
-        switch (channel.getUID().getId()) {
+        switch (channel.getChannelTypeUID().getId()) {
             case "indicator_level":
                 property = IndicatorProperty.MULTILEVEL;
                 break;
@@ -121,7 +121,8 @@ public class ZWaveIndicatorConverter extends ZWaveCommandClassConverter {
                 property = IndicatorProperty.ON_OFF_CYCLES;
                 break;
             default:
-                logger.warn("NODE {}: Unknown INDICATOR channel type {}", node.getNodeId(), channel.getUID().getId());
+                logger.warn("NODE {}: Unknown INDICATOR channel type {}", node.getNodeId(),
+                        channel.getChannelTypeUID().getId());
                 return null;
         }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveIndicatorConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveIndicatorConverter.java
@@ -70,7 +70,8 @@ public class ZWaveIndicatorConverter extends ZWaveCommandClassConverter {
 
         switch (channel.getChannelTypeUID().getId()) {
             case "indicator_level":
-                if (indicator.property != IndicatorProperty.MULTILEVEL) {
+                if (indicator.property != IndicatorProperty.MULTILEVEL
+                        && indicator.property != IndicatorProperty.BINARY) {
                     return null;
                 }
                 state = new PercentType(indicator.value);
@@ -100,6 +101,7 @@ public class ZWaveIndicatorConverter extends ZWaveCommandClassConverter {
             Command command) {
 
         String indicatorStringType = channel.getArguments().get("type");
+        String indicatorStringProperty = channel.getArguments().get("property");
 
         ZWaveIndicatorCommandClass commandClass = (ZWaveIndicatorCommandClass) node
                 .resolveCommandClass(ZWaveCommandClass.CommandClass.COMMAND_CLASS_INDICATOR, channel.getEndpoint());
@@ -113,6 +115,9 @@ public class ZWaveIndicatorConverter extends ZWaveCommandClassConverter {
         switch (channel.getChannelTypeUID().getId()) {
             case "indicator_level":
                 property = IndicatorProperty.MULTILEVEL;
+                if ("BINARY".equalsIgnoreCase(indicatorStringProperty)) {
+                    property = IndicatorProperty.BINARY;
+                }
                 break;
             case "indicator_period":
                 property = IndicatorProperty.ON_OFF_PERIOD;


### PR DESCRIPTION
I've do some work on the indicator command class to support Indicator_level property type binary.
Also I've bugfixed the indicator_command_class to support multiple endpoints.

The goal is to support the HeatIt Z-Scene Controller and other devices supporting this.

I've done some additions on the Z-Wave Device Database.
https://www.cd-jackson.com/index.php/zwave/zwave-device-database/zwave-device-list/devicesummary/846

It is needed to correct the database export.

indicator_level
indicator_period
indicator_flash

this types need to include the configuration parameter(s)

indicator_period
indicator_flash

this types need to be exported as DecimalType.

indicator_level now supports an additional configuration parameter "property=BINARY". Default is MULTILEVEL, as this was the only option without this patch.

The complete story is in the community forum:
https://community.openhab.org/t/heatit-z-scene-controller-how-to-use-indicator-command-class/96887

