### PR TITLE
Fix Attempting to add listener when controller is null #1202

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
@@ -503,7 +503,7 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
         }
 
         if (controller == null) {
-            logger.info("Attempting to add listener when controller is null");
+            logger.debug("Attempting to add listener when controller is null");
             return false;
         }
         controller.addEventListener(listener);


### PR DESCRIPTION
Fixes #1202 

Looks like the handler is not yet fully initialized and logs this message. As the binding works as expected, changing the log level from info to debug is better. 
