### PR TITLE
Add ZWave controller properties

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
+++ b/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
@@ -73,6 +73,7 @@ public class ZWaveBindingConstants {
     public final static String PROPERTY_DEVICETYPE = "zwave_devicetype";
     public final static String PROPERTY_VERSION = "zwave_version";
 
+    public final static String PROPERTY_HOMEID = "zwave_homeid";
     public final static String PROPERTY_NODEID = "zwave_nodeid";
     public final static String PROPERTY_NEIGHBOURS = "zwave_neighbours";
     public final static String PROPERTY_LISTENING = "zwave_listening";

--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
@@ -398,6 +398,13 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
         } catch (IllegalStateException e) {
             // Eat it...
         }
+
+        Map<String, String> properties = editProperties();
+        properties.put("manufacturerId", Integer.toHexString(controller.getManufactureId()));
+        properties.put("modelId", Integer.toHexString(controller.getDeviceId()));
+        properties.put("homeId", Integer.toHexString(controller.getHomeId()));
+        properties.put("nodeId", Integer.toString(controller.getOwnNodeId()));
+        updateProperties(properties);
     }
 
     @Override

--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
@@ -400,10 +400,10 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
         }
 
         Map<String, String> properties = editProperties();
-        properties.put("manufacturerId", Integer.toHexString(controller.getManufactureId()));
-        properties.put("modelId", Integer.toHexString(controller.getDeviceId()));
-        properties.put("homeId", Integer.toHexString(controller.getHomeId()));
-        properties.put("nodeId", Integer.toString(controller.getOwnNodeId()));
+        properties.put(PROPERTY_MANUFACTURER, Integer.toHexString(controller.getManufactureId()));
+        properties.put(PROPERTY_DEVICEID, Integer.toHexString(controller.getDeviceId()));
+        properties.put(PROPERTY_HOMEID, Integer.toHexString(controller.getHomeId()));
+        properties.put(PROPERTY_NODEID, Integer.toString(controller.getOwnNodeId()));
         updateProperties(properties);
     }
 

--- a/src/main/resources/ESH-INF/thing/controller_serial.xml
+++ b/src/main/resources/ESH-INF/thing/controller_serial.xml
@@ -17,6 +17,13 @@
             <channel id="serial_cse" typeId="serial_cse" />
         </channels>
 
+        <properties>
+            <property name="modelId"></property>
+            <property name="manufacturerId"></property>
+            <property name="nodeId"></property>
+        </properties>
+        <representation-property>homeId</representation-property>
+
         <config-description>
             <parameter-group name="port">
                 <label>Port Configuration</label>
@@ -198,7 +205,7 @@ In this mode, only <i>Entry Control Devices</i> such as locks will be securely i
         </config-description>
     </bridge-type>
 
-    <channel-type id="serial_sof">
+    <channel-type id="serial_sof" advanced="true">
         <item-type>Number</item-type>
         <label>Start Frames</label>
         <description>Counter tracking the number of SOF bytes received</description>
@@ -206,7 +213,7 @@ In this mode, only <i>Entry Control Devices</i> such as locks will be securely i
         <state pattern="%d" readOnly="true"></state>
     </channel-type>
 
-    <channel-type id="serial_ack">
+    <channel-type id="serial_ack" advanced="true">
         <item-type>Number</item-type>
         <label>Frames Acknowledged</label>
         <description>Counter tracking the number of frames acknowledged by the controller</description>
@@ -214,7 +221,7 @@ In this mode, only <i>Entry Control Devices</i> such as locks will be securely i
         <state pattern="%d" readOnly="true"></state>
     </channel-type>
 
-    <channel-type id="serial_nak">
+    <channel-type id="serial_nak" advanced="true">
         <item-type>Number</item-type>
         <label>Frames Rejected</label>
         <description>Counter tracking the number of frames rejected by the controller</description>
@@ -222,7 +229,7 @@ In this mode, only <i>Entry Control Devices</i> such as locks will be securely i
         <state pattern="%d" readOnly="true"></state>
     </channel-type>
 
-    <channel-type id="serial_can">
+    <channel-type id="serial_can" advanced="true">
         <item-type>Number</item-type>
         <label>Frames Cancelled</label>
         <description>Counter tracking the number of frames cancelled by the controller</description>
@@ -230,7 +237,7 @@ In this mode, only <i>Entry Control Devices</i> such as locks will be securely i
         <state pattern="%d" readOnly="true"></state>
     </channel-type>
 
-    <channel-type id="serial_oof">
+    <channel-type id="serial_oof" advanced="true">
         <item-type>Number</item-type>
         <label>OOF Bytes Received</label>
         <description>Counter tracking the number of out of flow bytes received</description>
@@ -238,7 +245,7 @@ In this mode, only <i>Entry Control Devices</i> such as locks will be securely i
         <state pattern="%d" readOnly="true"></state>
     </channel-type>
 
-    <channel-type id="serial_cse">
+    <channel-type id="serial_cse" advanced="true">
         <item-type>Number</item-type>
         <label>Received Checksum Errors</label>
         <description>Counter tracking the number of frames received with checksum errors</description>

--- a/src/main/resources/ESH-INF/thing/controller_serial.xml
+++ b/src/main/resources/ESH-INF/thing/controller_serial.xml
@@ -17,11 +17,6 @@
             <channel id="serial_cse" typeId="serial_cse" />
         </channels>
 
-        <properties>
-            <property name="modelId"></property>
-            <property name="manufacturerId"></property>
-            <property name="nodeId"></property>
-        </properties>
         <representation-property>homeId</representation-property>
 
         <config-description>

--- a/src/main/resources/ESH-INF/thing/controller_serial.xml
+++ b/src/main/resources/ESH-INF/thing/controller_serial.xml
@@ -17,8 +17,6 @@
             <channel id="serial_cse" typeId="serial_cse" />
         </channels>
 
-        <representation-property>homeId</representation-property>
-
         <config-description>
             <parameter-group name="port">
                 <label>Port Configuration</label>


### PR DESCRIPTION
This PR adds the modelId, the manufactureId, the homeId and the nodeId as properties to the Thing of the serial controller. The homeId is set as the representation property of the Thing. Also, it marks all the Thing's channels as advanced, because they are not very used (or not used at all by non-expert users).

Closes #1390 

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>