### PR TITLE
Add properties (Neighbor and Node) for controller to appear on network map

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
@@ -191,6 +191,10 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
         controller = new ZWaveController(this, config);
         controller.addEventListener(this);
 
+        // Set controller properties for Network Map since it will not be healed
+        getThing().setProperty(ZWaveBindingConstants.PROPERTY_NEIGHBOURS, sucNode.toString());
+        getThing().setProperty(ZWaveBindingConstants.PROPERTY_NODEID, sucNode.toString());
+
         // Add any listeners that were registered before the manager was registered
         synchronized (listeners) {
             for (ZWaveEventListener listener : listeners) {


### PR DESCRIPTION
From a comment on the [forum](https://community.openhab.org/t/zwave-controller-missing-in-network-map/150920/5) I added this to the controller handler so the controller would appear on the network map. It is basically cosmetic since the network map has little diagnostic value (see my comment in the thread just above the one referenced). The absence of the controller in the map was a side effect of 700 controllers not being able to heal themselves. I tested locally.  Since the controller doesn't show neighbors (except itself) the connections are shown one-way, but IMO that is good enough for this purpose.
![network map 2024-12-11 094950](https://github.com/user-attachments/assets/96456e76-2d45-4338-b136-9058da505293)

Signed-off-by: Bob Eckhoff <katmandodo@yahoo.com>