### PR TITLE
Workaround for buggy IRIS CT101 thermostat

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -1283,12 +1283,15 @@ public class ZWaveNode {
             }
 
             // Check that the length is long enough for the encapsulated command to be included
-            if (payload.getCommandClassCommand() == 6 && payload.getPayloadLength() > 4) {
+            if (payload.getCommandClassCommand() == 6 && payload.getPayloadLength() > 4
+                    && !hasMultiInstanceAsMultiChannelQuirk()) {
                 // MULTI_INSTANCE_ENCAP
                 endpointNumber = payload.getPayloadByte(2);
 
                 payload = new ZWaveCommandClassPayload(payload, 3);
-            } else if (payload.getCommandClassCommand() == 13 && payload.getPayloadLength() > 5) {
+            } else if ((payload.getCommandClassCommand() == 13
+                    || payload.getCommandClassCommand() == 6 && hasMultiInstanceAsMultiChannelQuirk())
+                    && payload.getPayloadLength() > 5) {
                 // MULTI_CHANNEL_ENCAP
                 endpointNumber = multichannelCommandClass.getSourceEndpoint(payload);
                 payload = new ZWaveCommandClassPayload(payload, 4);
@@ -1528,5 +1531,10 @@ public class ZWaveNode {
             timerTask.cancel();
         }
         timerTask = null;
+    }
+
+    // The IRIS Radio Thermostat CT-101 has a bug where it sends an incorrect command class code.
+    private boolean hasMultiInstanceAsMultiChannelQuirk() {
+        return manufacturer == 0x98 && deviceType == 0x6501 && deviceId == 0xc;
     }
 }


### PR DESCRIPTION
The IRIS version of the Radio Thermostat CT101 has a buggy Zwave
implementation.

Signed-off-by: Marcus Better <marcus@better.se>