### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.idea
+.vscode
+.DS_Store
+*.iml
 /.settings/org.eclipse.*
 target
 OSGI-INF/*.xml


### PR DESCRIPTION
Updates the .gitignore file to ignore files generated by:

* IntelliJ IDEA
* Visual Studio Code
* Apple Desktop Services Store

---

This prevents these files being commited in PRs, see also https://github.com/openhab/org.openhab.binding.zwave/pull/1681.