### PR TITLE
Fix XStream security framework not initialized warnings

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeSerializer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeSerializer.java
@@ -62,6 +62,8 @@ public class ZWaveNodeSerializer {
             folder.mkdirs();
         }
 
+        XStream.setupDefaultSecurity(stream);
+        stream.allowTypesByWildcard(new String[] { ZWaveNode.class.getPackageName() + ".**" });
         stream.setClassLoader(ZWaveNodeSerializer.class.getClassLoader());
 
         // Process the annotations so that XStream knows all the alias's


### PR DESCRIPTION
Cherry picks #1500 onto 3.0.x.