### PR TITLE
Add Refresh Channel Thing Action

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/actions/ZWaveThingActions.java
+++ b/src/main/java/org/openhab/binding/zwave/actions/ZWaveThingActions.java
@@ -83,6 +83,14 @@ public class ZWaveThingActions implements ThingActions {
         }
     }
 
+    public static String pollLinkedChannels(ThingActions actions) {
+        if (actions instanceof ZWaveThingActions nodeActions) {
+            return nodeActions.pollLinkedChannels();
+        } else {
+            throw new IllegalArgumentException("The 'actions' argument is not an instance of ZWaveThingActions");
+        }
+    }
+
     @Override
     public void setThingHandler(ThingHandler thingHandler) {
         this.handler = (ZWaveThingHandler) thingHandler;
@@ -145,5 +153,14 @@ public class ZWaveThingActions implements ThingActions {
             return handler.pingNode();
         }
         return "Handler is null, cannot ping node";
+    }
+
+    @RuleAction(label = "@text/actions.poll-linked-channels.label", description = "@text/actions.poll-linked-channels.description")
+    public @ActionOutput(type = "String") String pollLinkedChannels() {
+        ZWaveThingHandler handler = this.handler;
+        if (handler != null) {
+            return handler.pollLinkedChannels();
+        }
+        return "Handler is null, cannot poll linked channels";
     }
 }

--- a/src/main/resources/OH-INF/i18n/actions.properties
+++ b/src/main/resources/OH-INF/i18n/actions.properties
@@ -27,3 +27,6 @@ actions.node-heal.description=Discover and assign new routes from node to the co
 
 actions.node-ping.label=Ping the node
 actions.node-ping.description=Send a ping to the node to check if it is reachable.
+
+actions.poll-linked-channels.label=Refresh linked channels (nee Poll)
+actions.poll-linked-channels.description=Refresh values on updatable linked channels. Not all channels are pollable (e.g. Notifications, Scenes).


### PR DESCRIPTION
Add Refresh Channel Thing Action. Alternate to creating a rule with REFRESH, this can be executed from the Thing Main UI page. Accidently did a spotless:apply and reverted all but in the ThingHandler that I was modifying anyway, so there are some random formatting changes in that file.

I think this would be useful, so left it VISIBLE