### PR TITLE
Add textual configuration sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,16 +105,17 @@ There are a large number of things supported by the Z-Wave binding, so configura
 
 #### Textual Thing Configuration
 
-Things configured manually through text files require the following minimum configuration to be set. -:
-
-| Configuration      | Description                                                                                                   |
-|--------------------|---------------------------------------------------------------------------------------------------------------|
-| zwave_nodeid       | Sets the node id of the node within the network.                                                              |
-| zwave_manufacturer | Sets the manufacturer ID for this device (as decimal). This is used to get the thing type from the database.  |
-| zwave_deviceid     | Specifies the device ID for this device (as decimal). This is used to get the thing type from the database.   |
-| zwave_devicetype   | Specifies the device type for this device (as decimal). This is used to get the thing type from the database. |
-| zwave_version      | Specifies the application version for this device. This is used to get the thing type from the database.      |
-
+Things configured manually through text files must define a Bridge for the controller and all devices under that. 
+Follow this sample format:
+```
+Bridge zwave:serial_zstick:controller "ZWave Controller" [ port="/dev/ttyACM0", controller_softreset="false", controller_master="true", heal_enable="true", security_networkkey="XXX" ]
+{
+	aeon_zw100_01_008 sensor1 "Sensor 1" [ node_id=1 ]
+	august_asl03_00_000 frontDoor "Front Door Lock" [ node_id=2 ]	
+}
+```
+`serial_zstick` is the type of your controller. `controller` defines your controller's thing name. Replace `XXX` with your network key. 
+Check [here](https://community.openhab.org/t/zwave-manual-thing-configuration/26542) for additional details. 
 
 ## Channels
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Before the binding can be used, a serial adapter must be added. This needs to be
 
 Once the binding is authorized, and an adapter is added, it automatically reads all devices that are included into the network. This is read directly from the Z-Wave controller and new things are added to the Inbox. When the discovery process is started, the binding will put the controller into inclusion mode for a defined period of time to allow new devices to be discovered and added to the network. Device discovery occurs in two phases - first the device is added to the inbox as an *Unknown Device* to provide the user immediate feedback that the device has been discovered. Once the device type is known, the inbox entry is updated with the actual device name and manufacturer. 
 
+In particular the following properties will be automatically populated:
+| Property           | Description                                  |
+|--------------------|----------------------------------------------|
+| zwave_nodeid       | Node id of the node within the network       |
+| zwave_manufacturer | Manufacturer ID for this device (as decimal) |
+| zwave_deviceid     | Device ID for this device (as decimal)       |
+| zwave_devicetype   | Device type for this device (as decimal)     |
+| zwave_version      | Application version for this device          |
 
 ## Binding Configuration
 
@@ -105,7 +113,7 @@ There are a large number of things supported by the Z-Wave binding, so configura
 
 #### Textual Thing Configuration
 
-Things configured manually through text files must define a Bridge for the controller and all devices under that. 
+To configure things manually via a `.things` file you need to configure a Bridge for the controller and then configure devices under that bridge. 
 Follow this sample format:
 ```
 Bridge zwave:serial_zstick:controller "ZWave Controller" [ port="/dev/ttyACM0", controller_softreset="false", controller_master="true", heal_enable="true", security_networkkey="XXX" ]
@@ -114,8 +122,42 @@ Bridge zwave:serial_zstick:controller "ZWave Controller" [ port="/dev/ttyACM0", 
 	august_asl03_00_000 frontDoor "Front Door Lock" [ node_id=2 ]	
 }
 ```
-`serial_zstick` is the type of your controller. `controller` defines your controller's thing name. Replace `XXX` with your network key. 
-Check [here](https://community.openhab.org/t/zwave-manual-thing-configuration/26542) for additional details. 
+Adjust the bridge details as needed, where:
+
+* `serial_zstick` represents the thing type UID of the controller
+* `controller` defines the controller's thing name
+* `XXX` is a placeholder for the controller's network key
+
+Adjust the details for each device as needed as well, where:
+
+* The first value (e.g. `aeon_zw100_01_008`) specifies the device's thing type UID.
+You can find this value in the [documentation page for all supported Z-Wave devices](https://www.openhab.org/addons/bindings/zwave/doc/things.html).
+Note that the thing type UID has a firmware version appended (e.g. `01_008`).
+Some devices use different thing type UIDs for different firmware versions. 
+You need to make sure to pick the thing type UID that supports your device's firmware. 
+If you don't know your device's firmware version discover the device dynamically and find the firmware version under `Properties` - `zwave_version`.
+* The second value (e.g. `sensor1`) defines the thing name
+* `node_id` is the device's Z-Wwave node id
+
+Define items via a `.items` file leveraging the [channel details documented for your device](https://www.openhab.org/addons/bindings/zwave/doc/things.html), for example:
+```
+Switch Sensor1 "Motion Sensor" {channel="zwave:aeon_zw100_01_008:controller:sensor1:alarm_motion"}
+```
+
+##### A note on thing UIDs: 
+All things are assigned a unique id following the format `binding`:`device type`:`bridge`:`id` and Z-Wave devices are no different. 
+The above sample for example would be assigned the UID `zwave:aeon_zw100_01_008:controller:sensor1`.
+
+You might have noticed that if you don't define your device via a `.things` file and instead use dynamic discovery the device's UID will be `zwave:device:controller:node1`. 
+Why the difference? 
+During dynamic discovery the binding inquires about all existing Z-Wave nodes. 
+But all the binding receives immediately from the controller is a list of node ids. 
+Additional details about device types are retrieved only subsequently and require a significant amount of time (seconds or longer).
+To provide quick feedback to the user during dynamic discovery the binding has no choice but to create a UID that doesn't depend on any device details. 
+
+To accomplish this the binding uses a generic device type `device`, which simply represents an `Unknown Device`. 
+For the `id` the binding uses the nodeid, which is unique across all devices.
+On the other hand when you define a device via a `.things` file you are responsible for providing the exact device type and a unique id - thus the different UID format with textual configuration. 
 
 ## Channels
 


### PR DESCRIPTION
Samples are very powerful to quickly get users to understand the configuration. Removed the table that referred to the old device type. 

Signed-off-by: Mark Theiding <mark.theiding@gmail.com>