### PR TITLE
Update Thermostat Fan Mode options

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatFanModeCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatFanModeCommandClass.java
@@ -232,9 +232,9 @@ public class ZWaveThermostatFanModeCommandClass extends ZWaveCommandClass
         ON_LOW(1, "On Low"),
         AUTO_HIGH(2, "Auto High"),
         ON_HIGH(3, "On High"),
-        UNKNOWN_4(4, "Unknown 4"),
-        UNKNOWN_5(5, "Unknown 5"),
-        CIRCULATE(6, "Circulate");
+        AUTO_MEDIUM(4, "Auto Medium"),
+        MEDIUM(5, "Medium"),
+        CIRCULATE(6, "Circulate");  //Circulate is Version 3 Option
 
         /**
          * A mapping between the integer code and its corresponding fan mode type to facilitate lookup by code.


### PR DESCRIPTION
There were recent problems uploading an XML into the ZW DB with these parameters.  Don't know if this will resolve, but can't hurt.
Signed-off-by: Bob Eckhoff <katmandodo@yahoo.com>

More details;  This is from ZW Spec for version 2;
```
<cmd_class key="0x44" version="2" name="COMMAND_CLASS_THERMOSTAT_FAN_MODE" help="Command Class Thermostat Fan Mode" read_only="false" comment="">
    <cmd key="0x02" name="THERMOSTAT_FAN_MODE_GET" help="Thermostat Fan Mode Get" comment="" />
    <cmd key="0x03" name="THERMOSTAT_FAN_MODE_REPORT" help="Thermostat Fan Mode Report" comment="">
      <param key="0x00" name="Level" type="STRUCT_BYTE" typehashcode="0x07" comment="">
        <fieldenum key="0x00" fieldname="Fan Mode" fieldmask="0x0F" shifter="0">
          <fieldenum value="Auto Low" />
          <fieldenum value="Low" />
          <fieldenum value="Auto High" />
          <fieldenum value="High" />
          <fieldenum value="Auto Medium" />
          <fieldenum value="Medium" />
        </fieldenum>
        <bitfield key="0x01" fieldname="Reserved" fieldmask="0xF0" shifter="4" />
      </param>
    </cmd>
    <cmd key="0x01" name="THERMOSTAT_FAN_MODE_SET" help="Thermostat Fan Mode Set" comment="">
      <param key="0x00" name="Level" type="STRUCT_BYTE" typehashcode="0x07" comment="">
        <fieldenum key="0x00" fieldname="Fan Mode" fieldmask="0x0F" shifter="0">
          <fieldenum value="Auto Low" />
          <fieldenum value="Low" />
          <fieldenum value="Auto High" />
          <fieldenum value="High" />
          <fieldenum value="Auto Medium" />
          <fieldenum value="Medium" />
        </fieldenum>
        <bitfield key="0x01" fieldname="Reserved" fieldmask="0x70" shifter="4" />
        <bitflag key="0x02" flagname="Off" flagmask="0x80" />
      </param>
    </cmd>
    <cmd key="0x04" name="THERMOSTAT_FAN_MODE_SUPPORTED_GET" help="Thermostat Fan Mode Supported Get" comment="" />
    <cmd key="0x05" name="THERMOSTAT_FAN_MODE_SUPPORTED_REPORT" help="Thermostat Fan Mode Supported Report" comment="">
      <param key="0x00" name="Bit Mask" type="BITMASK" typehashcode="0x06" comment="">
        <bitmask key="0x00" paramoffs="255" lenmask="0x00" lenoffs="0" />
        <bitflag key="0x00" flagname="Auto" flagmask="0x00" />
        <bitflag key="0x01" flagname="Low" flagmask="0x01" />
        <bitflag key="0x02" flagname="Auto High" flagmask="0x02" />
        <bitflag key="0x03" flagname="High" flagmask="0x03" />
        <bitflag key="0x04" flagname="Auto Medium" flagmask="0x04" />
        <bitflag key="0x05" flagname="Medium" flagmask="0x05" />
      </param>
    </cmd>
  </cmd_class>
```
This was from the forum XML that caused the problem with ZW DB upload.  Once I deleted 4 and 5 it uploaded cleanly.
From OH XML
```
          <entry>
            <commandClass>COMMAND_CLASS_THERMOSTAT_FAN_MODE</commandClass>
            <COMMAND__CLASS__THERMOSTAT__FAN__MODE>
              <version>1</version>
              <instances>1</instances>
              <control>false</control>
              <versionSupported>2</versionSupported>
              <fanModeTypes>
                <fanModeType>AUTO_LOW</fanModeType>
                <fanModeType>ON_LOW</fanModeType>
                <fanModeType>ON_HIGH</fanModeType>
                <fanModeType>UNKNOWN_4</fanModeType>
                <fanModeType>UNKNOWN_5</fanModeType>
              </fanModeTypes>
              <isGetSupported>true</isGetSupported>
            </COMMAND__CLASS__THERMOSTAT__FAN__MODE>
          </entry>
```
