### PR TITLE
Set a default for Controller_sisnode

### DIFF
--- a/src/main/resources/OH-INF/thing/controller_serial.xml
+++ b/src/main/resources/OH-INF/thing/controller_serial.xml
@@ -62,6 +62,7 @@
             <parameter name="controller_sisnode" type="integer" groupName="network" min="1" max="232">
                 <label>SIS Node</label>
                 <description>Set node for SIS that will receive updates from other controllers in the network. If there is no SIS in the network, the controller will be set as SIS.</description>
+                <default>1</default>
                 <advanced>true</advanced>
             </parameter>
 


### PR DESCRIPTION
There have been a couple of [issues](https://community.openhab.org/t/z-stick-gen5-not-finding-dimmer/154327/6) and [here](https://community.openhab.org/t/z-wave-not-working-with-openhab-4-1-1/154344/12) in the forum recently where new users leave this at zero (it is an advanced param after all).  Before the rigorous checking introduced by OH core, a "0" was fixed by the binding.  Now the rigorous check appears to gum that fix up. Since 99% of all installations will start with controller = Node 1 and many of the lifeline groups put node 1 in the lifeline automatically the risk of issues here is low (IMO).  What makes this worse is that the controller still appears on-line and the problem occurs when trying to add devices. 


Signed-off-by: Bob Eckhoff <katmandodo@yahoo.com>