### PR TITLE
Remove deprecated XStream.setupDefaultSecurity call

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeSerializer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeSerializer.java
@@ -64,7 +64,6 @@ public class ZWaveNodeSerializer {
             folder.mkdirs();
         }
 
-        XStream.setupDefaultSecurity(stream);
         stream.allowTypesByWildcard(new String[] { ZWaveNode.class.getPackageName() + ".**" });
         stream.setClassLoader(ZWaveNodeSerializer.class.getClassLoader());
 


### PR DESCRIPTION
The XStream.setupDefaultSecurity method is deprecated since XStream 1.4.18.
It no longer does anything, because this is the default in newer XStream versions.