### PR TITLE
Add RFC2217 discovery using mDNS

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/discovery/ZWaveRFC2217DiscoveryParticipant.java
+++ b/src/main/java/org/openhab/binding/zwave/discovery/ZWaveRFC2217DiscoveryParticipant.java
@@ -69,7 +69,7 @@ public class ZWaveRFC2217DiscoveryParticipant implements MDNSDiscoveryParticipan
                     .withProperty(CONFIGURATION_PORT, port_id).withLabel(label);
 
             if (homeId != null) {
-                discoveryResult.withProperty("homeId", homeId).withRepresentationProperty("homeId");
+                discoveryResult.withProperty(PROPERTY_HOMEID, homeId).withRepresentationProperty(PROPERTY_HOMEID);
             }
 
             return discoveryResult.build();

--- a/src/main/resources/ESH-INF/thing/controller_serial.xml
+++ b/src/main/resources/ESH-INF/thing/controller_serial.xml
@@ -17,6 +17,8 @@
             <channel id="serial_cse" typeId="serial_cse" />
         </channels>
 
+        <representation-property>zwave_homeid</representation-property>
+
         <config-description>
             <parameter-group name="port">
                 <label>Port Configuration</label>


### PR DESCRIPTION
Hi @cdjackson!

I don't know what you're gonna think of my proposal, but I at least I have to try. A couple of months ago I opened an issue (https://github.com/openhab/openhab-core/issues/1511) in openHAB core's repository to try to create a standard for the discovery of RFC2217 ports in the local network. In fact, the program that searches for connected USB devices, creates the serial connection, shares it via RFC2217 and announces it via mDNS can be found here: https://github.com/bodiroga/rfc2217-gateway. As described in the issue, I decided to write the program because I could not find any similar convention or standard, that's why I chose the name ```_rfc2217._tpc.local```. Seeing that the topic did not arouse much interest, and that the idea would only be developed for openHAB 3, I have encouraged myself to write the Z-Wave discovery service to see how it works. The result: it works great.

My main idea opening the PR is to know if you are willing to integrate something like this into the binding before openHAB 3 becomes stable. As you can see, it's just a matter of adding a class and, in principle, it shouldn't affect the regular use of the binding. The things created through this service will make use of the RFC2217 protocol ("rfc2217://192.168.10.15:5555", for example), thanks to the work we did in May with @wborn .

Of course, I'm more than open to change any implementation detail that you don't like: the thingUID value, the representation property, the function names... That shouldn't be a problem! :wink: 

What do you think? Any feedback would be highly appreciated.

Thank you very much for your work and best regards!

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>