### PR TITLE
1334 support proprietary reports

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveManufacturerProprietaryConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveManufacturerProprietaryConverter.java
@@ -79,10 +79,10 @@ public class ZWaveManufacturerProprietaryConverter extends ZWaveCommandClassConv
         ZWaveValueEvent valueEvent = (ZWaveValueEvent) event;
         switch (channel.getUID().getId()) {
             case "blinds_lamella":
-                value = Integer.parseInt(valueEvent.getValue("LAMELLA_POSITION"));
+                value = (Integer) valueEvent.getValue("LAMELLA_POSITION");
                 break;
             case "blinds_shutter":
-                value = Integer.parseInt(valueEvent.getValue("SHUTTER_POSITION"));
+                value = (Integer) valueEvent.getValue("SHUTTER_POSITION");
                 break;
         }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
@@ -267,16 +267,16 @@ public abstract class ZWaveCommandClass {
         }
 
         logger.debug("NODE {}: Received {} V{} {}", getNode().getNodeId(), getCommandClass(), getVersion(),
-                commands.get(payload.getCommandClassCommand()).name);
+                commandMethod.name);
 
         Object[] parms = { payload, endpoint };
         try {
-            commands.get(payload.getCommandClassCommand()).method.invoke(this, parms);
+            commandMethod.method.invoke(this, parms);
         } catch (InvocationTargetException e) {
             // Handle exceptions from the command class processing
             if (e.getCause() instanceof ArrayIndexOutOfBoundsException) {
                 logger.debug("NODE {}: ArrayIndexOutOfBoundsException {} V{} {} {}", getNode().getNodeId(),
-                        getCommandClass(), getVersion(), commands.get(payload.getCommandClassCommand()).name,
+                        getCommandClass(), getVersion(), commandMethod.name,
                         SerialMessage.bb2hex(payload.getPayloadBuffer()));
             }
         } catch (IllegalAccessException | IllegalArgumentException e) {

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
@@ -589,9 +589,11 @@ public abstract class ZWaveCommandClass {
         COMMAND_CLASS_SENSOR_CONFIGURATION(0x9E, ZWaveSensorConfigurationCommandClass.class),
         COMMAND_CLASS_SECURITY_2(0x9F, null),
         COMMAND_CLASS_MARK(0xEF, null),
-        COMMAND_CLASS_NON_INTEROPERABLE(0xF0, null);
+        COMMAND_CLASS_NON_INTEROPERABLE(0xF0, null),
 
         // MANUFACTURER_PROPRIETARY class definitions are defined by the manufacturer and device id
+        COMMAND_CLASS_MANUFACTURER_PROPRIETARY_FGR222(0x010f, 0x0302, "FIBARO_FGR_222",
+                ZWaveManufacturerProprietaryCommandClass.class);
 
         /**
          * A mapping between the integer code and its corresponding

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
@@ -592,6 +592,8 @@ public abstract class ZWaveCommandClass {
         COMMAND_CLASS_NON_INTEROPERABLE(0xF0, null),
 
         // MANUFACTURER_PROPRIETARY class definitions are defined by the manufacturer and device id
+        COMMAND_CLASS_MANUFACTURER_PROPRIETARY_FGRM222(0x010f, 0x0301, "FIBARO_FGRM_222",
+                ZWaveManufacturerProprietaryCommandClass.class),
         COMMAND_CLASS_MANUFACTURER_PROPRIETARY_FGR222(0x010f, 0x0302, "FIBARO_FGR_222",
                 ZWaveManufacturerProprietaryCommandClass.class);
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveValueEvent.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveValueEvent.java
@@ -22,7 +22,7 @@ import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClas
  * @author Chris Jackson
  */
 public class ZWaveValueEvent extends ZWaveCommandClassValueEvent {
-    private Map<String, String> values;
+    private Map<String, Object> values;
 
     /**
      * Constructor. Creates a new instance of the ZWaveCommandClassValueEvent class.
@@ -30,9 +30,9 @@ public class ZWaveValueEvent extends ZWaveCommandClassValueEvent {
      * @param nodeId the nodeId of the event
      * @param endpoint the endpoint of the event.
      * @param commandClass the command class that fired the event;
-     * @param values the value for the event as Map<String, String>.
+     * @param values the value for the event as Map<String, Object>.
      */
-    public ZWaveValueEvent(int nodeId, int endpoint, CommandClass commandClass, Map<String, String> values) {
+    public ZWaveValueEvent(int nodeId, int endpoint, CommandClass commandClass, Map<String, Object> values) {
         super(nodeId, endpoint, commandClass, values);
 
         this.values = values;
@@ -44,8 +44,7 @@ public class ZWaveValueEvent extends ZWaveCommandClassValueEvent {
      * @param key the key for the requested value
      * @return the value.
      */
-    public String getValue(String key) {
+    public Object getValue(String key) {
         return values.get(key);
     }
-
 }

--- a/src/main/resources/ESH-INF/thing/fibaro/fgr222_24_24.xml
+++ b/src/main/resources/ESH-INF/thing/fibaro/fgr222_24_24.xml
@@ -76,6 +76,7 @@ Roller Shutter 2<br /><h1>Overview</h1><p>The device allows for controlling moto
       <property name="dbReference">413</property>
       <property name="commandClass:COMMAND_CLASS_SWITCH_MULTILEVEL">ccAdd</property>
       <property name="defaultAssociations">3</property>
+      <property name="commandClass:COMMAND_CLASS_MANUFACTURER_PROPRIETARY">ccAdd,className=FIBARO_FGRM222_V1</property>
     </properties>
 
     <!-- CONFIGURATION DESCRIPTIONS -->

--- a/src/main/resources/ESH-INF/thing/fibaro/fgrm222_0_0.xml
+++ b/src/main/resources/ESH-INF/thing/fibaro/fgrm222_0_0.xml
@@ -76,6 +76,7 @@ Roller Shutter<br /><h1>Overview</h1><p>Fibaro Roller Shutter is a universal, Z-
       <property name="dbReference">116</property>
       <property name="commandClass:COMMAND_CLASS_SWITCH_MULTILEVEL">ccAdd</property>
       <property name="defaultAssociations">3</property>
+      <property name="commandClass:COMMAND_CLASS_MANUFACTURER_PROPRIETARY">ccAdd,className=FIBARO_FGRM222_V1</property>
     </properties>
 
     <!-- CONFIGURATION DESCRIPTIONS -->

--- a/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveManufacturerProprietaryFibaroFgrm222ConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveManufacturerProprietaryFibaroFgrm222ConverterTest.java
@@ -26,7 +26,6 @@ import org.eclipse.smarthome.core.types.State;
 import org.junit.Test;
 import org.openhab.binding.zwave.handler.ZWaveThingChannel;
 import org.openhab.binding.zwave.handler.ZWaveThingChannel.DataType;
-import org.openhab.binding.zwave.internal.converter.ZWaveManufacturerProprietaryConverter;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveValueEvent;
@@ -52,9 +51,9 @@ public class ZWaveManufacturerProprietaryFibaroFgrm222ConverterTest extends ZWav
         State state;
         ZWaveValueEvent event;
 
-        Map<String, String> values = new HashMap<String, String>();
-        values.put("LAMELLA_POSITION", "62");
-        values.put("SHUTTER_POSITION", "12");
+        Map<String, Object> values = new HashMap<String, Object>();
+        values.put("LAMELLA_POSITION", 62);
+        values.put("SHUTTER_POSITION", 12);
         event = new ZWaveValueEvent(1, 0, CommandClass.COMMAND_CLASS_MANUFACTURER_PROPRIETARY, values);
         state = converter.handleEvent(channel, event);
         assertEquals(state.getClass(), PercentType.class);
@@ -72,9 +71,9 @@ public class ZWaveManufacturerProprietaryFibaroFgrm222ConverterTest extends ZWav
         State state;
         ZWaveValueEvent event;
 
-        Map<String, String> values = new HashMap<String, String>();
-        values.put("LAMELLA_POSITION", "62");
-        values.put("SHUTTER_POSITION", "12");
+        Map<String, Object> values = new HashMap<String, Object>();
+        values.put("LAMELLA_POSITION", 62);
+        values.put("SHUTTER_POSITION", 12);
         event = new ZWaveValueEvent(1, 0, CommandClass.COMMAND_CLASS_MANUFACTURER_PROPRIETARY, values);
         state = converter.handleEvent(channel, event);
         assertEquals(state.getClass(), PercentType.class);

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClassTest.java
@@ -128,7 +128,9 @@ public class ZWaveCommandClassTest {
                     mockedController);
             assertNotNull(cls);
             cls.setVersion(version);
-            cls.setOptions(commandClassOptions);
+            if (commandClassOptions != null) {
+                cls.setOptions(commandClassOptions);
+            }
 
             Mockito.when(mockedEndpoint0.getCommandClass(Matchers.any(CommandClass.class)))
                     .thenAnswer(new Answer<ZWaveCommandClass>() {

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClassTest.java
@@ -68,7 +68,8 @@ public class ZWaveCommandClassTest {
      * @param version commandclass version
      * @return List of ZWaveEvent(s)
      */
-    protected List<ZWaveEvent> processCommandClassMessage(byte[] packetData, int version) {
+    protected List<ZWaveEvent> processCommandClassMessage(byte[] packetData, int version, int manufacturer,
+            int deviceType, Map<String, String> commandClassOptions) {
         try {
 
             SerialMessage msg = new SerialMessage(packetData);
@@ -83,6 +84,8 @@ public class ZWaveCommandClassTest {
             argument = ArgumentCaptor.forClass(ZWaveEvent.class);
             Mockito.doNothing().when(mockedController).notifyEventListeners(argument.capture());
             mockedNode = new ZWaveNode(0, 0, mockedController);
+            mockedNode.setManufacturer(manufacturer);
+            mockedNode.setDeviceType(deviceType);
             ZWaveEndpoint mockedEndpoint0 = Mockito.mock(ZWaveEndpoint.class);
             ZWaveEndpoint mockedEndpoint1 = Mockito.mock(ZWaveEndpoint.class);
             ZWaveEndpoint mockedEndpoint2 = Mockito.mock(ZWaveEndpoint.class);
@@ -125,6 +128,7 @@ public class ZWaveCommandClassTest {
                     mockedController);
             assertNotNull(cls);
             cls.setVersion(version);
+            cls.setOptions(commandClassOptions);
 
             Mockito.when(mockedEndpoint0.getCommandClass(Matchers.any(CommandClass.class)))
                     .thenAnswer(new Answer<ZWaveCommandClass>() {
@@ -186,6 +190,10 @@ public class ZWaveCommandClassTest {
         return argument.getAllValues();
     }
 
+    protected List<ZWaveEvent> processCommandClassMessage(byte[] packetData, int version) {
+        return processCommandClassMessage(packetData, version, Integer.MAX_VALUE, Integer.MAX_VALUE, null);
+    }
+
     /**
      * Helper class to create everything we need to test a command class message.
      *
@@ -198,7 +206,7 @@ public class ZWaveCommandClassTest {
      * @return List of ZWaveEvent(s)
      */
     protected List<ZWaveEvent> processCommandClassMessage(byte[] packetData) {
-        return processCommandClassMessage(packetData, 1);
+        return processCommandClassMessage(packetData, 1, Integer.MAX_VALUE, Integer.MAX_VALUE, null);
     }
 
     protected ZWaveCommandClass getCommandClass(CommandClass cls) {

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveManufacturerProprietaryCommandClassFibaroFGRM222Test.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveManufacturerProprietaryCommandClassFibaroFGRM222Test.java
@@ -15,17 +15,18 @@ package org.openhab.binding.zwave.internal.protocol.commandclass;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Ignore;
 import org.junit.Test;
-import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmCommandClass.ReportType;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmCommandClass.ZWaveAlarmValueEvent;
-import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveBasicCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.impl.CommandClassManufacturerProprietaryFibaroFgrm222V1;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveValueEvent;
 
 /**
  * Test cases for {@link ZWaveBasicCommandClass}.
@@ -80,5 +81,21 @@ public class ZWaveManufacturerProprietaryCommandClassFibaroFGRM222Test extends Z
         assertEquals(event.getAlarmType(), ZWaveAlarmCommandClass.AlarmType.BURGLAR);
         assertEquals(event.getAlarmEvent(), 8);
         assertEquals(event.getAlarmStatus(), 0xFF);
+    }
+
+    @Test
+    public void ReceiveReportMessage() {
+        byte[] packetData = { 0x01, 0x0E, 0x00, 0x04, 0x00, 0x0B, 0x08, (byte) 0x91, 0x01, 0x0F, 0x26, 0x03, 0x03, 0x16,
+                0x63, 0x3A };
+
+        Map<String, String> options = new HashMap<String, String>();
+        options.put("className", "FIBARO_FGRM222_V1");
+
+        List<ZWaveEvent> events = processCommandClassMessage(packetData, 1, 0x010f, 0x0302, options);
+
+        assertEquals(1, events.size());
+        ZWaveValueEvent event = (ZWaveValueEvent) events.get(0);
+        assertEquals(22, event.getValue("SHUTTER_POSITION"));
+        assertEquals(99, event.getValue("LAMELLA_POSITION"));
     }
 }


### PR DESCRIPTION
Hello @cdjackson 

This is my second try at fixing / completing the code for handling manufacturer proprietary reports of fibaro fgr-222 roller shutters in venetian blind mode (parameter 3: reports type set to 1).
This approach does not delete any code and will support future manufacturer proprietary code.

The first try (PR) was this: #1335 
The issue is here: #1334 

The following needed to be changed for it to work:
1) a new property in the database for the things (it should work for fgrm-222 and fgr-222) to force CommandClass instantiation an being able to provide a custom option called `className`
2) an enum entry in `ZWaveCommandClass.CommandClass` for both devices mapping to `ZWaveManufacturerProprietaryCommandClass`
3) change the value type of `ZWaveValueEvent` from String to object to match the generated code and the existing converter code.
4) fix a bug in `ZWaveCommandClass.handleApplicationCommandRequest` which prevented handling of command requests by the default handler
5) implement the handling of manufacturer proprietary reports for fibaro fgrm-222 / fgr-222 devices in `ZWaveManufacturerProprietaryCommandClass` which delegates the work to a specific, generated class, depending on the database property `className` added above

I still think it's kind of unnecessary to having to configure which class should be used for delegation by the database property and also specifically adding a manufacturer/device type specific entry in the CommandClass enum. I can come up with reasons for one and the other, but not for having both:
a) using the enum would enable to subclass `ZWaveManufacturerProprietaryCommandClass` for different manufacturers or even devices, which can then delegate to the proper generated code class. For that, the database property would not be needed, as the code would already know where to delegate to.
b) using the database property allows to have all manufacturer proprietary code to be handled by `ZWaveManufacturerProprietaryCommandClass` (which delegates to different classes, depending on the database property). This does not need the CommandClass - it could be setup straight forward by mapping 0x91 directly to `ZWaveManufacturerProprietaryCommandClass`.
c) other than being super-flexible on how to implement future proprietary stuff, I can't see why we should do both a) and b)
But after all, one of the main reasons I struggled to get this to work was the lack of an example, aka existing code already having been implemented - I seem to be the first to use these mechanisms.
With this code, it should now be easier to understand what one needs to do to add more proprietary code... 

I'd greatly appreciate any feedback on this solution - I'm no professional java developer (I code in C# for almost 10 years now and C++ before that), so I could very well have coded something un-java-ish.

Best regards
Patrik