### PR TITLE
Added System notification events used by a device

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
@@ -86,10 +86,14 @@ public class ZWaveAlarmConverter extends ZWaveCommandClassConverter {
         events.put(NotificationEvent.ACCESS_CONTROL__MANUAL_UNLOCK, OnOffType.OFF);
         notifications.put("alarm_entry", events);
 
-        // Heart beats
+        // System Alarms and Heart Beat
         events = new HashMap<NotificationEvent, State>();
-        events.put(NotificationEvent.SYSTEM__HEARTBEAT, OnOffType.ON);
         events.put(NotificationEvent.SYSTEM__NONE, OnOffType.OFF);
+        events.put(NotificationEvent.SYSTEM__HARDWARE_FAILURE, OnOffType.ON);
+        events.put(NotificationEvent.SYSTEM__SOFTWARE_FAILURE, OnOffType.ON);
+        events.put(NotificationEvent.SYSTEM__HARDWARE_FAILURE_MANUFACTURER_CODE, OnOffType.ON);
+        events.put(NotificationEvent.SYSTEM__SOFTWARE_FAILURE_MANUFACTURER_CODE, OnOffType.ON);
+        events.put(NotificationEvent.SYSTEM__HEARTBEAT, OnOffType.ON);
         notifications.put("alarm_system", events);
 
         // Heat alarms


### PR DESCRIPTION
The Euro Comet (Device 1561) uses system notifications 1-4 that are not covered in alarm_system channel, but are available in the binding.
Signed-off-by: Bob Eckhoff <katmandodo@yahoo.com>  From that device manual; However I just used the current labeling used in the specification, so they could be used by others
![Notification 2024-11-25 145929](https://github.com/user-attachments/assets/a6a027f0-d01a-40f8-95ea-40c81789d906)
