### PR TITLE
create callback ID so Add Node stop command doesn't time out

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
@@ -81,7 +81,7 @@ public class AddNodeMessageClass extends ZWaveCommandProcessor {
 
         // Create the request
         ZWaveSerialPayload payload = new ZWaveTransactionMessageBuilder(SerialMessageClass.AddNodeToNetwork)
-                .withPayload(ADD_NODE_STOP).withRequiresData(false).build();
+                .withPayload(ADD_NODE_STOP).withTimeout(300).withRequiresData(false).build();
 
         if (complete) {
             payload.setCallbackId(0);

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
@@ -81,10 +81,10 @@ public class AddNodeMessageClass extends ZWaveCommandProcessor {
 
         // Create the request
         ZWaveSerialPayload payload = new ZWaveTransactionMessageBuilder(SerialMessageClass.AddNodeToNetwork)
-                .withPayload(ADD_NODE_STOP).withTimeout(300).withRequiresData(false).build();
+                .withPayload(ADD_NODE_STOP).withRequiresData(false).build();
 
         if (complete) {
-            payload.setCallbackId(0);
+//            payload.setCallbackId(0);
         }
         return payload;
     }


### PR DESCRIPTION
This command is timing out in 5 seconds and reducing the configuration time for the node before it is put to sleep.  Shortening the time gets it out of the way. (This is my first try at creating a pull request, so be easy on me).  This is the background
https://community.openhab.org/t/wake-up-no-more-information-command-to-battery-node-not-getting-through/120139

I have a debug with this change below that configures the device in 5 seconds versus the other logs in the above link.[zwave.log](https://github.com/openhab/org.openhab.binding.zwave/files/6690179/zwave.log)

Signed-off-by: robert eckhoff roberteckhoff@yahoo.com
