### PR TITLE
Add Bridge Application Command Handler Class

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
@@ -33,6 +33,7 @@ import org.openhab.binding.zwave.internal.protocol.ZWaveController;
 import org.openhab.binding.zwave.internal.protocol.ZWaveEventListener;
 import org.openhab.binding.zwave.internal.protocol.ZWaveIoHandler;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.ZWaveDeviceClass.Specific;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveNetworkEvent;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveNetworkStateEvent;
@@ -240,8 +241,9 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
                     }
                     logger.debug("Starting network mesh heal for controller {}.", getThing().getUID());
                     for (ZWaveNode node : controller.getNodes()) {
-                        logger.debug("Starting network mesh heal for controller {}.", getThing().getUID());
-                        node.healNode();
+                        if ( node.getDeviceClass().getSpecificDeviceClass() != Specific.SPECIFIC_TYPE_PC_CONTROLLER) {
+                            node.healNode();
+                        }
                     }
                 }
             };

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialMessage.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialMessage.java
@@ -165,6 +165,9 @@ public class SerialMessage {
         if (messageType == SerialMessageType.Request) {
             callbackId = buffer[4] & 0xFF;
             messageNode = buffer[5] & 0xFF;
+            if(messageClassKey == 168) {
+                messageNode = buffer[6] & 0xFF; 
+            }
         }
         logger.trace("NODE {}: Message payload = {}", getMessageNode(), SerialMessage.bb2hex(messagePayload));
     }
@@ -564,6 +567,7 @@ public class SerialMessage {
         SetSlaveLearnMode(0xA4), // Enter slave learn mode
         GetVirtualNodes(0xA5), // Return all virtual nodes
         IsVirtualNode(0xA6), // Virtual node test
+        BridgeApplicationCommandHandler(0xA8), // BRIDGE_APPLICATION_COMMAND_HANDLER
         SetWutTimeout(0xB4),
         WatchDogEnable(0xB6),
         WatchDogDisable(0xB7),

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionManager.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveTransactionManager.java
@@ -516,7 +516,22 @@ public class ZWaveTransactionManager {
                 }
 
                 // Manage incoming command class messages separately so we can manage transaction responses
-                if (incomingMessage.getMessageClass() == SerialMessageClass.ApplicationCommandHandler) {
+                if (incomingMessage.getMessageClass() == SerialMessageClass.ApplicationCommandHandler 
+                || incomingMessage.getMessageClass() == SerialMessageClass.BridgeApplicationCommandHandler) {
+                    if (incomingMessage.getMessageClass() == SerialMessageClass.BridgeApplicationCommandHandler) {
+                        // Extra byte is "Destination" (i.e controller node) legacy was "Source", now "Destination" "Source"
+                        // This strips the "Destination" to create a "500 chip-like" message
+                        int arraylengthold = incomingMessage.getMessagePayload().length;
+                        int arraylengthnew = arraylengthold-1;
+                        byte[] arraynew = new byte[arraylengthnew];
+                        for(int i=0, j=0; i< arraylengthold; i++){
+                            if( i !=1){
+                            arraynew[j++]=incomingMessage.getMessagePayload()[i];
+                            }
+                        }   
+                        incomingMessage.setMessagePayload(arraynew);
+                    }
+
                     try {
                         int nodeId = incomingMessage.getMessagePayloadByte(1);
                         ZWaveNode node = controller.getNode(nodeId);
@@ -566,8 +581,8 @@ public class ZWaveTransactionManager {
                                                 continue;
                                             }
 
-                                            if (transaction
-                                                    .getExpectedReplyClass() == SerialMessageClass.ApplicationCommandHandler
+                                            if ((transaction.getExpectedReplyClass() == SerialMessageClass.ApplicationCommandHandler || 
+                                                    transaction.getExpectedReplyClass() == SerialMessageClass.BridgeApplicationCommandHandler)
                                                     && transaction.getExpectedCommandClass() != null
                                                     && command.getCommandClassId() == transaction
                                                             .getExpectedCommandClass().getKey()

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/transaction/ZWaveCommandClassTransactionPayload.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/transaction/ZWaveCommandClassTransactionPayload.java
@@ -134,7 +134,7 @@ public class ZWaveCommandClassTransactionPayload extends ZWaveCommandClassPayloa
         if (expectedResponseCommandClass == null) {
             return null;
         }
-        return SerialMessageClass.ApplicationCommandHandler;
+        return SerialMessageClass.BridgeApplicationCommandHandler;
     }
 
     @Override


### PR DESCRIPTION
This was extracted from #1765, updated to OH4.0, additional comments added, and unneeded files removed. With this PR, 700 controllers should work with Openhab. It is not perfect or technically complete (explained later) but will buy time to improve the code to your standards and suppress the crazy talk on the forum. Based on information on the Home Assistant site and google, Version 7.17 or greater should be required (earlier versions seemed to have problems). I started with 7.17 but upgraded to 7.18 for testing

Below are three relevant extracts from the 2022A Zwave Specification - Zwave Host API , a picture that the Zooz 700 Controller is set as a Static PC Controller. (This can only be set with a blank stick, but mine came this way out of the box), and three logs of initial tests of startup, inclusion, exclusion, and Heal from a working jar created with the changes in this file.  I also have the jar with these changes working on a RPi3b with an older Aeotec ZW090 controller to validate no interference with the current installed base. 

[Application Command.pdf](https://github.com/openhab/org.openhab.binding.zwave/files/10405210/Application.Command.pdf)
[Bridge Application Handler.pdf](https://github.com/openhab/org.openhab.binding.zwave/files/10405211/Bridge.Application.Handler.pdf)
[Bridge Controller Library.pdf](https://github.com/openhab/org.openhab.binding.zwave/files/10405212/Bridge.Controller.Library.pdf)
[Zooz-700-PC Controller.pdf](https://github.com/openhab/org.openhab.binding.zwave/files/10405213/Zooz-700-PC.Controller.pdf)
[zwave-node2-addand delete.log](https://github.com/openhab/org.openhab.binding.zwave/files/10405214/zwave-node2-addand.delete.log)
[zwave-node3-addand heal.log](https://github.com/openhab/org.openhab.binding.zwave/files/10405215/zwave-node3-addand.heal.log)
[zwave-node4-add.log](https://github.com/openhab/org.openhab.binding.zwave/files/10405216/zwave-node4-add.log)

The "not perfect" comment is because one of the extra bytes (Destination) in 0xA8 versus 0x04 is simply dropped and the others (one minimum) regarding Multicast Destination Node Mask ignored.  You would know better but my speculation it for a multiple controller environment where the bridge controller could create a new message to forward to another controller. However, I believe these bytes are remnants from the Z/IP idea and not currently needed.

My last observation is the ZWave viewer will need to address 0xA8 with the same parameters as 0x04.  Edit 1: I'm assuming this is not open source? If it is I could look to see if I could figure out what needs to be changed for you.

**Edit 2**: Did a compare of the Application Command class with the Bridge Application Command class. Edit: Not relevant in latest commit !
[Compare Bridge to Application Command.pdf](https://github.com/openhab/org.openhab.binding.zwave/files/10435869/Compare.Bridge.to.Application.Command.pdf)

**Edit 3** for Third commit: Files referenced in the commit commentary are zniffer . Converted and shortened to excel files
1) Here is the 500 controller Network Heal (today's binding)
[Controller 500 Network Heal.xlsx](https://github.com/openhab/org.openhab.binding.zwave/files/10523430/Controller.500.Network.Heal.xlsx)

2) Here are the 700 controller network heal 22 hours after other nodes have healed
[Controller 700 Network Heal issues.xlsx](https://github.com/openhab/org.openhab.binding.zwave/files/10523491/Controller.700.Network.Heal.issues.xlsx)

 Here are the two pictures I referenced in Edit 3 related to the Heal.  First is 700 and second is 500, both Zooz controllers.

![Find Nodes in Range700](https://user-images.githubusercontent.com/54947543/215205479-4097b4db-ec14-4a2c-895c-03c5a50e28fb.png)
![Find Nodes in Range 500](https://user-images.githubusercontent.com/54947543/215205480-eed741ed-5aab-4f17-a414-ee119279b198.png)

**EDIT 4**: Here is a debug level start with the last commit without a separate BridgeApplicationCommandMessage class. This works on my Rpi3 and Rpi4.  The only hiccup (and I believe is unrelated to the code) that I see it that node 24 "sent data" while the binding was still "Waiting Request" mode, but it was sorted out in a few seconds. 

Could be ready to others to try as beta test, but I sense you want to write your own.
[startupwithPR version-rpi3.txt](https://github.com/openhab/org.openhab.binding.zwave/files/10579905/startupwithPR.version-rpi3.txt)




Signed-off-by: Bob Eckhoff <katmandodo@yahoo.com>