### PR TITLE
Initial Stage GATEWAY 700 series adapter support

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -391,7 +391,8 @@ public class ZWaveNodeInitStageAdvancer {
 
         // Controllers aren't designed to allow communication with their node.
         // If this is a controller, we're done
-        if (node.getDeviceClass().getSpecificDeviceClass() == Specific.SPECIFIC_TYPE_PC_CONTROLLER) {
+        if ((node.getDeviceClass().getSpecificDeviceClass() == Specific.SPECIFIC_TYPE_PC_CONTROLLER) ||
+            (node.getDeviceClass().getSpecificDeviceClass() == Specific.SPECIFIC_TYPE_GATEWAY)) {
             logger.debug("NODE {}: Node advancer: FAILED_CHECK - Controller - terminating initialisation",
                     node.getNodeId());
             setCurrentStage(ZWaveNodeInitStage.DONE);


### PR DESCRIPTION
Fix for Z-Wave 700 series USB adapters, which are using Specific type Gateway, compared to specific type PC_Controller, used by 500 series adapters.
fixes #1369 

Signed-off-by: Nikita Selednikov <selednikovne@gmail.com> (github: NilsBohr)