### PR TITLE
Remove dependency on 'org.apache.commons.*'

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveSerialHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveSerialHandler.java
@@ -22,7 +22,6 @@ import java.util.TooManyListenersException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.io.IOUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -222,11 +221,19 @@ public class ZWaveSerialHandler extends ZWaveControllerHandler {
     private void disposeSerialConnection() {
         logger.debug("Disposing serial connection");
         if (inputStream != null) {
-            IOUtils.closeQuietly(inputStream);
+            try {
+                inputStream.close();
+            } catch (IOException e) {
+                logger.debug("Error while closing the input stream: {}", e.getMessage());
+            }
             inputStream = null;
         }
         if (outputStream != null) {
-            IOUtils.closeQuietly(outputStream);
+            try {
+                outputStream.close();
+            } catch (IOException e) {
+                logger.debug("Error while closing the output stream: {}", e.getMessage());
+            }
             outputStream = null;
         }
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialMessage.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialMessage.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.commons.lang.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -158,7 +157,7 @@ public class SerialMessage {
         }
         messageType = buffer[2] == 0x00 ? SerialMessageType.Request : SerialMessageType.Response;
         messageClassKey = buffer[3] & 0xFF;
-        messagePayload = ArrayUtils.subarray(buffer, 4, messageLength + 1);
+        messagePayload = Arrays.copyOfRange(buffer, 4, messageLength + 1);
         messageNode = nodeId;
 
         // TODO: This check isn't 100% correct - at least not for ApplicationUpdate as it has no callback id

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/GetVersionMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/GetVersionMessageClass.java
@@ -12,7 +12,8 @@
  */
 package org.openhab.binding.zwave.internal.protocol.serialmessage;
 
-import org.apache.commons.lang.ArrayUtils;
+import java.util.Arrays;
+
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
@@ -43,7 +44,7 @@ public class GetVersionMessageClass extends ZWaveCommandProcessor {
     public boolean handleResponse(ZWaveController zController, ZWaveTransaction transaction,
             SerialMessage incomingMessage) throws ZWaveSerialMessageException {
         ZWaveLibraryType = incomingMessage.getMessagePayloadByte(12);
-        zWaveVersion = new String(ArrayUtils.subarray(incomingMessage.getMessagePayload(), 0, 11));
+        zWaveVersion = new String(Arrays.copyOfRange(incomingMessage.getMessagePayload(), 0, 11));
         logger.debug("Got MessageGetVersion response. Version={}, Library Type={}", zWaveVersion, ZWaveLibraryType);
 
         transaction.setTransactionComplete();


### PR DESCRIPTION
Hi @cdjackson!

As promised in #1343, I have removed all references to 'org.apache.commons.*' in line with https://github.com/openhab/openhab-addons/issues/7722.

Closes #1343

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>