### PR TITLE
Corrected entry for Heatit ZM Single Relay

### DIFF
--- a/doc/thermofloor/zmrelay_0_0.md
+++ b/doc/thermofloor/zmrelay_0_0.md
@@ -5,10 +5,10 @@ title: ZM Relay - ZWave
 
 {% include base.html %}
 
-# ZM Relay Heati Single Relay 16A
+# Heatit ZM Single Relay 16A
 This describes the Z-Wave device *ZM Relay*, manufactured by *ThermoFloor* with the thing type UID of ```thermofloor_zmrelay_00_000```.
 
-The device is in the category of *Battery*, defining Batteries, Energy Storages.
+The device is in the category of *Power Outlet*, defining Small devices to be plugged into a power socket in a wall which stick there.
 
 ![ZM Relay product image](https://opensmarthouse.org/zwavedatabase/1440/image/)
 

--- a/doc/things.md
+++ b/doc/things.md
@@ -899,6 +899,7 @@ and links to more detailed information about each thing.
 | Teptron AB | [MoveZ](teptron/movez_0_0.md) |  | ```teptron_movez_00_000``` | Blinds |
 | ThermoFloor | [HeatIt ZDim](thermofloor/019b_0_0.md) |  | ```thermofloor_019b_00_000``` | Wall Switch |
 | ThermoFloor | [HEATIT Z-RELAY](thermofloor/heatitzrelay_0_0.md) |  | ```thermofloor_heatitzrelay_00_000``` | Power Outlet |
+| ThermoFloor | [Heatit ZM Single Relay](thermofloor/zmrelay_0_0.md) |  | ```thermofloor_zmrelay_00_000``` | Power Outlet |
 | ThermoFloor | [TF016](thermofloor/tf016_0_0.md) | 1.7 | ```thermofloor_tf016_00_000``` | HVAC |
 | ThermoFloor | [TF016](thermofloor/tf016_1_8.md) | 1.8 to 1.91 | ```thermofloor_tf016_01_008``` | HVAC |
 | ThermoFloor | [TF016](thermofloor/tf016_1_92.md) | 1.92 | ```thermofloor_tf016_01_092``` | HVAC |


### PR DESCRIPTION
Added "Heatit ZM Single Relay" in the table in things.md with link to existing markdown documentation.
Also corrected a typo and wrong category description.


