### PR TITLE
Use the Set Serial API (0x0B) to reset nodeId to 8 bits

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -28,5 +28,16 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -28,16 +28,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="target/generated-sources/annotations">
-		<attributes>
-			<attribute name="optional" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialMessage.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialMessage.java
@@ -501,6 +501,7 @@ public class SerialMessage {
         SerialApiSetTimeouts(0x06, true, false, false), // Set Serial API timeouts
         SerialApiGetCapabilities(0x07, true, false, false), // Request Serial API capabilities
         SerialApiSoftReset(0x08, false, false, false), // Soft reset. Restarts Z-Wave chip
+        SetUpZwaveApi(0x0B,true, false, false), // Set the Node ID to 8 bits (or 16 bits-TODO)
         RfReceiveMode(0x10), // Power down the RF section of the stick
         SetSleepMode(0x11), // Set the CPU into sleep mode
         SendNodeInfo(0x12), // Send Node Information Frame of the stick

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialMessage.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialMessage.java
@@ -501,7 +501,7 @@ public class SerialMessage {
         SerialApiSetTimeouts(0x06, true, false, false), // Set Serial API timeouts
         SerialApiGetCapabilities(0x07, true, false, false), // Request Serial API capabilities
         SerialApiSoftReset(0x08, false, false, false), // Soft reset. Restarts Z-Wave chip
-        SetUpZwaveApi(0x0B,true, false, false), // Set the Node ID to 8 bits (or 16 bits-TODO)
+        SetUpZwaveApi(0x0B,true, false, false), // Set the Node ID to 8 bits
         RfReceiveMode(0x10), // Power down the RF section of the stick
         SetSleepMode(0x11), // Set the CPU into sleep mode
         SendNodeInfo(0x12), // Send Node Information Frame of the stick

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -59,6 +59,7 @@ import org.openhab.binding.zwave.internal.protocol.serialmessage.SerialApiGetCap
 import org.openhab.binding.zwave.internal.protocol.serialmessage.SerialApiGetInitDataMessageClass;
 import org.openhab.binding.zwave.internal.protocol.serialmessage.SerialApiSetTimeoutsMessageClass;
 import org.openhab.binding.zwave.internal.protocol.serialmessage.SerialApiSoftResetMessageClass;
+import org.openhab.binding.zwave.internal.protocol.serialmessage.SetNodeIdTypeMessageClass;
 import org.openhab.binding.zwave.internal.protocol.serialmessage.SetSucNodeMessageClass;
 import org.openhab.binding.zwave.internal.protocol.serialmessage.ZWaveCommandProcessor;
 import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
@@ -639,6 +640,7 @@ public class ZWaveController {
      */
     public void initialize() {
         enqueue(new GetVersionMessageClass().doRequest());
+        enqueue(new SetNodeIdTypeMessageClass().doRequest());
         enqueue(new MemoryGetIdMessageClass().doRequest());
         enqueue(new SerialApiGetCapabilitiesMessageClass().doRequest());
         enqueue(new SerialApiSetTimeoutsMessageClass().doRequest(150, 15));

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetNodeIdTypeMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetNodeIdTypeMessageClass.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.zwave.internal.protocol.serialmessage;
+
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
+import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
+import org.openhab.binding.zwave.internal.protocol.ZWaveSerialPayload;
+import org.openhab.binding.zwave.internal.protocol.ZWaveTransaction;
+import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveTransactionMessageBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class sets the NodeId Type to 8 bits
+ *
+ * @author Bob Eckhoff - Initial Conteribution
+ */
+public class SetNodeIdTypeMessageClass extends ZWaveCommandProcessor {
+    private final Logger logger = LoggerFactory.getLogger(SetNodeIdTypeMessageClass.class);
+
+    public ZWaveSerialPayload doRequest() {
+        logger.debug("SetNodeIdType for controller");
+
+        byte[] payload = new byte[2];
+        payload[0] = (byte) 0x80;
+        payload[1] = (byte) 0x01;  // 1=8bit, 2=16bit
+
+        // Possibly restrict command to library 7
+        // GetVersionMessageClass instance = new GetVersionMessageClass();
+        // if(instance.getLibraryType() == 7) {}
+        // What happens with no command?
+        
+        // Create the request
+        return new ZWaveTransactionMessageBuilder(SerialMessageClass.SetUpZwaveApi).withPayload(payload).build();
+    }
+
+    @Override
+    public boolean handleResponse(ZWaveController zController, ZWaveTransaction transaction,
+            SerialMessage incomingMessage) throws ZWaveSerialMessageException {
+        int nodeIdType = transaction.getSerialMessage().getMessagePayloadByte(1);
+
+        logger.debug("SetNodeIdType node response {}", nodeIdType);
+
+        if (incomingMessage.getMessagePayloadByte(1) != 0x00) {
+            logger.debug("Eight bit NodeId command OK.");
+        } else {
+            logger.error("Eight bit NodeId command failed.");
+            transaction.setTransactionCanceled();
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetNodeIdTypeMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetNodeIdTypeMessageClass.java
@@ -30,15 +30,15 @@ import org.slf4j.LoggerFactory;
 public class SetNodeIdTypeMessageClass extends ZWaveCommandProcessor {
     private final Logger logger = LoggerFactory.getLogger(SetNodeIdTypeMessageClass.class);
 
-    private static byte cmdSetNodeIdType = (byte) 0x80; // Subclass of SetUpZwaveAPI for NodeID Type
-    private static byte nodeIdType8Bit = (byte) 0x01;  // 1=8 bit, 2=16 bit NodeID Type
+    private static final byte CMD_SETNODEID = (byte) 0x80; // Subclass of SetUpZwaveAPI for NodeID Type
+    private static final byte NODEID_8BIT = (byte) 0x01;  // 1=8 bit, 2=16 bit NodeID Type
 
     public ZWaveSerialPayload doRequest() {
         logger.debug("SetNodeIdType for controller");
 
         byte[] payload = new byte[2];
-        payload[0] = cmdSetNodeIdType;
-        payload[1] = nodeIdType8Bit;
+        payload[0] = CMD_SETNODEID;
+        payload[1] = NODEID_8BIT;
         
         // Create the request
         return new ZWaveTransactionMessageBuilder(SerialMessageClass.SetUpZwaveApi).withPayload(payload).build();

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetNodeIdTypeMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetNodeIdTypeMessageClass.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This class sets the NodeId Type to 8 bits
  *
- * @author Bob Eckhoff - Initial Conteribution
+ * @author Bob Eckhoff - Initial contribution
  */
 public class SetNodeIdTypeMessageClass extends ZWaveCommandProcessor {
     private final Logger logger = LoggerFactory.getLogger(SetNodeIdTypeMessageClass.class);
@@ -44,8 +44,7 @@ public class SetNodeIdTypeMessageClass extends ZWaveCommandProcessor {
     @Override
     public boolean handleResponse(ZWaveController zController, ZWaveTransaction transaction,
             SerialMessage incomingMessage) throws ZWaveSerialMessageException {
-
-        logger.debug("SetNodeIdType node response {}");
+        logger.debug("SetNodeIdType node response");
 
         // Index 0 = 0x00 means the serial message class is not supported, so NodeId has to be the 8 bit default
         if (incomingMessage.getMessagePayloadByte(1) != 0x00 || incomingMessage.getMessagePayloadByte(0) == 0x00) {

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetNodeIdTypeMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetNodeIdTypeMessageClass.java
@@ -35,7 +35,12 @@ public class SetNodeIdTypeMessageClass extends ZWaveCommandProcessor {
 
         byte[] payload = new byte[2];
         payload[0] = (byte) 0x80;
-        payload[1] = (byte) 0x01;  // 1=8 bit, 2=16 bit
+        payload[1] = (byte) 0x01;  // 1=8bit, 2=16bit
+
+        // Possibly restrict command to library 7
+        // GetVersionMessageClass instance = new GetVersionMessageClass();
+        // if(instance.getLibraryType() == 7) {}
+        // What happens with no command?
         
         // Create the request
         return new ZWaveTransactionMessageBuilder(SerialMessageClass.SetUpZwaveApi).withPayload(payload).build();
@@ -44,11 +49,11 @@ public class SetNodeIdTypeMessageClass extends ZWaveCommandProcessor {
     @Override
     public boolean handleResponse(ZWaveController zController, ZWaveTransaction transaction,
             SerialMessage incomingMessage) throws ZWaveSerialMessageException {
+        int nodeIdType = transaction.getSerialMessage().getMessagePayloadByte(1);
 
-        logger.debug("SetNodeIdType node response received");
+        logger.debug("SetNodeIdType node response {}", nodeIdType);
 
-        // Index 0 = 0x00 means the serial message class is not supported, so NodeId has to be the 8 bit default
-        if (incomingMessage.getMessagePayloadByte(1) != 0x00 || incomingMessage.getMessagePayloadByte(0) == 0x00) {
+        if (incomingMessage.getMessagePayloadByte(1) != 0x00) {
             logger.debug("Eight bit NodeId command OK.");
         } else {
             logger.error("Eight bit NodeId command failed.");

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetNodeIdTypeMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetNodeIdTypeMessageClass.java
@@ -30,12 +30,15 @@ import org.slf4j.LoggerFactory;
 public class SetNodeIdTypeMessageClass extends ZWaveCommandProcessor {
     private final Logger logger = LoggerFactory.getLogger(SetNodeIdTypeMessageClass.class);
 
+    private static byte cmdSetNodeIdType = (byte) 0x80; // Subclass of SetUpZwaveAPI for NodeID Type
+    private static byte nodeIdType8Bit = (byte) 0x01;  // 1=8 bit, 2=16 bit NodeID Type
+
     public ZWaveSerialPayload doRequest() {
         logger.debug("SetNodeIdType for controller");
 
         byte[] payload = new byte[2];
-        payload[0] = (byte) 0x80;
-        payload[1] = (byte) 0x01;  // 1=8 bit, 2=16 bit
+        payload[0] = cmdSetNodeIdType;
+        payload[1] = nodeIdType8Bit;
         
         // Create the request
         return new ZWaveTransactionMessageBuilder(SerialMessageClass.SetUpZwaveApi).withPayload(payload).build();

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetNodeIdTypeMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetNodeIdTypeMessageClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -35,12 +35,7 @@ public class SetNodeIdTypeMessageClass extends ZWaveCommandProcessor {
 
         byte[] payload = new byte[2];
         payload[0] = (byte) 0x80;
-        payload[1] = (byte) 0x01;  // 1=8bit, 2=16bit
-
-        // Possibly restrict command to library 7
-        // GetVersionMessageClass instance = new GetVersionMessageClass();
-        // if(instance.getLibraryType() == 7) {}
-        // What happens with no command?
+        payload[1] = (byte) 0x01;  // 1=8 bit, 2=16 bit
         
         // Create the request
         return new ZWaveTransactionMessageBuilder(SerialMessageClass.SetUpZwaveApi).withPayload(payload).build();
@@ -49,11 +44,11 @@ public class SetNodeIdTypeMessageClass extends ZWaveCommandProcessor {
     @Override
     public boolean handleResponse(ZWaveController zController, ZWaveTransaction transaction,
             SerialMessage incomingMessage) throws ZWaveSerialMessageException {
-        int nodeIdType = transaction.getSerialMessage().getMessagePayloadByte(1);
 
-        logger.debug("SetNodeIdType node response {}", nodeIdType);
+        logger.debug("SetNodeIdType node response {}");
 
-        if (incomingMessage.getMessagePayloadByte(1) != 0x00) {
+        // Index 0 = 0x00 means the serial message class is not supported, so NodeId has to be the 8 bit default
+        if (incomingMessage.getMessagePayloadByte(1) != 0x00 || incomingMessage.getMessagePayloadByte(0) == 0x00) {
             logger.debug("Eight bit NodeId command OK.");
         } else {
             logger.error("Eight bit NodeId command failed.");

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetNodeIdTypeMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetNodeIdTypeMessageClass.java
@@ -35,12 +35,7 @@ public class SetNodeIdTypeMessageClass extends ZWaveCommandProcessor {
 
         byte[] payload = new byte[2];
         payload[0] = (byte) 0x80;
-        payload[1] = (byte) 0x01;  // 1=8bit, 2=16bit
-
-        // Possibly restrict command to library 7
-        // GetVersionMessageClass instance = new GetVersionMessageClass();
-        // if(instance.getLibraryType() == 7) {}
-        // What happens with no command?
+        payload[1] = (byte) 0x01;  // 1=8 bit, 2=16 bit
         
         // Create the request
         return new ZWaveTransactionMessageBuilder(SerialMessageClass.SetUpZwaveApi).withPayload(payload).build();
@@ -49,11 +44,11 @@ public class SetNodeIdTypeMessageClass extends ZWaveCommandProcessor {
     @Override
     public boolean handleResponse(ZWaveController zController, ZWaveTransaction transaction,
             SerialMessage incomingMessage) throws ZWaveSerialMessageException {
-        int nodeIdType = transaction.getSerialMessage().getMessagePayloadByte(1);
 
-        logger.debug("SetNodeIdType node response {}", nodeIdType);
+        logger.debug("SetNodeIdType node response received");
 
-        if (incomingMessage.getMessagePayloadByte(1) != 0x00) {
+        // Index 0 = 0x00 means the serial message class is not supported, so NodeId has to be the 8 bit default
+        if (incomingMessage.getMessagePayloadByte(1) != 0x00 || incomingMessage.getMessagePayloadByte(0) == 0x00) {
             logger.debug("Eight bit NodeId command OK.");
         } else {
             logger.error("Eight bit NodeId command failed.");

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ZWaveCommandProcessor.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ZWaveCommandProcessor.java
@@ -135,6 +135,7 @@ public abstract class ZWaveCommandProcessor {
                     SerialApiSetTimeoutsMessageClass.class);
             messageMap.put(SerialMessage.SerialMessageClass.SerialApiSoftReset, SerialApiSoftResetMessageClass.class);
             messageMap.put(SerialMessage.SerialMessageClass.SetSucNodeID, SetSucNodeMessageClass.class);
+            messageMap.put(SerialMessage.SerialMessageClass.SetUpZwaveApi, SetNodeIdTypeMessageClass.class);
             messageMap.put(SerialMessage.SerialMessageClass.SetDefault, ControllerSetDefaultMessageClass.class);
         }
 

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetNodeIdTypeMessageClassTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetNodeIdTypeMessageClassTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.zwave.internal.protocol.serialmessage;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+
+/**
+ * Test case for SetNodeIdTypeMessageClass message.
+ * This takes some example packets, processes them, and checks that the processing is correct.
+ *
+ * @author Bob Eckhoff - Initial contribution
+ *
+ */
+public class SetNodeIdTypeMessageClassTest {
+    @Test
+    public void doRequest() {
+        byte[] expectedResponse = { 1, 5, 0, 11, -128, 1, 112};
+
+        SerialMessage msg;
+        SetNodeIdTypeMessageClass handler = new SetNodeIdTypeMessageClass();
+
+        msg = handler.doRequest().getSerialMessage();
+        msg.setCallbackId(1);
+        assertTrue(Arrays.equals(msg.getMessageBuffer(), expectedResponse));
+    }
+}


### PR DESCRIPTION
The other PR was not going to work without major refactoring to allow both 8 and 16 bit node IDs.  Since the binding can not support LR nodes anyway (S2 and Smart Start are also required), this PR sends a message to use 8bit. It worked on a zooz 800 with SDK 7.22 originally using 16bit. (I used Simplicity studio to change the zooz 700 controller on 7.21.41.
![NodeID 2025-01-04 205530](https://github.com/user-attachments/assets/c38b9d6d-1c35-4a65-a3b6-e8ae71b47f04)
![NodeID page 2 2025-01-04 205642](https://github.com/user-attachments/assets/8f930590-4539-4649-977c-37675a3dcf77)

Signed-off-by: Bob Eckhoff <katmandodo@yahoo.com>