### PR TITLE
[OH3] Add new serial reconnect logic

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveSerialHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveSerialHandler.java
@@ -108,11 +108,10 @@ public class ZWaveSerialHandler extends ZWaveControllerHandler {
             try {
                 commPort = portIdentifier.open("org.openhab.binding.zwave", 2000);
             } catch (IllegalStateException e) {
-                if (serialPort != null) {
-                    onSerialPortError(ZWaveBindingConstants.OFFLINE_SERIAL_NOTFOUND);
-                }
+                watchdog = scheduler.schedule(this::watchSerialPort, WATCHDOG_CHECK_SECONDS, TimeUnit.SECONDS);
                 return;
             }
+
             serialPort = commPort;
             commPort.setSerialPortParams(115200, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
             try {
@@ -126,6 +125,7 @@ public class ZWaveSerialHandler extends ZWaveControllerHandler {
             } catch (UnsupportedCommOperationException e) {
                 logger.debug("Enabling receive timeout is unsupported");
             }
+
             inputStream = commPort.getInputStream();
             outputStream = commPort.getOutputStream();
             logger.debug("Starting receive thread");
@@ -311,6 +311,7 @@ public class ZWaveSerialHandler extends ZWaveControllerHandler {
                         if (serialPort == null) {
                             break;
                         }
+
                         nextByte = inputStream.read();
                         // logger.debug("SERIAL:: STATE {}, nextByte {}, count {} ", rxState, nextByte, rxLength);
 


### PR DESCRIPTION
Hi @cdjackson!

With the new nrjavaserial library version that will be available in OH3 (@wborn, this is correct, isn't it?), I think that we can improve the serial reconnect logic and remove the workaround pointed out in #1332.

The new reconnect logic just checks the serial port when the library detects that the USB device has been removed. For that, we make use of the ```serialEvent``` callback, which no longer stresses the CPU and is able to detect when the Z-Wave controller is unplugged. We also get rid of the periodic watchSerialPort thread and the reconnect task is only executed when needed.

The PR has been done against the 2.5.x branch, but, in case you are interested in it, it should be merged in a separate branch. **Warning**: it will not work with the nrjavaserial version included in openHAB 2.5.x!

Many thanks for your attention and thank you also @wborn for the work you are doing with the serial library :wink: 

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>