### PR TITLE
Add low battery (0x0A) to the list of battery alarms so we get notified of a low battery

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
@@ -128,6 +128,7 @@ public class ZWaveAlarmConverter extends ZWaveCommandClassConverter {
         // Battery alarms
         events = new HashMap<NotificationEvent, State>();
         events.put(NotificationEvent.POWER_MANAGEMENT__NONE, OnOffType.OFF);
+        events.put(NotificationEvent.POWER_MANAGEMENT__REPLACE_BATTERY_SOON, OnOffType.ON);
         events.put(NotificationEvent.POWER_MANAGEMENT__REPLACE_BATTERY_NOW, OnOffType.ON);
         notifications.put("alarm_battery", events);
 


### PR DESCRIPTION
This goes with the database update for ZW164 to make the low battery alarm work

Signed-off-by: sbholmes <sbholmes@gmail.com>