### PR TITLE
Skip static init and NIF request for restored nodes

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -467,8 +467,10 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
         }
     }
 
+    // Start polling with a random initial delay, but right after the thing is initialised (DONE).
+    // 30 seconds mimimum, 90 seconds maximum
     private void startPolling() {
-        startPolling(pollingPeriod * (int) (1000 * Math.random()));
+        startPolling(30000 + 60 * (int) (1000 * Math.random()));
     }
 
     @Override

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStageAdvancer.java
@@ -193,8 +193,8 @@ public class ZWaveNodeInitStageAdvancer {
                         return;
                     }
 
-                    // If restored from a config file, jump to Done to reduce congestion.
-                    // Persistance will take care of restoring values
+                    // If restored from a config file, jump to Done to reduce OH startup congestion.
+                    // Adjusted initial Poll to capture any channel changes since startup.
                     if (isRestoredFromConfigfile()) {
                         logger.debug("NODE {}: Node advancer: Restored from file - skipping static initialisation",
                                 node.getNodeId());


### PR DESCRIPTION
When a node is restored from a config file, initialization now jumps directly to the DONE stage and skips the REQUEST_NIF step to reduce network congestion. Persistence is relied upon to restore values, assuming the node on the controller matches the restored node.
Probably a little more controversial... I have been using both ZUI and this binding for a couple of years now. One thing I noticed right away is that it only does a ping on startup for devices already in their "Store". The zwave-js has applied (or at least targeting) ZWA certification, so this must be allowed.  This PR allows devices that are recovered from XML files to basically go to "Done". In one case I had had one device without an XML (The battery devices in my test system have no XML, so they go to wait NIF). The only devices get a ping and go to complete.  The one device without an XML goes through all the steps.
[WSL Ping only Test with OH5-main network.txt](https://github.com/user-attachments/files/22104981/WSL.Ping.only.Test.with.OH5-main.network.txt)
In this test on another controller only pings of listening devices.
[WSL 800 Basement Test  Ping only.txt](https://github.com/user-attachments/files/22104985/WSL.800.Basement.Test.Ping.only.txt)
About 22 nodes in 2 seconds.  As OH in general gets bigger this would help IMO.  Also since the devices are DONE, they could be reinitialized or Healed outside the startup window, if something doesn't look okay.