### PR TITLE
Convert commands to channels datatype if possible

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingChannel.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingChannel.java
@@ -14,11 +14,14 @@ package org.openhab.binding.zwave.handler;
 
 import java.util.Map;
 
+import org.openhab.core.library.types.*;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.type.ChannelTypeUID;
+import org.openhab.core.types.Command;
 import org.openhab.binding.zwave.internal.converter.ZWaveCommandClassConverter;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.core.types.State;
 
 /**
  *
@@ -27,17 +30,37 @@ import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClas
  */
 public class ZWaveThingChannel {
     public enum DataType {
-        DecimalType,
-        HSBType,
-        IncreaseDecreaseType,
-        OnOffType,
-        OpenClosedType,
-        PercentType,
-        StringType,
-        DateTimeType,
-        UpDownType,
-        QuantityType,
-        StopMoveType;
+        DecimalType(DecimalType.class),
+        HSBType(HSBType.class),
+        IncreaseDecreaseType(IncreaseDecreaseType.class),
+        OnOffType(OnOffType.class),
+        OpenClosedType(OpenClosedType.class),
+        PercentType(PercentType.class),
+        StringType(StringType.class),
+        DateTimeType(DateTimeType.class),
+        UpDownType(UpDownType.class),
+        QuantityType(QuantityType.class),
+        StopMoveType(StopMoveType.class);
+
+        private final Class<? extends Command> typeClass;
+
+        DataType(Class<? extends Command> typeClass) {
+            this.typeClass = typeClass;
+        }
+
+        public Class<? extends Command> getTypeClass() {
+            return this.typeClass;
+        }
+
+        public static DataType fromTypeClass(Class<? extends Command> typeClass) {
+            for (DataType dt : DataType.values()) {
+                if (dt.getTypeClass().equals(typeClass)) {
+                    return dt;
+                }
+            }
+
+            throw new IllegalArgumentException("No DataType found for class " + typeClass.getName());
+        }
     }
 
     // int nodeId;
@@ -97,4 +120,5 @@ public class ZWaveThingChannel {
     public ZWaveCommandClassConverter getConverter() {
         return converter;
     }
+
 }

--- a/src/test/java/org/openhab/binding/zwave/handler/ZWaveThingHandlerTest.java
+++ b/src/test/java/org/openhab/binding/zwave/handler/ZWaveThingHandlerTest.java
@@ -38,12 +38,19 @@ import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveWakeUpComma
 import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.config.core.status.ConfigStatusMessage;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.StopMoveType;
+import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
 import org.openhab.core.thing.type.ThingType;
 import org.openhab.core.thing.type.ThingTypeBuilder;
+import org.openhab.core.types.Command;
+
+import javax.measure.quantity.Temperature;
 
 /**
  * Test of the ZWaveThingHandler
@@ -242,6 +249,38 @@ public class ZWaveThingHandlerTest {
         assertEquals(2, response.size());
 
         response = doConfigurationUpdateCommands("group_1", "[node_1, node_2_1, node_2]");
+    }
+
+    @Test
+    public void testConvertToDataType() {
+        ZWaveThingHandler sut = new ZWaveThingHandlerForTest(null);
+
+        ChannelUID channelUID = new ChannelUID("channel:for:a:test");
+        Command command = new QuantityType<>("22 °C");
+
+        Command result = sut.convertCommandToDataType(channelUID, ZWaveThingChannel.DataType.DecimalType, command,
+                ZWaveThingChannel.DataType.QuantityType);
+
+        assertTrue(result instanceof DecimalType);
+    }
+
+    @Test
+    public void testConvertToDataTypeFails() {
+        ZWaveThingHandler sut = new ZWaveThingHandlerForTest(null);
+
+        ChannelUID channelUID = new ChannelUID("channel:for:a:test");
+
+        // couldnt convert to channel data-type because channel data-type is not an instance of State
+        Command result = sut.convertCommandToDataType(channelUID, ZWaveThingChannel.DataType.StopMoveType,
+                StopMoveType.STOP, ZWaveThingChannel.DataType.DecimalType);
+
+        assertNull(result);
+
+        // command is not an instance of State and couldnt be converted to something
+        result = sut.convertCommandToDataType(channelUID, ZWaveThingChannel.DataType.DecimalType,
+                StopMoveType.STOP, ZWaveThingChannel.DataType.StopMoveType);
+
+        assertNull(result);
     }
 
     @Test


### PR DESCRIPTION
Fixes #1546 

I really don't know if this is the correct approach to solve this issue.. I am running this right now on my local instance it it seems to work.

The problem is that for example a `QuantityType` can't be send if there is no channel that expects a `QuantityType` even if e.g. there is a channel with a `DecimalType` to which a `QuantityType` can easily be converted to.

Thus I try to find a channel to which the source type (`QuantityType` in the example) can be converted to.

My approach:
* Stick to as-is behavior if a channel with the required datatype can be found and use this one
* If no channel with matching datatype can be found iterate over all channels with the same `channelUID` and try to convert the command to the one matching with the expected datatype, the first one found that can be converted will be used

Another idea I had:
Add a channel to this device that expects a `DecimalType` -> would most likely just fix the issue I am facing for this particular device and not similar issues for other devices