### PR TITLE
Add Weather (as Humidity) and low heat alarms

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
@@ -99,6 +99,13 @@ public class ZWaveAlarmConverter extends ZWaveCommandClassConverter {
         events.put(NotificationEvent.HEAT__HIGH_DETECTED_UNKNOWN, OnOffType.ON);
         notifications.put("alarm_heat", events);
 
+        // Cold alarms
+        events = new HashMap<NotificationEvent, State>();
+        events.put(NotificationEvent.HEAT__NONE, OnOffType.OFF);
+        events.put(NotificationEvent.HEAT__LOW_DETECTED, OnOffType.ON);
+        events.put(NotificationEvent.HEAT__LOW_DETECTED_UNKNOWN, OnOffType.ON);
+        notifications.put("alarm_cold", events);
+
         // Motion alarms
         events = new HashMap<NotificationEvent, State>();
         events.put(NotificationEvent.HOME_SECURITY__NONE, OnOffType.OFF);
@@ -182,6 +189,16 @@ public class ZWaveAlarmConverter extends ZWaveCommandClassConverter {
         events.put(NotificationEvent.SIREN__NONE, OnOffType.OFF);
         events.put(NotificationEvent.SIREN__ACTIVE, OnOffType.ON);
         notifications.put("notification_siren", events);
+
+        // Weather Alarms
+        events = new HashMap<NotificationEvent, State>();
+        events.put(NotificationEvent.WEATHER__NONE, OnOffType.OFF);
+        events.put(NotificationEvent.WEATHER__RAIN, OnOffType.ON);
+        events.put(NotificationEvent.WEATHER__MOISTURE, OnOffType.ON);
+        events.put(NotificationEvent.WEATHER__FREEZE, OnOffType.ON);
+        events.put(NotificationEvent.WEATHER__DRY, OnOffType.ON);
+        notifications.put("alarm_humidity", events);
+
     }
 
     /**
@@ -560,6 +577,12 @@ public class ZWaveAlarmConverter extends ZWaveCommandClassConverter {
 
         SIREN__NONE("SIREN", 0),
         SIREN__ACTIVE("SIREN", 1),
+
+        WEATHER__NONE("WEATHER", 0),
+        WEATHER__RAIN("WEATHER", 1),
+        WEATHER__MOISTURE("WEATHER", 2),
+        WEATHER__FREEZE("WEATHER", 3),
+        WEATHER__DRY("WEATHER", 6),
 
         GAS__NONE("GAS", 0),
         GAS__COMBUSTIBLE_DETECTED("GAS", 1),

--- a/src/main/resources/OH-INF/thing/channels.xml
+++ b/src/main/resources/OH-INF/thing/channels.xml
@@ -168,7 +168,22 @@
         <label>Heat alarm</label>
         <description>Indicates if a heat alarm is triggered
         </description>
-        <category>Fire</category>
+        <category>temperature_hot</category>
+        <state readOnly="true">
+            <options>
+                <option value="OFF">OK</option>
+                <option value="ON">Alarm</option>
+            </options>
+        </state>
+    </channel-type>
+
+    <!-- Cold Temperature Alarm Channel -->
+    <channel-type id="alarm_cold">
+        <item-type>Switch</item-type>
+        <label>Freeze alarm</label>
+        <description>Indicates if a low temp alarm is triggered
+        </description>
+        <category>temperature_cold</category>
         <state readOnly="true">
             <options>
                 <option value="OFF">OK</option>
@@ -280,6 +295,21 @@
         <description>
         </description>
         <category></category>
+        <state readOnly="true">
+            <options>
+                <option value="OFF">OK</option>
+                <option value="ON">Alarm</option>
+            </options>
+        </state>
+    </channel-type>
+    
+    <!-- Weather Alarm Channel -->
+    <channel-type id="alarm_humidity">
+        <item-type>Switch</item-type>
+        <label>Humidity-Moisture Alarm</label>
+        <description>
+        </description>
+        <category>Humidity</category>
         <state readOnly="true">
             <options>
                 <option value="OFF">OK</option>


### PR DESCRIPTION
Several newer temperature and humidity sensor devices (Zooz zse44, Aeotec ZWA009 and Aeotec ZWA039) have high and low humidity alarms using 0x10 "Weather" and also a low temperature alarm.  This adds PR adds both.  Separately, channels "temperature_cold" and "alarm_humidity" will need to be added to the Zwave database drop down menu.

Signed-off-by: Bob Eckhoff <katmandodo@yahoo.com>