### PR TITLE
Add support for setting default tone in COMMAND_CLASS_SOUND_SWITCH

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSoundSwitchConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSoundSwitchConverter.java
@@ -62,6 +62,10 @@ public class ZWaveSoundSwitchConverter extends ZWaveCommandClassConverter {
         {
             payload = commandClass.getConfigMessage();
         }
+        else if( channel.getChannelTypeUID().getId().equals("sound_default_tone") )
+        {
+            payload = commandClass.getConfigMessage();
+        }
         else
         {
             payload = commandClass.getValueMessage();
@@ -83,7 +87,11 @@ public class ZWaveSoundSwitchConverter extends ZWaveCommandClassConverter {
         ZWaveCommandClassTransactionPayload payload = null;
         if( channel.getChannelTypeUID().getId().equals("sound_volume") )
         {
-            payload = commandClass.setConfigMessage(((PercentType) command).intValue());
+            payload = commandClass.setConfigMessage(((PercentType) command).intValue(),0);
+        }
+        else if( channel.getChannelTypeUID().getId().equals("sound_default_tone") )
+        {
+            payload = commandClass.setConfigMessage(255, ((DecimalType) command).intValue());
         }
         else
         {
@@ -112,6 +120,11 @@ public class ZWaveSoundSwitchConverter extends ZWaveCommandClassConverter {
                 return new PercentType((Integer)event.getValue());
             case TONE_PLAY:
                 if (!channel.getChannelTypeUID().getId().equals("sound_tone_play")) {
+                    return null;
+                }
+                return new DecimalType((Integer) event.getValue());
+            case DEFAULT_TONE:
+                if (!channel.getChannelTypeUID().getId().equals("sound_default_tone")) {
                     return null;
                 }
                 return new DecimalType((Integer) event.getValue());

--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSoundSwitchConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSoundSwitchConverter.java
@@ -15,10 +15,6 @@ package org.openhab.binding.zwave.internal.converter;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.openhab.core.library.types.DecimalType;
-import org.openhab.core.library.types.PercentType;
-import org.openhab.core.types.Command;
-import org.openhab.core.types.State;
 import org.openhab.binding.zwave.handler.ZWaveControllerHandler;
 import org.openhab.binding.zwave.handler.ZWaveThingChannel;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
@@ -26,6 +22,10 @@ import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClas
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveSoundSwitchCommandClass;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
 import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,21 +58,15 @@ public class ZWaveSoundSwitchConverter extends ZWaveCommandClassConverter {
         logger.debug("NODE {}: Generating poll message for {}, endpoint {}", node.getNodeId(),
                 commandClass.getCommandClass(), channel.getEndpoint());
         ZWaveCommandClassTransactionPayload payload = null;
-        if ( channel.getChannelTypeUID().getId().equals("sound_volume") ) 
-        {
+        if (channel.getChannelTypeUID().getId().equals("sound_volume")) {
             payload = commandClass.getConfigMessage();
-        }
-        else if( channel.getChannelTypeUID().getId().equals("sound_default_tone") )
-        {
+        } else if (channel.getChannelTypeUID().getId().equals("sound_default_tone")) {
             payload = commandClass.getConfigMessage();
-        }
-        else
-        {
+        } else {
             payload = commandClass.getValueMessage();
         }
-        
-        ZWaveCommandClassTransactionPayload transaction = node.encapsulate(payload,
-                channel.getEndpoint());
+
+        ZWaveCommandClassTransactionPayload transaction = node.encapsulate(payload, channel.getEndpoint());
         List<ZWaveCommandClassTransactionPayload> response = new ArrayList<ZWaveCommandClassTransactionPayload>(1);
         response.add(transaction);
         return response;
@@ -81,23 +75,18 @@ public class ZWaveSoundSwitchConverter extends ZWaveCommandClassConverter {
     @Override
     public List<ZWaveCommandClassTransactionPayload> receiveCommand(ZWaveThingChannel channel, ZWaveNode node,
             Command command) {
-        ZWaveSoundSwitchCommandClass commandClass = (ZWaveSoundSwitchCommandClass) node.resolveCommandClass(
-                ZWaveCommandClass.CommandClass.COMMAND_CLASS_SOUND_SWITCH, channel.getEndpoint());
+        ZWaveSoundSwitchCommandClass commandClass = (ZWaveSoundSwitchCommandClass) node
+                .resolveCommandClass(ZWaveCommandClass.CommandClass.COMMAND_CLASS_SOUND_SWITCH, channel.getEndpoint());
 
         ZWaveCommandClassTransactionPayload payload = null;
-        if( channel.getChannelTypeUID().getId().equals("sound_volume") )
-        {
-            payload = commandClass.setConfigMessage(((PercentType) command).intValue(),0);
-        }
-        else if( channel.getChannelTypeUID().getId().equals("sound_default_tone") )
-        {
+        if (channel.getChannelTypeUID().getId().equals("sound_volume")) {
+            payload = commandClass.setConfigMessage(((PercentType) command).intValue(), 0);
+        } else if (channel.getChannelTypeUID().getId().equals("sound_default_tone")) {
             payload = commandClass.setConfigMessage(255, ((DecimalType) command).intValue());
-        }
-        else
-        {
+        } else {
             payload = commandClass.setValueMessage(((DecimalType) command).intValue());
         }
-        ZWaveCommandClassTransactionPayload serialMessage = node.encapsulate(payload,channel.getEndpoint());
+        ZWaveCommandClassTransactionPayload serialMessage = node.encapsulate(payload, channel.getEndpoint());
 
         if (serialMessage == null) {
             logger.warn("NODE {}: Generating message failed for command class = {}, endpoint = {}", node.getNodeId(),
@@ -117,7 +106,7 @@ public class ZWaveSoundSwitchConverter extends ZWaveCommandClassConverter {
                 if (!channel.getChannelTypeUID().getId().equals("sound_volume")) {
                     return null;
                 }
-                return new PercentType((Integer)event.getValue());
+                return new PercentType((Integer) event.getValue());
             case TONE_PLAY:
                 if (!channel.getChannelTypeUID().getId().equals("sound_tone_play")) {
                     return null;

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSoundSwitchCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSoundSwitchCommandClass.java
@@ -40,38 +40,38 @@ public class ZWaveSoundSwitchCommandClass extends ZWaveCommandClass {
 
     private static final Logger logger = LoggerFactory.getLogger(ZWaveSoundSwitchCommandClass.class);
 
-    
-     /**
+    /**
      * This command is used to set the configuration for playing tones at the supporting node.
      */
     private static final int CONFIGURATION_SET = 0x05;
 
-     /**
+    /**
      * This command is used to request the current configuration for playing tones at the supporting node
      */
     private static final int CONFIGURATION_GET = 0x06;
-     
-     /**
+
+    /**
      * This command is used to advertise the current configuration for playing tones at the sending node.
      */
     private static final int CONFIGURATION_REPORT = 0x07;
-    
-     /**
+
+    /**
      * This command is used to instruct a supporting node to play (or stop playing) a tone.
      */
     private static final int TONE_PLAY_SET = 0x08;
-   
-     /**
+
+    /**
      * This command is used to request the current tone being played by the receiving node.
      */
     private static final int TONE_PLAY_GET = 0x09;
 
-     /**
+    /**
      * This command is used to advertise the current tone being played by the sending node
      */
     private static final int TONE_PLAY_REPORT = 0x0A;
-    
+
     int lastVolume = -1;
+
     /**
      * Creates a new instance of the ZWaveSoundSwitchCommandClass class.
      *
@@ -92,24 +92,25 @@ public class ZWaveSoundSwitchCommandClass extends ZWaveCommandClass {
     public void handleConfigReport(ZWaveCommandClassPayload payload, int endpoint) {
         lastVolume = payload.getPayloadByte(2);
         int defaultTone = payload.getPayloadByte(3);
-        logger.debug("NODE {}: Config report - volume={} defaultTone={}", this.getNode().getNodeId(), lastVolume, defaultTone);
+        logger.debug("NODE {}: Config report - volume={} defaultTone={}", this.getNode().getNodeId(), lastVolume,
+                defaultTone);
 
         ZWaveCommandClassValueEvent zEvent = new ZWaveCommandClassValueEvent(this.getNode().getNodeId(), endpoint,
-                CommandClass.COMMAND_CLASS_SOUND_SWITCH,lastVolume , Type.VOLUME );
+                CommandClass.COMMAND_CLASS_SOUND_SWITCH, lastVolume, Type.VOLUME);
         this.getController().notifyEventListeners(zEvent);
 
         zEvent = new ZWaveCommandClassValueEvent(this.getNode().getNodeId(), endpoint,
-                CommandClass.COMMAND_CLASS_SOUND_SWITCH,defaultTone , Type.DEFAULT_TONE );
+                CommandClass.COMMAND_CLASS_SOUND_SWITCH, defaultTone, Type.DEFAULT_TONE);
         this.getController().notifyEventListeners(zEvent);
     }
-     
+
     @ZWaveResponseHandler(id = TONE_PLAY_REPORT, name = "TONE_PLAY_REPORT")
     public void handleIndicatorReport(ZWaveCommandClassPayload payload, int endpoint) {
         int playTone = payload.getPayloadByte(2);
         logger.debug("NODE {}: Tone play report - playTone={}", this.getNode().getNodeId(), playTone);
 
         ZWaveCommandClassValueEvent zEvent = new ZWaveCommandClassValueEvent(this.getNode().getNodeId(), endpoint,
-                CommandClass.COMMAND_CLASS_SOUND_SWITCH,  playTone , Type.TONE_PLAY);
+                CommandClass.COMMAND_CLASS_SOUND_SWITCH, playTone, Type.TONE_PLAY);
         this.getController().notifyEventListeners(zEvent);
     }
 
@@ -133,36 +134,43 @@ public class ZWaveSoundSwitchCommandClass extends ZWaveCommandClass {
     }
 
     public ZWaveCommandClassTransactionPayload getConfigMessage() {
-        logger.debug("NODE {}: Creating new message for application command CONFIGURATION_GET",
-                getNode().getNodeId());
+        logger.debug("NODE {}: Creating new message for application command CONFIGURATION_GET", getNode().getNodeId());
 
-        return new ZWaveCommandClassTransactionPayloadBuilder(getNode().getNodeId(), getCommandClass(), CONFIGURATION_GET)
-                .withExpectedResponseCommand(CONFIGURATION_REPORT).withPriority(TransactionPriority.Get).build();
+        return new ZWaveCommandClassTransactionPayloadBuilder(getNode().getNodeId(), getCommandClass(),
+                CONFIGURATION_GET).withExpectedResponseCommand(CONFIGURATION_REPORT)
+                        .withPriority(TransactionPriority.Get).build();
     }
+
     /**
      * Create a new configuration set message
      *
-     * @param volume in percent from 0 to 100. The Value 255 is special and Z-Wave Application Command Class Specification.pdf specifies this:
-     *                   This value MUST indicate to restore most recent non-zero volume setting.
-     *                   This value MUST be ignored if the current volume is not zero (0x00). 
-     *                   This value MAY be used to set the Default Tone Identifier and do not modify the volume setting
-     * @param defaultTone Values in the range 1..{Total number of supported tones} MUST indicate that the receiving node MUST use the specified Identifier as Default Tone.
-     *                    The value 0x00 MUST indicate that the receiving node MUST NOT update its current default tone and the command is sent to configure the volume only. 
-     *                     
+     * @param volume in percent from 0 to 100. The Value 255 is special and Z-Wave Application Command Class
+     *            Specification.pdf specifies this:
+     *            This value MUST indicate to restore most recent non-zero volume setting.
+     *            This value MUST be ignored if the current volume is not zero (0x00).
+     *            This value MAY be used to set the Default Tone Identifier and do not modify the volume setting
+     * @param defaultTone Values in the range 1..{Total number of supported tones} MUST indicate that the receiving node
+     *            MUST use the specified Identifier as Default Tone.
+     *            The value 0x00 MUST indicate that the receiving node MUST NOT update its current default tone and the
+     *            command is sent to configure the volume only.
+     * 
      * @return SerialMessage
      */
-    public ZWaveCommandClassTransactionPayload setConfigMessage(int volume,int defaultTone) {
-        logger.debug("NODE {}: Creating new message for application command CONFIGURATION_SET", this.getNode().getNodeId());
-        if( volume == 255 ) {
-            // We are trying not to change volume. But as described in params above this may happen if the volume is 0 therefore we handle this differently
-            if( lastVolume == 0 ) {
+    public ZWaveCommandClassTransactionPayload setConfigMessage(int volume, int defaultTone) {
+        logger.debug("NODE {}: Creating new message for application command CONFIGURATION_SET",
+                this.getNode().getNodeId());
+        if (volume == 255) {
+            // We are trying not to change volume. But as described in params above this may happen if the volume is 0
+            // therefore we handle this differently
+            if (lastVolume == 0) {
                 // If we know that the last volume was 0 then the device will change it in case we use 255
                 // Therefore we set it to 0 instead.
-                // If we do not know what the last volume was set to then lastVolume should be (-1) and we just use 255 and hope not to change volume 
+                // If we do not know what the last volume was set to then lastVolume should be (-1) and we just use 255
+                // and hope not to change volume
                 volume = 0;
             }
         }
-        return new ZWaveCommandClassTransactionPayloadBuilder(getNode().getNodeId(), getCommandClass(), CONFIGURATION_SET)
-                .withPayload(volume,defaultTone).withPriority(TransactionPriority.Set).build();
+        return new ZWaveCommandClassTransactionPayloadBuilder(getNode().getNodeId(), getCommandClass(),
+                CONFIGURATION_SET).withPayload(volume, defaultTone).withPriority(TransactionPriority.Set).build();
     }
 }

--- a/src/main/resources/OH-INF/thing/channels.xml
+++ b/src/main/resources/OH-INF/thing/channels.xml
@@ -1245,6 +1245,12 @@
             The value 0 will stop any tone beeing played. 
             The value 255 will play the default tone</description>
         <category></category>
+        <state>
+            <options>
+                <option value="0">Stop</option>
+                <option value="255">Play default tone</option>
+            </options>
+        </state>
     </channel-type>
 
     <!-- Sound volume Channel -->

--- a/src/main/resources/OH-INF/thing/channels.xml
+++ b/src/main/resources/OH-INF/thing/channels.xml
@@ -1241,7 +1241,9 @@
     <channel-type id="sound_tone_play">
         <item-type>Number</item-type>
         <label>Sound tone play</label>
-        <description>The Sound tone that will play. The allowed tone numbers depend on the device</description>
+        <description>The Sound tone that will play. The allowed tone numbers depend on the device. 
+            The value 0 will stop any tone beeing played. 
+            The value 255 will play the default tone</description>
         <category></category>
     </channel-type>
 
@@ -1250,6 +1252,14 @@
         <item-type>Dimmer</item-type>
         <label>Sound volume</label>
         <description>The sound volume channel allows control of the loudness</description>
+        <category></category>
+    </channel-type>
+
+    <!-- Sound default tone Channel -->
+    <channel-type id="sound_default_tone">
+        <item-type>Number</item-type>
+        <label>Sound default tone</label>
+        <description>The sound default tone used when the device is activated</description>
         <category></category>
     </channel-type>
 

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSoundSwitchCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSoundSwitchCommandClassTest.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
 import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
+import org.openhab.binding.zwave.internal.protocol.ZWaveCommandClassPayload;
 
 /**
  * Test cases for {@link ZWaveBasicCommandClass}.
@@ -71,7 +72,19 @@ public class ZWaveSoundSwitchCommandClassTest extends ZWaveCommandClassTest {
 
         byte[] expectedResponseV1 = { 0x79, 5 , 100 , 0 };
         cls.setVersion(1);
-        msg = cls.setConfigMessage(100);
+        msg = cls.setConfigMessage(100,0);
+        assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseV1));
+    }
+
+    @Test
+    public void setConfigMessage_will_use_volume_0_when_changing_tone_when_this_is_the_last_known_volume() {
+        ZWaveSoundSwitchCommandClass cls = (ZWaveSoundSwitchCommandClass) getCommandClass( CommandClass.COMMAND_CLASS_SOUND_SWITCH);
+        cls.setVersion(1);
+        byte[] input = { 0x79, 7 , 0 , 2 }; // volume 0 and default tone 2
+        cls.handleConfigReport(new ZWaveCommandClassPayload(input), 0);
+
+        byte[] expectedResponseV1 = { 0x79, 5 , 0 , 1 };
+        ZWaveCommandClassTransactionPayload msg = cls.setConfigMessage(255,1);
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseV1));
     }
 }

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSoundSwitchCommandClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSoundSwitchCommandClassTest.java
@@ -17,9 +17,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
+import org.openhab.binding.zwave.internal.protocol.ZWaveCommandClassPayload;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
 import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
-import org.openhab.binding.zwave.internal.protocol.ZWaveCommandClassPayload;
 
 /**
  * Test cases for {@link ZWaveBasicCommandClass}.
@@ -63,28 +63,29 @@ public class ZWaveSoundSwitchCommandClassTest extends ZWaveCommandClassTest {
         msg = cls.getConfigMessage();
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseV1));
     }
-    
+
     @Test
     public void setConfigMessage() {
         ZWaveSoundSwitchCommandClass cls = (ZWaveSoundSwitchCommandClass) getCommandClass(
                 CommandClass.COMMAND_CLASS_SOUND_SWITCH);
         ZWaveCommandClassTransactionPayload msg;
 
-        byte[] expectedResponseV1 = { 0x79, 5 , 100 , 0 };
+        byte[] expectedResponseV1 = { 0x79, 5, 100, 0 };
         cls.setVersion(1);
-        msg = cls.setConfigMessage(100,0);
+        msg = cls.setConfigMessage(100, 0);
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseV1));
     }
 
     @Test
     public void setConfigMessage_will_use_volume_0_when_changing_tone_when_this_is_the_last_known_volume() {
-        ZWaveSoundSwitchCommandClass cls = (ZWaveSoundSwitchCommandClass) getCommandClass( CommandClass.COMMAND_CLASS_SOUND_SWITCH);
+        ZWaveSoundSwitchCommandClass cls = (ZWaveSoundSwitchCommandClass) getCommandClass(
+                CommandClass.COMMAND_CLASS_SOUND_SWITCH);
         cls.setVersion(1);
-        byte[] input = { 0x79, 7 , 0 , 2 }; // volume 0 and default tone 2
+        byte[] input = { 0x79, 7, 0, 2 }; // volume 0 and default tone 2
         cls.handleConfigReport(new ZWaveCommandClassPayload(input), 0);
 
-        byte[] expectedResponseV1 = { 0x79, 5 , 0 , 1 };
-        ZWaveCommandClassTransactionPayload msg = cls.setConfigMessage(255,1);
+        byte[] expectedResponseV1 = { 0x79, 5, 0, 1 };
+        ZWaveCommandClassTransactionPayload msg = cls.setConfigMessage(255, 1);
         assertTrue(Arrays.equals(msg.getPayloadBuffer(), expectedResponseV1));
     }
 }


### PR DESCRIPTION
Added new channel type "Sound default tone" and extended explanation of "Sound tone play" channel type.
The sound switch command class does not always allow setting the default tone without changing volume therefore the last know volume is stored. Tested with Aeotech doorbell.

Closes https://github.com/openhab/org.openhab.binding.zwave/issues/1775

Signed-off-by: kennetn <kennetn@gmail.com>