### PR TITLE
Add Node Stop Fine Tune

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
@@ -77,16 +77,20 @@ public class AddNodeMessageClass extends ZWaveCommandProcessor {
     }
 
     public ZWaveSerialPayload doRequestStop(boolean complete) {
-        logger.debug("Ending INCLUSION mode.");
-
         // Create the request
+        if (complete) {
+            logger.debug("Stop INCLUSION mode with timeout.");
+            ZWaveSerialPayload payload = new ZWaveTransactionMessageBuilder(SerialMessageClass.AddNodeToNetwork)
+            .withPayload(ADD_NODE_STOP).withTimeout(500).withRequiresData(false).build();
+
+            payload.setCallbackId(0);
+            return payload;
+        }
+        logger.debug("Ending Protocol INCLUSION mode.");
         ZWaveSerialPayload payload = new ZWaveTransactionMessageBuilder(SerialMessageClass.AddNodeToNetwork)
                 .withPayload(ADD_NODE_STOP).withRequiresData(false).build();
 
-        if (complete) {
-            payload.setCallbackId(0);
-        }
-        return payload;
+        return payload;  
     }
 
     @Override


### PR DESCRIPTION
The problem addressed with this PR is that the second Add Node stop message (when “complete”) has Callback=0 because the Silabs specification only requires a controller Response, however the serial message (4A) is set-up to require a Request from Node 255.  Request is needed on the serial message because the first time the 4A serial message is sent to 255 a Request is required.  Since the serial message 4A can’t be configured both ways (at least with my level of knowledge), this PR separates the second calling with a timeout reflecting the Response nature in line with the timeout documentation below. The 0.5 second timeout at twice the default is a proxy for the controller response.  This is really only communication between the binding and the attached serial controller.  No messages go through the air, so there’s going to be bigger problems if the Response doesn’t happen in 0.5 seconds, but a timeout up to 1 second will not cause the battery device initialization problem described below.

* <h2>Timeouts</h2>
 * <p>
 * A timer thread manages timeouts - different times are used for the different stages of a transaction.
 * Defaults for each timer are as follows -:
 * <ul>
 * <li><i>RES</i>ponse - should be received within <b>250ms</b> of the <i>REQ</i>uest</li>
 * <li><i>REQ</i>uest - should be received within <b>2500ms</b> of the <i>REQ</i>uest or the controllers <i>RES</i>ponse
 * </li>
 * <li><i>DATA</i> - should be received within <b>2500ms</b> of the <i>REQ</i>uest.</li>
 * </ul>

The issue caused by the current 5 second timeout on a 4A message is that initialization is delayed about 4 seconds during the period the battery device is awake.  There is no issue with mains powered devices since initialization resumes after 4 seconds.  However, for battery devices with a 5 second awake period (in the current design or set at that level with #1760) reduces the time available for the first time initialization to 1 second; not enough.  Subsequent reawakes of a not fully initialized battery device do not pick up smoothly, as documented elsewhere and user frustration ensues.
Data presented in my first comment show this happens very quickly since it is only between the serial controller and the binding.
Signed-off-by: Bob Eckhoff <katmandodo@yahoo.com>