### PR TITLE
Extend Door Lock Command Class

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveDoorLockConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveDoorLockConverter.java
@@ -19,6 +19,7 @@ import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
+import org.openhab.core.types.UnDefType;
 import org.openhab.binding.zwave.handler.ZWaveControllerHandler;
 import org.openhab.binding.zwave.handler.ZWaveThingChannel;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
@@ -76,13 +77,20 @@ public class ZWaveDoorLockConverter extends ZWaveCommandClassConverter {
     }
 
     private State handleEventLockState(ZWaveThingChannel channel, ZWaveCommandClassValueEvent event) {
-        if (!channel.getUID().getId().equals("lock_door")) {
+        if (!channel.getChannelTypeUID().getId().equals("lock_door")) {
             return null;
         }
 
         switch (channel.getDataType()) {
             case OnOffType:
-                return (Integer) event.getValue() == 0x00 ? OnOffType.OFF : OnOffType.ON;
+                switch ((Integer) event.getValue()) {
+                    case 0xFF:
+                        return OnOffType.ON;
+                    case 0xFE:
+                        return UnDefType.UNDEF;
+                    default:
+                        return OnOffType.OFF;
+                }
             default:
                 logger.warn("No conversion in {} to {}", this.getClass().getSimpleName(), channel.getDataType());
                 break;
@@ -92,13 +100,24 @@ public class ZWaveDoorLockConverter extends ZWaveCommandClassConverter {
     }
 
     private State handleEventCondition(ZWaveThingChannel channel, ZWaveCommandClassValueEvent event) {
-        if (!channel.getUID().getId().equals("sensor_door")) {
+        if (!channel.getChannelTypeUID().getId().equals("sensor_door")) {
             return null;
         }
-
+        Integer eventValue = (Integer) event.getValue();
+        if (channel.getArguments().containsKey("type")) {
+            String sensorType = channel.getArguments().get("type").toUpperCase();
+            switch (sensorType) {
+                case "BOLT":
+                    eventValue = ~(eventValue >> 1);
+                    break;
+                case "LATCH":
+                    eventValue = eventValue >> 2;
+                    break;
+            }
+        }
         switch (channel.getDataType()) {
             case OpenClosedType:
-                return ((Integer) event.getValue() & 0x01) == 0x00 ? OpenClosedType.OPEN : OpenClosedType.CLOSED;
+                return (eventValue & 0x01) == 0x00 ? OpenClosedType.OPEN : OpenClosedType.CLOSED;
             default:
                 logger.warn("No conversion in {} to {}", this.getClass().getSimpleName(), channel.getDataType());
                 break;

--- a/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveDoorLockConverterTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/converter/ZWaveDoorLockConverterTest.java
@@ -54,7 +54,7 @@ public class ZWaveDoorLockConverterTest extends ZWaveCommandClassConverterTest {
         assertEquals(OnOffType.class, state.getClass());
         assertEquals(state, OnOffType.OFF);
 
-        event = new ZWaveCommandClassValueEvent(1, 0, CommandClass.COMMAND_CLASS_DOOR_LOCK, 1,
+        event = new ZWaveCommandClassValueEvent(1, 0, CommandClass.COMMAND_CLASS_DOOR_LOCK, 0xFF,
                 ZWaveDoorLockCommandClass.Type.DOOR_LOCK_STATE);
         state = converter.handleEvent(channel, event);
         assertEquals(OnOffType.class, state.getClass());


### PR DESCRIPTION
Hi Chris,
I just realized, that my previews PR #1447 against 2.5 branch was not "automatical" merged into 3.0 (master) branch.
So here is the one, that do this.
@cdjackson , I've also created a ticket in the zwave device database, that the configuration for sensor_door should be exported to the XML files. Could you please do that and reexport the device https://opensmarthouse.org/zwavedatabase/1200?

Thank you, 
regards,
Daniel