### PR TITLE
Handle timeout state in node init response logging

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -296,8 +296,10 @@ public class ZWaveNodeInitStageAdvancer {
                 break;
             }
 
-            logger.debug("NODE {}: Node Init response ({}) {}", node.getNodeId(), retryCount, response);
-            if (response != null && response.getState() == State.COMPLETE) {
+            logger.debug("NODE {}: Node Init response ({}) {}", node.getNodeId(), retryCount, response.getState());
+            // The controller may report no ACK received on a listening but inactive node before the binding timer sends an abort
+            // This handles both cases.
+            if (response != null && (response.getState() == State.COMPLETE || response.getState() == State.TIMEOUT_WAITING_FOR_RESPONSE)) {
                 break;
             }
 


### PR DESCRIPTION
Logger now outputs the response state instead of the full response object. The node initialization logic also breaks on TIMEOUT_WAITING_FOR_RESPONSE state, improving handling of inactive nodes.
--
This started with OP issue. The controller reports no ACK before the binding transaction timer ends (5 Seconds), this causes the ping to repeat over and over. Except of issue from OP
[openhab-OP_clean2.txt](https://github.com/user-attachments/files/22104723/openhab-OP_clean2.txt)
I was able to recreate on small Rpi3
[Offline node on startup ping continues.txt](https://github.com/user-attachments/files/22104729/Offline.node.on.startup.ping.continues.txt)
Interestingly on separate OH test environment the timer is hit and the command aborts to complete.
[WSL700 offline node aborted-timeout.txt](https://github.com/user-attachments/files/22104747/WSL700.offline.node.aborted-timeout.txt)
This fix solved the problem even with the abort timer not being reached;
[Offline node on startup ping stopped.txt](https://github.com/user-attachments/files/22104752/Offline.node.on.startup.ping.stopped.txt)

