### PR TITLE
[zwave] Execute slow dispose() actions on a scheduler thread

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
@@ -191,7 +191,6 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
         }
 
         initializeHeal();
-
     }
 
     /**
@@ -254,6 +253,15 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
 
     @Override
     public void dispose() {
+        scheduler.submit(() -> {
+            disposeSchedulerJob();
+        });
+    }
+
+    /**
+     * Execute long running disposal actions on a background thread
+     */
+    private void disposeSchedulerJob() {
         if (healJob != null) {
             healJob.cancel(true);
             healJob = null;


### PR DESCRIPTION
**Background:**
The `ZWaveControllerHandler.dispose()` method violates the openHAB coding guidelines because it takes a very long time (ca. 6 seconds) to complete its actions (see screenshot below).

This delay can cause problems in shutting down other bindings because it starves them of sufficient time to shut themselves down properly [e.g. Velux binding](https://community.openhab.org/t/velux-new-openhab2-binding-feedback-welcome/32926/1311)

![image](https://user-images.githubusercontent.com/893994/129556645-362c069a-1914-4e4b-8776-bf71d33119eb.png)

**Solution:**
This PR shifts the long running `ZWaveControllerHandler.dispose()` tasks to a separate thread run on the scheduler. So the `dispose()` can itself return immediately.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>