### PR TITLE
Increase sleep timer delay when initializing a device (#1670)

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -1515,7 +1515,7 @@ public class ZWaveNode {
         if (isInitializationComplete()) {
             timerDelay = sleepDelay;
         } else {
-            timerDelay = 5000;
+            timerDelay = 30000;
         }
         logger.debug("NODE {}: Start sleep timer at {}ms", getNodeId(), timerDelay);
 


### PR DESCRIPTION
Some devices are slow to respond during intialization, and a timeout
of 5000 ms is not enough to let them progress. Examples include the
ZCOMBO smoke alarm.

Increasing the timeout interval to 30 seconds allows the smoke alarm
to finish initialization within a few wakeups.

Signed-off-by: Marcus Better <marcus@better.se>