### PR TITLE
Add events to make low battery alarm notifications work for ZW130/ZW129

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
@@ -128,8 +128,12 @@ public class ZWaveAlarmConverter extends ZWaveCommandClassConverter {
         // Battery alarms
         events = new HashMap<NotificationEvent, State>();
         events.put(NotificationEvent.POWER_MANAGEMENT__NONE, OnOffType.OFF);
+        events.put(NotificationEvent.POWER_MANAGEMENT__BATTERY_CHARGING, OnOffType.OFF);
+        events.put(NotificationEvent.POWER_MANAGEMENT__BATTERY_FULL, OnOffType.OFF);
         events.put(NotificationEvent.POWER_MANAGEMENT__REPLACE_BATTERY_SOON, OnOffType.ON);
         events.put(NotificationEvent.POWER_MANAGEMENT__REPLACE_BATTERY_NOW, OnOffType.ON);
+        events.put(NotificationEvent.POWER_MANAGEMENT__CHARGE_BATTERY_SOON, OnOffType.ON);
+        events.put(NotificationEvent.POWER_MANAGEMENT__CHARGE_BATTERY_NOW, OnOffType.ON);
         notifications.put("alarm_battery", events);
 
         // Power alarms


### PR DESCRIPTION
This change makes the (rechargeable) battery low notifications work for the WallMote ZW130/ZW129
I set the battery charging and battery full notifications to toggle the channel off - so when you plug the device (or any device implementing these notifications) into a charger the alarm resets to OFF.  Tested locally and works, if you unplug the device from the charger too early it re-triggers to ON successfully.
Needs an XML update as well to change from alarm_power to alarm_battery (will do shortly)

Signed-off-by: sbholmes <sbholmes@gmail.com>