### PR TITLE
Extend Door Lock Command Class

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveDoorLockConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveDoorLockConverter.java
@@ -100,7 +100,7 @@ public class ZWaveDoorLockConverter extends ZWaveCommandClassConverter {
     }
 
     private State handleEventCondition(ZWaveThingChannel channel, ZWaveCommandClassValueEvent event) {
-        if (!channel.getUID().getId().equals("sensor_door")) {
+        if (!channel.getUID().getId().startsWith("sensor_door")) {
             return null;
         }
         Integer eventValue = (Integer) event.getValue();

--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveDoorLockConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveDoorLockConverter.java
@@ -19,6 +19,7 @@ import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.zwave.handler.ZWaveControllerHandler;
 import org.openhab.binding.zwave.handler.ZWaveThingChannel;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
@@ -82,7 +83,14 @@ public class ZWaveDoorLockConverter extends ZWaveCommandClassConverter {
 
         switch (channel.getDataType()) {
             case OnOffType:
-                return (Integer) event.getValue() == 0x00 ? OnOffType.OFF : OnOffType.ON;
+                switch ((Integer) event.getValue()) {
+                    case 0xFF:
+                        return OnOffType.ON;
+                    case 0xFE:
+                        return UnDefType.UNDEF;
+                    default:
+                        return OnOffType.OFF;
+                }
             default:
                 logger.warn("No conversion in {} to {}", this.getClass().getSimpleName(), channel.getDataType());
                 break;

--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveDoorLockConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveDoorLockConverter.java
@@ -77,7 +77,7 @@ public class ZWaveDoorLockConverter extends ZWaveCommandClassConverter {
     }
 
     private State handleEventLockState(ZWaveThingChannel channel, ZWaveCommandClassValueEvent event) {
-        if (!channel.getUID().getId().equals("lock_door")) {
+        if (!channel.getChannelTypeUID().getId().equals("lock_door")) {
             return null;
         }
 
@@ -100,7 +100,7 @@ public class ZWaveDoorLockConverter extends ZWaveCommandClassConverter {
     }
 
     private State handleEventCondition(ZWaveThingChannel channel, ZWaveCommandClassValueEvent event) {
-        if (!channel.getUID().getId().startsWith("sensor_door")) {
+        if (!channel.getChannelTypeUID().getId().equals("sensor_door")) {
             return null;
         }
         Integer eventValue = (Integer) event.getValue();

--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveDoorLockConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveDoorLockConverter.java
@@ -103,10 +103,21 @@ public class ZWaveDoorLockConverter extends ZWaveCommandClassConverter {
         if (!channel.getUID().getId().equals("sensor_door")) {
             return null;
         }
-
+        Integer eventValue = (Integer) event.getValue();
+        if (channel.getArguments().containsKey("type")) {
+            String sensorType = channel.getArguments().get("type").toUpperCase();
+            switch (sensorType) {
+                case "BOLT":
+                    eventValue = ~(eventValue >> 1);
+                    break;
+                case "LATCH":
+                    eventValue = eventValue >> 2;
+                    break;
+            }
+        }
         switch (channel.getDataType()) {
             case OpenClosedType:
-                return ((Integer) event.getValue() & 0x01) == 0x00 ? OpenClosedType.OPEN : OpenClosedType.CLOSED;
+                return (eventValue & 0x01) == 0x00 ? OpenClosedType.OPEN : OpenClosedType.CLOSED;
             default:
                 logger.warn("No conversion in {} to {}", this.getClass().getSimpleName(), channel.getDataType());
                 break;

--- a/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveDoorLockConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveDoorLockConverterTest.java
@@ -54,7 +54,7 @@ public class ZWaveDoorLockConverterTest extends ZWaveCommandClassConverterTest {
         assertEquals(OnOffType.class, state.getClass());
         assertEquals(state, OnOffType.OFF);
 
-        event = new ZWaveCommandClassValueEvent(1, 0, CommandClass.COMMAND_CLASS_DOOR_LOCK, 1,
+        event = new ZWaveCommandClassValueEvent(1, 0, CommandClass.COMMAND_CLASS_DOOR_LOCK, 0xFF,
                 ZWaveDoorLockCommandClass.Type.DOOR_LOCK_STATE);
         state = converter.handleEvent(channel, event);
         assertEquals(OnOffType.class, state.getClass());


### PR DESCRIPTION
This PR adds two features to the door lock command class:
- Adds the capability to the door lock command class to accept UNKNOWN lock state, mapped to UndefType.UNDEF
- Adds the capability to handle BOLT and LATCH to the door condition event. Needs to be defined by a type in the device database.
