### PR TITLE
Add RGBW color mode

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveColorConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveColorConverter.java
@@ -18,10 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.openhab.core.library.types.HSBType;
-import org.openhab.core.library.types.PercentType;
-import org.openhab.core.types.Command;
-import org.openhab.core.types.State;
 import org.openhab.binding.zwave.handler.ZWaveControllerHandler;
 import org.openhab.binding.zwave.handler.ZWaveThingChannel;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
@@ -29,8 +25,14 @@ import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveColorComman
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveColorCommandClass.ZWaveColorType;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveColorCommandClass.ZWaveColorValueEvent;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiLevelSwitchCommandClass;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
 import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
+import org.openhab.core.library.types.HSBType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,11 +113,15 @@ public class ZWaveColorConverter extends ZWaveCommandClassConverter {
     @Override
     public List<ZWaveCommandClassTransactionPayload> receiveCommand(ZWaveThingChannel channel, ZWaveNode node,
             Command command) {
-        ZWaveColorCommandClass commandClass = (ZWaveColorCommandClass) node
+        ZWaveColorCommandClass colorCommandClass = (ZWaveColorCommandClass) node
                 .resolveCommandClass(ZWaveCommandClass.CommandClass.COMMAND_CLASS_SWITCH_COLOR, channel.getEndpoint());
+        ZWaveMultiLevelSwitchCommandClass levelCommandClass = (ZWaveMultiLevelSwitchCommandClass) node
+                .resolveCommandClass(ZWaveCommandClass.CommandClass.COMMAND_CLASS_SWITCH_MULTILEVEL,
+                        channel.getEndpoint());
 
-        Collection<ZWaveCommandClassTransactionPayload> rawMessages = null;
+        Collection<ZWaveCommandClassTransactionPayload> rawMessages = new ArrayList<>();
 
+        int level = -1;
         Map<ZWaveColorType, Integer> colors = new TreeMap<>();
 
         // Since we get an HSB, there is brightness information. However, we only deal with the color class here
@@ -123,16 +129,31 @@ public class ZWaveColorConverter extends ZWaveCommandClassConverter {
         if ("RGB".equals(channel.getArguments().get("colorMode"))) {
             // Command must be color - convert to zwave format
             HSBType color = (HSBType) command;
+            level = color.getBrightness().intValue();
 
             // Queue the command
             colors.put(ZWaveColorType.RED, scaleColor(color.getRed()));
             colors.put(ZWaveColorType.GREEN, scaleColor(color.getGreen()));
             colors.put(ZWaveColorType.BLUE, scaleColor(color.getBlue()));
-            if (commandClass.isColorSupported(ZWaveColorType.COLD_WHITE)) {
+            if (colorCommandClass.isColorSupported(ZWaveColorType.COLD_WHITE)) {
                 colors.put(ZWaveColorType.COLD_WHITE, 0);
             }
-            if (commandClass.isColorSupported(ZWaveColorType.WARM_WHITE)) {
+            if (colorCommandClass.isColorSupported(ZWaveColorType.WARM_WHITE)) {
                 colors.put(ZWaveColorType.WARM_WHITE, 0);
+            }
+        } else if ("RGBW".equals(channel.getArguments().get("colorMode"))) {
+            // Command must be color - convert to zwave format
+            String rgbwColor = ((StringType) command).toString().toUpperCase();
+
+            String[] rgbwColors = rgbwColor.split(",");
+            for (String color : rgbwColors) {
+                String[] colorData = color.split("=");
+
+                if ("LEVEL".equals(colorData[0])) {
+                    level = Integer.parseInt(colorData[1]);
+                } else {
+                    colors.put(ZWaveColorType.valueOf(colorData[0]), Integer.parseInt(colorData[1]));
+                }
             }
         } else if ("COLD_WHITE".equals(channel.getArguments().get("colorMode"))) {
             PercentType color = (PercentType) command;
@@ -153,14 +174,22 @@ public class ZWaveColorConverter extends ZWaveCommandClassConverter {
             colors.put(ZWaveColorType.WARM_WHITE, value);
         } else {
             logger.warn("NODE {}: Unknown color mode {}.", node.getNodeId(), channel.getArguments().get("colorMode"));
+            return null;
         }
 
         logger.debug("NODE {}: Converted command '{}' to {} for channel = {}, endpoint = {}.", node.getNodeId(),
                 command.toString(), colors, channel.getUID(), channel.getEndpoint());
 
-        rawMessages = commandClass.setColor(colors);
+        if (levelCommandClass != null && level != -1) {
+            if (level == 100) {
+                level = 99;
+            }
+            rawMessages.add(levelCommandClass.setValueMessage(level));
+        }
+        rawMessages.addAll(colorCommandClass.setColor(colors));
 
-        if (rawMessages == null) {
+        if (rawMessages.isEmpty()) {
+            logger.debug("NODE {}: No commands generated from {}", node.getNodeId(), command);
             return null;
         }
 
@@ -170,7 +199,7 @@ public class ZWaveColorConverter extends ZWaveCommandClassConverter {
         }
 
         // Add a poll to update the color
-        rawMessages = commandClass.getColor();
+        rawMessages = colorCommandClass.getColor();
         for (ZWaveCommandClassTransactionPayload msg : rawMessages) {
             messages.add(node.encapsulate(msg, channel.getEndpoint()));
         }

--- a/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveColorConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveColorConverterTest.java
@@ -19,10 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.openhab.core.library.types.HSBType;
-import org.openhab.core.thing.ChannelUID;
-import org.openhab.core.thing.type.ChannelTypeUID;
-import org.openhab.core.types.State;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.openhab.binding.zwave.handler.ZWaveThingChannel;
@@ -36,6 +32,11 @@ import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveColorComman
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
 import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
+import org.openhab.core.library.types.HSBType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.openhab.core.types.State;
 
 /**
  *
@@ -76,7 +77,7 @@ public class ZWaveColorConverterTest extends ZWaveCommandClassConverterTest {
     }
 
     @Test
-    public void convert() {
+    public void convertRGB() {
         ZWaveColorConverter converter = new ZWaveColorConverter(null);
         Map<String, String> args = new HashMap<>();
         args.put("colorMode", "RGB");
@@ -86,9 +87,25 @@ public class ZWaveColorConverterTest extends ZWaveCommandClassConverterTest {
         ZWaveNode node = CreateMockedNode(1);
         List<ZWaveCommandClassTransactionPayload> transactions = converter.receiveCommand(channel, node,
                 new HSBType("0,100,100"));
-        assertEquals(1, transactions.size());
-        ZWaveCommandClassTransactionPayload transaction = transactions.get(0);
+        assertEquals(2, transactions.size());
+        ZWaveCommandClassTransactionPayload transaction = transactions.get(1);
 
         assertTrue(Arrays.equals(new byte[] { 51, 5, 3, 2, -1, 3, 0, 4, 0 }, transaction.getPayloadBuffer()));
+    }
+
+    @Test
+    public void convertRGBW() {
+        ZWaveColorConverter converter = new ZWaveColorConverter(null);
+        Map<String, String> args = new HashMap<>();
+        args.put("colorMode", "RGBW");
+        ZWaveThingChannel channel = new ZWaveThingChannel(null, typeUid, uid, DataType.StringType,
+                CommandClass.COMMAND_CLASS_SWITCH_COLOR.toString(), 0, args);
+
+        ZWaveNode node = CreateMockedNode(1);
+        List<ZWaveCommandClassTransactionPayload> transactions = converter.receiveCommand(channel, node,
+                new StringType("red=1,green=2,blue=3,warm_white=4,level=44"));
+        assertEquals(2, transactions.size());
+        ZWaveCommandClassTransactionPayload transaction = transactions.get(1);
+        assertTrue(Arrays.equals(new byte[] { 51, 5, 4, 0, 4, 2, 1, 3, 2, 4, 3 }, transaction.getPayloadBuffer()));
     }
 }


### PR DESCRIPTION
Adds a new color mode optons `RGBW`.

This is a STRING type - it is used to command a colour device with specific colour information. The user can set any colours they like in a comma separated string - eg `red=33,green=44,warm_white=99,level=35`.

Colours must have the names defined in the binding -:

https://github.com/openhab/org.openhab.binding.zwave/blob/master/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveColorCommandClass.java#L289

`LEVEL` is not a colour, but if used can set the levelcontrol (dimmer) channel.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>