### PR TITLE
Add support for COMMAND_CLASS_SOUND_SWITCH

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveCommandClassConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveCommandClassConverter.java
@@ -69,6 +69,7 @@ public abstract class ZWaveCommandClassConverter {
         temp.put(CommandClass.COMMAND_CLASS_SENSOR_ALARM, ZWaveAlarmSensorConverter.class);
         temp.put(CommandClass.COMMAND_CLASS_SENSOR_BINARY, ZWaveBinarySensorConverter.class);
         temp.put(CommandClass.COMMAND_CLASS_SENSOR_MULTILEVEL, ZWaveMultiLevelSensorConverter.class);
+        temp.put(CommandClass.COMMAND_CLASS_SOUND_SWITCH, ZWaveSoundSwitchConverter.class);
         temp.put(CommandClass.COMMAND_CLASS_SWITCH_BINARY, ZWaveBinarySwitchConverter.class);
         temp.put(CommandClass.COMMAND_CLASS_SWITCH_MULTILEVEL, ZWaveMultiLevelSwitchConverter.class);
         temp.put(CommandClass.COMMAND_CLASS_THERMOSTAT_FAN_MODE, ZWaveThermostatFanModeConverter.class);

--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSoundSwitchConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSoundSwitchConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.zwave.internal.converter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+import org.openhab.binding.zwave.handler.ZWaveControllerHandler;
+import org.openhab.binding.zwave.handler.ZWaveThingChannel;
+import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveSoundSwitchCommandClass;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
+import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ZWaveSoundSwitchConverter class. Converter for communication with the {@link ZWaveSoundSwitchCommandClass}.
+ * Implements polling of the mode state and receiving of mode state events.
+ *
+ * @author Kennet Nielsen
+ */
+public class ZWaveSoundSwitchConverter extends ZWaveCommandClassConverter {
+
+    private final Logger logger = LoggerFactory.getLogger(ZWaveSoundSwitchConverter.class);
+
+    /**
+     * Constructor. Creates a new instance of the {@link ZWaveSoundSwitchConverter} class.
+     *
+     */
+    public ZWaveSoundSwitchConverter(ZWaveControllerHandler controller) {
+        super(controller);
+    }
+
+    @Override
+    public List<ZWaveCommandClassTransactionPayload> executeRefresh(ZWaveThingChannel channel, ZWaveNode node) {
+        ZWaveSoundSwitchCommandClass commandClass = (ZWaveSoundSwitchCommandClass) node
+                .getCommandClass(ZWaveCommandClass.CommandClass.COMMAND_CLASS_SOUND_SWITCH);
+        if (commandClass == null) {
+            return null;
+        }
+
+        logger.debug("NODE {}: Generating poll message for {}, endpoint {}", node.getNodeId(),
+                commandClass.getCommandClass(), channel.getEndpoint());
+        ZWaveCommandClassTransactionPayload payload = null;
+        if ( channel.getChannelTypeUID().getId().equals("sound_volume") ) 
+        {
+            payload = commandClass.getConfigMessage();
+        }
+        else
+        {
+            payload = commandClass.getValueMessage();
+        }
+        
+        ZWaveCommandClassTransactionPayload transaction = node.encapsulate(payload,
+                channel.getEndpoint());
+        List<ZWaveCommandClassTransactionPayload> response = new ArrayList<ZWaveCommandClassTransactionPayload>(1);
+        response.add(transaction);
+        return response;
+    }
+
+    @Override
+    public List<ZWaveCommandClassTransactionPayload> receiveCommand(ZWaveThingChannel channel, ZWaveNode node,
+            Command command) {
+        ZWaveSoundSwitchCommandClass commandClass = (ZWaveSoundSwitchCommandClass) node.resolveCommandClass(
+                ZWaveCommandClass.CommandClass.COMMAND_CLASS_SOUND_SWITCH, channel.getEndpoint());
+
+        ZWaveCommandClassTransactionPayload payload = null;
+        if( channel.getChannelTypeUID().getId().equals("sound_volume") )
+        {
+            payload = commandClass.setConfigMessage(((PercentType) command).intValue());
+        }
+        else
+        {
+            payload = commandClass.setValueMessage(((DecimalType) command).intValue());
+        }
+        ZWaveCommandClassTransactionPayload serialMessage = node.encapsulate(payload,channel.getEndpoint());
+
+        if (serialMessage == null) {
+            logger.warn("NODE {}: Generating message failed for command class = {}, endpoint = {}", node.getNodeId(),
+                    commandClass.getCommandClass(), channel.getEndpoint());
+            return null;
+        }
+
+        List<ZWaveCommandClassTransactionPayload> messages = new ArrayList<ZWaveCommandClassTransactionPayload>();
+        messages.add(serialMessage);
+        return messages;
+    }
+
+    @Override
+    public State handleEvent(ZWaveThingChannel channel, ZWaveCommandClassValueEvent event) {
+        switch ((ZWaveSoundSwitchCommandClass.Type) event.getType()) {
+            case VOLUME:
+                if (!channel.getChannelTypeUID().getId().equals("sound_volume")) {
+                    return null;
+                }
+                return new PercentType((Integer)event.getValue());
+            case TONE_PLAY:
+                if (!channel.getChannelTypeUID().getId().equals("sound_tone_play")) {
+                    return null;
+                }
+                return new DecimalType((Integer) event.getValue());
+            default:
+                return null;
+        }
+    }
+}

--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSoundSwitchConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSoundSwitchConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
@@ -551,6 +551,7 @@ public abstract class ZWaveCommandClass {
         COMMAND_CLASS_PROTECTION(0x75, ZWaveProtectionCommandClass.class),
         COMMAND_CLASS_LOCK(0x76, ZWaveLockCommandClass.class),
         COMMAND_CLASS_NODE_NAMING(0x77, ZWaveNodeNamingCommandClass.class),
+        COMMAND_CLASS_SOUND_SWITCH(0x79, ZWaveSoundSwitchCommandClass.class),
         COMMAND_CLASS_FIRMWARE_UPDATE_MD(0x7A, ZWaveFirmwareUpdateCommandClass.class),
         COMMAND_CLASS_GROUPING_NAME(0x7B, ZWaveGroupingNameCommandClass.class),
         COMMAND_CLASS_REMOTE_ASSOCIATION_ACTIVATE(0x7C, null),

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSoundSwitchCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSoundSwitchCommandClass.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.zwave.internal.protocol.commandclass;
+
+import org.openhab.binding.zwave.internal.protocol.ZWaveCommandClassPayload;
+import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
+import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.ZWaveTransaction.TransactionPriority;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
+import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
+import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayloadBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Handles the Sound Switch command class.
+ *
+ * @author Kennet Nielsen
+ */
+@XStreamAlias("COMMAND_CLASS_SOUND_SWITCH")
+public class ZWaveSoundSwitchCommandClass extends ZWaveCommandClass {
+    public enum Type {
+        TONE_PLAY,
+        VOLUME
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(ZWaveSoundSwitchCommandClass.class);
+
+    
+     /**
+     * This command is used to set the configuration for playing tones at the supporting node.
+     */
+    private static final int CONFIGURATION_SET = 0x05;
+
+     /**
+     * This command is used to request the current configuration for playing tones at the supporting node
+     */
+    private static final int CONFIGURATION_GET = 0x06;
+     
+     /**
+     * This command is used to advertise the current configuration for playing tones at the sending node.
+     */
+    private static final int CONFIGURATION_REPORT = 0x07;
+    
+     /**
+     * This command is used to instruct a supporting node to play (or stop playing) a tone.
+     */
+    private static final int TONE_PLAY_SET = 0x08;
+   
+     /**
+     * This command is used to request the current tone being played by the receiving node.
+     */
+    private static final int TONE_PLAY_GET = 0x09;
+
+     /**
+     * This command is used to advertise the current tone being played by the sending node
+     */
+    private static final int TONE_PLAY_REPORT = 0x0A;
+    
+    /**
+     * Creates a new instance of the ZWaveSoundSwitchCommandClass class.
+     *
+     * @param node the node this command class belongs to
+     * @param controller the controller to use
+     * @param endpoint the endpoint this Command class belongs to
+     */
+    public ZWaveSoundSwitchCommandClass(ZWaveNode node, ZWaveController controller, ZWaveEndpoint endpoint) {
+        super(node, controller, endpoint);
+    }
+
+    @Override
+    public CommandClass getCommandClass() {
+        return CommandClass.COMMAND_CLASS_SOUND_SWITCH;
+    }
+
+    @ZWaveResponseHandler(id = CONFIGURATION_REPORT, name = "CONFIGURATION_REPORT")
+    public void handleConfigReport(ZWaveCommandClassPayload payload, int endpoint) {
+        int volume = payload.getPayloadByte(2);
+        //int defaultTone = payload.getPayloadByte(3);
+        logger.debug("NODE {}: Config report - volume={}", this.getNode().getNodeId(), volume);
+
+        ZWaveCommandClassValueEvent zEvent = new ZWaveCommandClassValueEvent(this.getNode().getNodeId(), endpoint,
+                CommandClass.COMMAND_CLASS_SOUND_SWITCH,volume , Type.VOLUME );
+        this.getController().notifyEventListeners(zEvent);
+    }
+     
+    @ZWaveResponseHandler(id = TONE_PLAY_REPORT, name = "TONE_PLAY_REPORT")
+    public void handleIndicatorReport(ZWaveCommandClassPayload payload, int endpoint) {
+        int playTone = payload.getPayloadByte(2);
+        logger.debug("NODE {}: Tone play report - playTone={}", this.getNode().getNodeId(), playTone);
+
+        ZWaveCommandClassValueEvent zEvent = new ZWaveCommandClassValueEvent(this.getNode().getNodeId(), endpoint,
+                CommandClass.COMMAND_CLASS_SOUND_SWITCH,  playTone , Type.TONE_PLAY);
+        this.getController().notifyEventListeners(zEvent);
+    }
+
+    /**
+     * Gets a SerialMessage with the TONE_PLAY_GET command
+     *
+     * @return the serial message
+     */
+    public ZWaveCommandClassTransactionPayload getValueMessage() {
+        logger.debug("NODE {}: Creating new message for application command TONE_PLAY_GET", this.getNode().getNodeId());
+
+        return new ZWaveCommandClassTransactionPayloadBuilder(getNode().getNodeId(), getCommandClass(), TONE_PLAY_GET)
+                .withExpectedResponseCommand(TONE_PLAY_REPORT).withPriority(TransactionPriority.Get).build();
+    }
+
+    public ZWaveCommandClassTransactionPayload setValueMessage(int value) {
+        logger.debug("NODE {}: Creating new message for application command TONE_PLAY_SET", this.getNode().getNodeId());
+
+        return new ZWaveCommandClassTransactionPayloadBuilder(getNode().getNodeId(), getCommandClass(), TONE_PLAY_SET)
+                .withPayload(value).withPriority(TransactionPriority.Set).build();
+    }
+
+    public ZWaveCommandClassTransactionPayload getConfigMessage() {
+        logger.debug("NODE {}: Creating new message for application command CONFIGURATION_GET",
+                getNode().getNodeId());
+
+        return new ZWaveCommandClassTransactionPayloadBuilder(getNode().getNodeId(), getCommandClass(), CONFIGURATION_GET)
+                .withExpectedResponseCommand(CONFIGURATION_REPORT).withPriority(TransactionPriority.Get).build();
+    }
+
+    public ZWaveCommandClassTransactionPayload setConfigMessage(int volume) {
+        logger.debug("NODE {}: Creating new message for application command CONFIGURATION_SET", this.getNode().getNodeId());
+        
+        int defaultTone = 0; // The value 0x00 MUST indicate that the receiving node MUST NOT update its current default tone and
+        //the command is sent to configure the volume only.
+        return new ZWaveCommandClassTransactionPayloadBuilder(getNode().getNodeId(), getCommandClass(), CONFIGURATION_SET)
+                .withPayload(volume,defaultTone).withPriority(TransactionPriority.Set).build();
+    }
+}

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSoundSwitchCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSoundSwitchCommandClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/src/main/resources/OH-INF/thing/channels.xml
+++ b/src/main/resources/OH-INF/thing/channels.xml
@@ -1237,6 +1237,22 @@
         </state>
     </channel-type>
 
+    <!-- Sound tone play Channel -->
+    <channel-type id="sound_tone_play">
+        <item-type>Number</item-type>
+        <label>Sound tone play</label>
+        <description>The Sound tone that will play. The allowed tone numbers depend on the device</description>
+        <category></category>
+    </channel-type>
+
+    <!-- Sound volume Channel -->
+    <channel-type id="sound_volume">
+        <item-type>Dimmer</item-type>
+        <label>Sound volume</label>
+        <description>The sound volume channel allows control of the loudness</description>
+        <category></category>
+    </channel-type>
+
     <!-- Switch Channel -->
     <channel-type id="switch_binary">
         <item-type>Switch</item-type>

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSoundSwitchCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSoundSwitchCommandClassTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSoundSwitchCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSoundSwitchCommandClassTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.zwave.internal.protocol.commandclass;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
+import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
+
+/**
+ * Test cases for {@link ZWaveBasicCommandClass}.
+ *
+ * @author Kennet Nielsen - Initial version
+ */
+public class ZWaveSoundSwitchCommandClassTest extends ZWaveCommandClassTest {
+
+    @Test
+    public void getValueMessage() {
+        ZWaveSoundSwitchCommandClass cls = (ZWaveSoundSwitchCommandClass) getCommandClass(
+                CommandClass.COMMAND_CLASS_SOUND_SWITCH);
+        ZWaveCommandClassTransactionPayload msg;
+
+        byte[] expectedResponseV1 = { 0x79, 9 };
+        cls.setVersion(1);
+        msg = cls.getValueMessage();
+        assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void setValueMessage() {
+        ZWaveSoundSwitchCommandClass cls = (ZWaveSoundSwitchCommandClass) getCommandClass(
+                CommandClass.COMMAND_CLASS_SOUND_SWITCH);
+        ZWaveCommandClassTransactionPayload msg;
+
+        byte[] expectedResponseV1 = { 0x79, 8, 3 };
+        cls.setVersion(1);
+        msg = cls.setValueMessage(3);
+        assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void getConfigMessage() {
+        ZWaveSoundSwitchCommandClass cls = (ZWaveSoundSwitchCommandClass) getCommandClass(
+                CommandClass.COMMAND_CLASS_SOUND_SWITCH);
+        ZWaveCommandClassTransactionPayload msg;
+
+        byte[] expectedResponseV1 = { 0x79, 6 };
+        cls.setVersion(1);
+        msg = cls.getConfigMessage();
+        assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseV1));
+    }
+    
+    @Test
+    public void setConfigMessage() {
+        ZWaveSoundSwitchCommandClass cls = (ZWaveSoundSwitchCommandClass) getCommandClass(
+                CommandClass.COMMAND_CLASS_SOUND_SWITCH);
+        ZWaveCommandClassTransactionPayload msg;
+
+        byte[] expectedResponseV1 = { 0x79, 5 , 100 , 0 };
+        cls.setVersion(1);
+        msg = cls.setConfigMessage(100);
+        assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseV1));
+    }
+}


### PR DESCRIPTION
Adds new COMMAND_CLASS_SOUND_SWITCH needed to be able to trigger siren and volume on Aeotec Siren/Doorbell 6.
This pull request is more polished than the previous one and I am not aware of any bugs. I also tried to keep in line with the rest of the code.

The ZWaveSoundSwitchCommandClass.java is strait forward and made like all the other command classes.
But because the command class supports getting and setting status of both volume and the tone to play / being played.
I needed to differentiate between the two in the ZWaveSoundSwitchConverter.java. I could not find any other classes that did this so I was a bit unsure how I should do this.
I decided to do this with `channel.getChannelTypeUID().getId().equals("sound_volume")` I guess I could also have used parameters or maybe multiply Converter classes. But I think there is always a 1 to 1 relatiationship between command class and converter. So I thought this was the right way to do it.
I therefore added two new channel types (sound_tone_play and sound_volume) in channels.xml but again I was not sure how they should be named. If there is some schema in the names that I did not get, let me know and I will update.

I guess the two new types need to be added to the Z-wave database editor also, is there any way I can help with that ?

The tone_play channel will be updated when the tone has finished playing.

Closes #1245
Signed-off-by: kennetn <kennetn@gmail.com>