### PR TITLE
Adding channel type for raw control of color

### DIFF
--- a/src/main/resources/OH-INF/thing/channels.xml
+++ b/src/main/resources/OH-INF/thing/channels.xml
@@ -414,6 +414,14 @@
         <category>ColorLight</category>
     </channel-type>
 
+    <!-- Color Command Class - Raw -->
+    <channel-type id="color_raw">
+        <item-type>String</item-type>
+        <label>Color Raw Setting</label>
+        <description>Sets the color from a comma delimited key=value string</description>
+        <category></category>
+    </channel-type>
+
     <!-- Configuration Command Class Channel - Decimal Conversion -->
     <channel-type id="config_decimal">
         <item-type>Number</item-type>


### PR DESCRIPTION
Adding a channel type to support raw control of a color light.  This follows up #1675 

Signed-off-by: Jeff Lauterbach <jjlauterbach@gmail.com>