### PR TITLE
Change update memory class for newer SDKs

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/GetSucNodeIdMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/GetSucNodeIdMessageClass.java
@@ -43,10 +43,10 @@ public class GetSucNodeIdMessageClass extends ZWaveCommandProcessor {
     public boolean handleResponse(ZWaveController zController, ZWaveTransaction transaction,
             SerialMessage incomingMessage) throws ZWaveSerialMessageException {
         logger.debug("Got SUC NodeID response.");
-
-        if (incomingMessage.getMessagePayloadByte(0) != 0x00) {
-            logger.debug("NODE {}: Node is SUC.", incomingMessage.getMessagePayloadByte(0));
-            sucNode = incomingMessage.getMessagePayloadByte(0);
+                //will need to fix if this works
+        if (incomingMessage.getMessagePayloadByte(1) != 0x00) {
+            logger.debug("NODE {}: Node is SUC.", incomingMessage.getMessagePayloadByte(1));
+            sucNode = incomingMessage.getMessagePayloadByte(1);
         } else {
             logger.debug("No SUC Node is set");
         }

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/IdentifyNodeMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/IdentifyNodeMessageClass.java
@@ -38,8 +38,8 @@ public class IdentifyNodeMessageClass extends ZWaveCommandProcessor {
     private final Logger logger = LoggerFactory.getLogger(IdentifyNodeMessageClass.class);
 
     public ZWaveSerialPayload doRequest(int nodeId) {
-        // Create the request
-        return new ZWaveTransactionMessageBuilder(SerialMessageClass.IdentifyNode).withPayload(nodeId).build();
+        // Create the request- Will need to fix
+        return new ZWaveTransactionMessageBuilder(SerialMessageClass.IdentifyNode).withPayload(0x00, nodeId).build();
         // .withResponseNodeId(nodeId).build();
     }
 
@@ -54,7 +54,7 @@ public class IdentifyNodeMessageClass extends ZWaveCommandProcessor {
         if (transaction.getSerialMessage() == null) {
             return false;
         }
-        int nodeId = transaction.getSerialMessage().getMessagePayloadByte(0);
+        int nodeId = transaction.getSerialMessage().getMessagePayloadByte(1);
         logger.debug("NODE {}: ProtocolInfo", nodeId);
 
         ZWaveNode node = zController.getNode(nodeId);

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/MemoryGetIdMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/MemoryGetIdMessageClass.java
@@ -46,7 +46,7 @@ public class MemoryGetIdMessageClass extends ZWaveCommandProcessor {
                 | ((incomingMessage.getMessagePayloadByte(2)) << 8) | (incomingMessage.getMessagePayloadByte(3));
         ownNodeId = incomingMessage.getMessagePayloadByte(4);  
         if (messageLength == 6) {
-            ownNodeId = (incomingMessage.getMessagePayloadByte(4) | incomingMessage.getMessagePayloadByte(5));
+            ownNodeId = ((incomingMessage.getMessagePayloadByte(4)) << 8) | (incomingMessage.getMessagePayloadByte(5));
         }
         logger.debug("Got MessageMemoryGetId response. Home id = 0x{}, Controller Node id = {}",
                 Integer.toHexString(homeId), ownNodeId);

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/MemoryGetIdMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/MemoryGetIdMessageClass.java
@@ -41,9 +41,13 @@ public class MemoryGetIdMessageClass extends ZWaveCommandProcessor {
     @Override
     public boolean handleResponse(ZWaveController zController, ZWaveTransaction transaction,
             SerialMessage incomingMessage) throws ZWaveSerialMessageException {
+        int messageLength = incomingMessage.getMessagePayload().length;
         homeId = ((incomingMessage.getMessagePayloadByte(0)) << 24) | ((incomingMessage.getMessagePayloadByte(1)) << 16)
                 | ((incomingMessage.getMessagePayloadByte(2)) << 8) | (incomingMessage.getMessagePayloadByte(3));
-        ownNodeId = incomingMessage.getMessagePayloadByte(4);
+        ownNodeId = incomingMessage.getMessagePayloadByte(4);  
+        if (messageLength == 6) {
+            ownNodeId = (incomingMessage.getMessagePayloadByte(4) | incomingMessage.getMessagePayloadByte(5));
+        }
         logger.debug("Got MessageMemoryGetId response. Home id = 0x{}, Controller Node id = {}",
                 Integer.toHexString(homeId), ownNodeId);
 

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetSucNodeMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetSucNodeMessageClass.java
@@ -33,11 +33,13 @@ public class SetSucNodeMessageClass extends ZWaveCommandProcessor {
     public ZWaveSerialPayload doRequest(int nodeId, boolean enable) {
         logger.debug("NODE {}: SetSucNodeID node {}", nodeId, enable);
 
-        byte[] payload = new byte[4];
-        payload[0] = (byte) nodeId;
-        payload[1] = (byte) (enable ? 1 : 0);
-        payload[2] = 0;
-        payload[3] = (byte) (enable ? 1 : 0);
+        byte[] payload = new byte[5];
+        //will need to figure a switch if this works
+        payload[0] = 0;
+        payload[1] = (byte) nodeId;
+        payload[2] = (byte) (enable ? 1 : 0);
+        payload[3] = 0;
+        payload[4] = (byte) (enable ? 1 : 0);
 
         // Create the request
         return new ZWaveTransactionMessageBuilder(SerialMessageClass.SetSucNodeID).withPayload(payload).build();

--- a/src/main/resources/OH-INF/thing/controller_serial.xml
+++ b/src/main/resources/OH-INF/thing/controller_serial.xml
@@ -59,7 +59,7 @@
                 <advanced>true</advanced>
             </parameter>
 
-            <parameter name="controller_sisnode" type="integer" groupName="network" min="1" max="232">
+            <parameter name="controller_sisnode" type="integer" groupName="network" min="0" max="232">
                 <label>SIS Node</label>
                 <description>Set node for SIS that will receive updates from other controllers in the network. If there is no SIS in the network, the controller will be set as SIS.</description>
                 <default>1</default>

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetSucNodeMessageClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetSucNodeMessageClassTest.java
@@ -30,8 +30,8 @@ import org.openhab.binding.zwave.internal.protocol.ZWaveSerialPayload;
 public class SetSucNodeMessageClassTest {
     @Test
     public void doRequest() {
-        byte[] expectedResponseNone = { 12, 1, 0, 1 };
-        byte[] expectedResponseBasic = { 12, 0, 0, 0 };
+        byte[] expectedResponseNone = { 0, 12, 1, 0, 1 };
+        byte[] expectedResponseBasic = { 0, 12, 0, 0, 0 };
 
         ZWaveSerialPayload msg;
         SetSucNodeMessageClass handler = new SetSucNodeMessageClass();


### PR DESCRIPTION
It appears the location of the controller node ID has changed in the newer SDKs in the MemoryGetID.  Forum issues with SDK [7.21](https://community.openhab.org/t/aeotec-z-wave-controller-gen7-working-with-openhab/161284/4) and 7.22 [probably](https://community.openhab.org/t/im-trying-to-get-habmin-installed/160679/36) to accommodate the 16 bit LR address range. I have to decide about testing since I'd have to buy a new zstick as I don't want to mess with my working version by trying to upgrade.  Will mark this as draft, since you might not like it anyway. This will need to be backported so it can work with java17.
```
2025-01-02 12:02:48.459 [DEBUG] [nal.protocol.ZWaveTransactionManager] - lastTransaction TID 21: [WAIT_RESPONSE] priority=Controller, requiresResponse=true, callback: 0
2025-01-02 12:02:48.459 [DEBUG] [nal.protocol.ZWaveTransactionManager] - Checking outstanding transactions: 1
2025-01-02 12:02:48.460 [DEBUG] [nal.protocol.ZWaveTransactionManager] - Last transaction: TID 21: [WAIT_RESPONSE] priority=Controller, requiresResponse=true, callback: 0
2025-01-02 12:02:48.460 [DEBUG] [ve.internal.protocol.ZWaveController] - Incoming Message: Message: class=MemoryGetId[32], type=Response[1], dest=255, callback=0, payload=FD 20 DE 03 00 01 
2025-01-02 12:02:48.461 [DEBUG] [erialmessage.MemoryGetIdMessageClass] - Got MessageMemoryGetId response. Home id = 0xfd20de03, Controller Node id = 0
```
 
![Get memoryID 2025-01-02 164925](https://github.com/user-attachments/assets/cc96d570-d50d-40d1-aec9-c45d6c762441)
 More info to follow

Signed-off-by: Bob Eckhoff <katmandodo@yahoo.com>