### PR TITLE
fixed handling of manufacturer proprietary reports for fgr222

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
@@ -311,9 +311,7 @@ public abstract class ZWaveCommandClass {
             ZWaveEndpoint endpoint) {
         try {
             CommandClass commandClass = CommandClass.getCommandClass(classId);
-            if (commandClass != null && commandClass.equals(CommandClass.COMMAND_CLASS_MANUFACTURER_PROPRIETARY)) {
-                commandClass = CommandClass.getCommandClass(node.getManufacturer(), node.getDeviceType());
-            }
+
             if (commandClass == null) {
                 logger.debug("NODE {}: Unknown command class 0x{}", node.getNodeId(), Integer.toHexString(classId));
                 return null;
@@ -654,17 +652,6 @@ public abstract class ZWaveCommandClass {
             }
 
             return codeToCommandClassMapping.get(i);
-        }
-
-        /**
-         * Lookup function based on the manufacturer and device ID.
-         *
-         * @param manufacturer the manufacturer ID
-         * @param deviceId the device ID
-         * @return enumeration value of the command class or null if there is no command class.
-         */
-        public static CommandClass getCommandClass(int manufacturer, int deviceId) {
-            return getCommandClass(getKeyFromManufacturerAndDeviceId(manufacturer, deviceId));
         }
 
         /**

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveManufacturerProprietaryCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveManufacturerProprietaryCommandClass.java
@@ -20,6 +20,8 @@ import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
 import org.openhab.binding.zwave.internal.protocol.commandclass.impl.CommandClassManufacturerProprietaryFibaroFgrm222V1;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveValueEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -32,6 +34,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("COMMAND_CLASS_MANUFACTURER_PROPRIETARY")
 public class ZWaveManufacturerProprietaryCommandClass extends ZWaveCommandClass {
+    private static final Logger logger = LoggerFactory.getLogger(ZWaveManufacturerProprietaryCommandClass.class);
+
     private ManufacturerProprietaryClass classType;
 
     /**
@@ -61,6 +65,7 @@ public class ZWaveManufacturerProprietaryCommandClass extends ZWaveCommandClass 
 
     @ZWaveResponseHandler(id = 1, name = "PROPRIETARY_HANDLER")
     public void handleManufacturerProprietaryReport(ZWaveCommandClassPayload payload, int endpoint) {
+        logger.debug("handling manufacturer proprietary report");
         Map<String, String> values = CommandClassManufacturerProprietaryFibaroFgrm222V1
                 .handleFgrm222Report(payload.getPayloadBuffer());
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveManufacturerProprietaryCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveManufacturerProprietaryCommandClass.java
@@ -18,6 +18,8 @@ import org.openhab.binding.zwave.internal.protocol.ZWaveCommandClassPayload;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
 import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.commandclass.impl.CommandClassManufacturerProprietaryFibaroFgrm222V1;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveValueEvent;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -55,6 +57,16 @@ public class ZWaveManufacturerProprietaryCommandClass extends ZWaveCommandClass 
         if (classType == null) {
             return;
         }
+    }
+
+    @ZWaveResponseHandler(id = 1, name = "PROPRIETARY_HANDLER")
+    public void handleManufacturerProprietaryReport(ZWaveCommandClassPayload payload, int endpoint) {
+        Map<String, String> values = CommandClassManufacturerProprietaryFibaroFgrm222V1
+                .handleFgrm222Report(payload.getPayloadBuffer());
+
+        ZWaveValueEvent zEvent = new ZWaveValueEvent(getNode().getNodeId(), endpoint, getCommandClass(), values);
+
+        getController().notifyEventListeners(zEvent);
     }
 
     @Override

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/impl/CommandClassManufacturerProprietaryFibaroFgrm222V1.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/impl/CommandClassManufacturerProprietaryFibaroFgrm222V1.java
@@ -287,6 +287,8 @@ public class CommandClassManufacturerProprietaryFibaroFgrm222V1 {
      * @return a {@link Map} of processed response data
      */
     public static Map<String, String> handleFgrm222Report(byte[] payload) {
+        logger.debug("parsing received message FGRM222_REPORT version 1");
+
         // Create our response map
         Map<String, String> response = new HashMap<String, String>();
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/impl/CommandClassManufacturerProprietaryFibaroFgrm222V1.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/impl/CommandClassManufacturerProprietaryFibaroFgrm222V1.java
@@ -286,9 +286,9 @@ public class CommandClassManufacturerProprietaryFibaroFgrm222V1 {
      * @param payload the {@link byte[]} payload data to process
      * @return a {@link Map} of processed response data
      */
-    public static Map<String, Object> handleFgrm222Report(byte[] payload) {
+    public static Map<String, String> handleFgrm222Report(byte[] payload) {
         // Create our response map
-        Map<String, Object> response = new HashMap<String, Object>();
+        Map<String, String> response = new HashMap<String, String>();
 
         // Process 'Constant1'
 
@@ -297,10 +297,10 @@ public class CommandClassManufacturerProprietaryFibaroFgrm222V1 {
         // Process 'Constant3'
 
         // Process 'Shutter Position'
-        response.put("SHUTTER_POSITION", Integer.valueOf(payload[6]));
+        response.put("SHUTTER_POSITION", Integer.valueOf(payload[6]).toString());
 
         // Process 'Lamella Position'
-        response.put("LAMELLA_POSITION", Integer.valueOf(payload[7]));
+        response.put("LAMELLA_POSITION", Integer.valueOf(payload[7]).toString());
 
         // Return the map of processed response data;
         return response;

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveManufacturerProprietaryCommandClassFibaroFGRM222Test.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveManufacturerProprietaryCommandClassFibaroFGRM222Test.java
@@ -81,4 +81,14 @@ public class ZWaveManufacturerProprietaryCommandClassFibaroFGRM222Test extends Z
         assertEquals(event.getAlarmEvent(), 8);
         assertEquals(event.getAlarmStatus(), 0xFF);
     }
+
+    @Test
+    public void ReceiveReportMessage() {
+        byte[] packetData = { 0x01, 0x0E, 0x00, 0x04, 0x00, 0x0B, 0x08, (byte) 0x91, 0x01, 0x0F, 0x26, 0x03, 0x03, 0x16,
+                0x63, 0x3A };
+
+        List<ZWaveEvent> events = processCommandClassMessage(packetData);
+
+        assertEquals(events.size(), 1);
+    }
 }

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveManufacturerProprietaryCommandClassFibaroFGRM222Test.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveManufacturerProprietaryCommandClassFibaroFGRM222Test.java
@@ -19,13 +19,12 @@ import java.util.List;
 
 import org.junit.Ignore;
 import org.junit.Test;
-import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmCommandClass.ReportType;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmCommandClass.ZWaveAlarmValueEvent;
-import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveBasicCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.impl.CommandClassManufacturerProprietaryFibaroFgrm222V1;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveValueEvent;
 
 /**
  * Test cases for {@link ZWaveBasicCommandClass}.
@@ -89,6 +88,9 @@ public class ZWaveManufacturerProprietaryCommandClassFibaroFGRM222Test extends Z
 
         List<ZWaveEvent> events = processCommandClassMessage(packetData);
 
-        assertEquals(events.size(), 1);
+        assertEquals(1, events.size());
+        ZWaveValueEvent event = (ZWaveValueEvent) events.get(0);
+        assertEquals("22", event.getValue("SHUTTER_POSITION"));
+        assertEquals("99", event.getValue("LAMELLA_POSITION"));
     }
 }


### PR DESCRIPTION
This is just a suggestion on how it could be fixed.
Please give feedback on how you wanted to go on with manufacturer proprietary stuff (ZWaveCommandClass and ZWaveManufacturerProprietaryCommandClass specifically).
Issue: https://github.com/openhab/org.openhab.binding.zwave/issues/1334