### PR TITLE
Add RF region support for Z-Wave controllers

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
+++ b/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
@@ -88,6 +88,7 @@ public class ZWaveBindingConstants {
     public final static String PROPERTY_LASTWAKEUP = "zwave_lastwakeup";
     public final static String PROPERTY_USINGSECURITY = "zwave_secure";
     public final static String PROPERTY_LASTHEAL = "zwave_lastheal";
+    public final static String PROPERTY_RF_REGION = "zwave_rf_region";
 
     public final static String CHANNEL_SERIAL_SOF = "serial_sof";
     public final static String CHANNEL_SERIAL_ACK = "serial_ack";

--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveControllerHandler.java
@@ -423,6 +423,14 @@ public abstract class ZWaveControllerHandler extends BaseBridgeHandler implement
     private void updateControllerProperties() {
         Configuration configuration = editConfiguration();
         configuration.put(ZWaveBindingConstants.CONFIGURATION_SISNODE, controller.getSucId());
+
+        String rfRegionName = controller.getRfRegionName();
+        if (rfRegionName != null) {
+            getThing().setProperty(ZWaveBindingConstants.PROPERTY_RF_REGION, rfRegionName);
+        } else {
+            getThing().setProperty(ZWaveBindingConstants.PROPERTY_RF_REGION, "unknown");
+        }
+
         try {
             // If the thing is defined statically, then this will fail and we will never start!
             updateConfiguration(configuration);

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialMessage.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialMessage.java
@@ -508,6 +508,7 @@ public class SerialMessage {
         SendData(0x13, true, true, true), // Send data.
         SendDataMulti(0x14, true, true, true),
         GetVersion(0x15, true, false, false), // Request controller hardware version
+        GetRfRegion(0x97, true, false, false), // Request the controller RF region.
         SendDataAbort(0x16, false, false, false), // Abort Send data.
         RfPowerLevelSet(0x17), // Set RF Power level
         SendDataMeta(0x18),

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -15,6 +15,7 @@ package org.openhab.binding.zwave.internal.protocol;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -26,11 +27,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
+import org.openhab.binding.zwave.internal.protocol.serialmessage.GetRfRegionMessageClass.ZWaveRegion;
 import org.openhab.binding.zwave.internal.protocol.ZWaveDeviceClass.Basic;
 import org.openhab.binding.zwave.internal.protocol.ZWaveTransaction.TransactionState;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiInstanceCommandClass;
-import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveNoOperationCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveSecurityCommandClass;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveInclusionEvent;
@@ -47,6 +48,7 @@ import org.openhab.binding.zwave.internal.protocol.serialmessage.ControllerSetDe
 import org.openhab.binding.zwave.internal.protocol.serialmessage.DeleteReturnRouteMessageClass;
 import org.openhab.binding.zwave.internal.protocol.serialmessage.GetControllerCapabilitiesMessageClass;
 import org.openhab.binding.zwave.internal.protocol.serialmessage.GetRoutingInfoMessageClass;
+import org.openhab.binding.zwave.internal.protocol.serialmessage.GetRfRegionMessageClass;
 import org.openhab.binding.zwave.internal.protocol.serialmessage.GetSucNodeIdMessageClass;
 import org.openhab.binding.zwave.internal.protocol.serialmessage.GetVersionMessageClass;
 import org.openhab.binding.zwave.internal.protocol.serialmessage.IdentifyNodeMessageClass;
@@ -92,6 +94,8 @@ public class ZWaveController {
     private String zwaveVersion = "Unknown";
     private String serialAPIVersion = "Unknown";
     private int homeId = 0;
+    private ZWaveRegion rfRegion = ZWaveRegion.UNKNOWN;
+    private Locale locale = Locale.getDefault();
     private int ownNodeId = 0;
     private int manufactureId = 0;
     private int deviceType = 0;
@@ -335,6 +339,27 @@ public class ZWaveController {
      */
     public int getHomeId() {
         return homeId;
+    }
+
+    public ZWaveRegion getRfRegion() {
+        return rfRegion;
+    }
+
+    public @Nullable String getRfRegionName() {
+        if (rfRegion != ZWaveRegion.UNKNOWN) {
+            return rfRegion.getLowerCaseName();
+        }
+
+        ZWaveRegion fallbackRegion = ZWaveRegion.fromLocale(locale);
+        return fallbackRegion == ZWaveRegion.UNKNOWN ? null : fallbackRegion.getLowerCaseName();
+    }
+
+    public void setRfRegion(ZWaveRegion region) {
+        this.rfRegion = region;
+    }
+
+    public void setLocale(Locale locale) {
+        this.locale = locale;
     }
 
     // Controller methods
@@ -646,6 +671,7 @@ public class ZWaveController {
         enqueue(new SerialApiGetCapabilitiesMessageClass().doRequest());
         enqueue(new SerialApiSetTimeoutsMessageClass().doRequest(150, 15));
         enqueue(new GetSucNodeIdMessageClass().doRequest());
+        enqueue(new GetRfRegionMessageClass().doRequest());
     }
 
     /**

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/GetRfRegionMessageClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/GetRfRegionMessageClass.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.zwave.internal.protocol.serialmessage;
+
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
+import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
+import org.openhab.binding.zwave.internal.protocol.ZWaveSerialPayload;
+import org.openhab.binding.zwave.internal.protocol.ZWaveTransaction;
+import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveTransactionMessageBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Requests the RF region from a Z-Wave controller.
+ * Only supported by 700 and 800 series Z-Wave controllers.
+ * 500 series controllers do not support this command (UNKNOWN region will be returned).
+ * 
+ * @author Bob Eckhoff - Initial contribution
+ */
+public class GetRfRegionMessageClass extends ZWaveCommandProcessor {
+    private final Logger logger = LoggerFactory.getLogger(GetRfRegionMessageClass.class);
+
+    public ZWaveSerialPayload doRequest() {
+        return new ZWaveTransactionMessageBuilder(SerialMessageClass.GetRfRegion).build();
+    }
+
+    @Override
+    public boolean handleResponse(ZWaveController zController, ZWaveTransaction transaction,
+            SerialMessage incomingMessage) throws ZWaveSerialMessageException {
+        if (incomingMessage.getMessagePayload().length == 0) {
+            logger.debug("RF region response was empty; leaving region unchanged");
+            transaction.setTransactionComplete();
+            return true;
+        }
+
+        int regionCode = incomingMessage.getMessagePayloadByte(0) & 0xFF;
+        ZWaveRegion region = ZWaveRegion.fromCode(regionCode);
+        zController.setRfRegion(region);
+        logger.debug("Got RF region response {} -> {}", regionCode, region);
+
+        transaction.setTransactionComplete();
+        return true;
+    }
+
+    /**
+     * Enumerates the RF regions reported by supported Z-Wave controllers.
+     */
+    public enum ZWaveRegion {
+        UNKNOWN(-1),
+        EU(0x00),
+        US(0x01),
+        ANZ(0x02),
+        HK(0x03),
+        IN(0x04),
+        IL(0x05),
+        RU(0x06),
+        CN(0x07),
+        JP(0x08),
+        KR(0x09),
+        TW(0x0A),
+        BR(0x0B);
+
+        private final int code;
+
+        ZWaveRegion(int code) {
+            this.code = code;
+        }
+
+        public int getCode() {
+            return code;
+        }
+
+        public @Nullable String getLowerCaseName() {
+            return switch (this) {
+                case EU -> "europe";
+                case US -> "usa";
+                case ANZ -> "australia/new zealand";
+                case HK -> "hong kong";
+                case IN -> "india";
+                case IL -> "israel";
+                case RU -> "russia";
+                case CN -> "china";
+                case JP -> "japan";
+                case KR -> "korea";
+                case TW -> "taiwan";
+                case BR -> "brazil";
+                case UNKNOWN -> null;
+                default -> name().toLowerCase();
+            };
+        }
+
+        public static ZWaveRegion fromCode(int code) {
+            for (ZWaveRegion region : values()) {
+                if (region.code == code) {
+                    return region;
+                }
+            }
+
+            return UNKNOWN;
+        }
+
+        public static ZWaveRegion fromLocale(Locale locale) {
+            String country = locale.getCountry();
+
+            if ("US".equals(country) || "CA".equals(country) || "MX".equals(country)) {
+                return US;
+            }
+
+            if ("AU".equals(country) || "NZ".equals(country)) {
+                return ANZ;
+            }
+
+            if ("AT".equals(country) || "BE".equals(country) || "BG".equals(country) || "HR".equals(country)
+                    || "CY".equals(country) || "CZ".equals(country) || "DK".equals(country)
+                    || "EE".equals(country) || "FI".equals(country) || "FR".equals(country)
+                    || "DE".equals(country) || "GR".equals(country) || "HU".equals(country)
+                    || "IE".equals(country) || "IT".equals(country) || "LV".equals(country)
+                    || "LT".equals(country) || "LU".equals(country) || "MT".equals(country)
+                    || "NL".equals(country) || "PL".equals(country) || "PT".equals(country)
+                    || "RO".equals(country) || "SK".equals(country) || "SI".equals(country)
+                    || "ES".equals(country) || "SE".equals(country) || "GB".equals(country)) {
+                return EU;
+            }
+
+            return UNKNOWN;
+        }
+    }
+}

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ZWaveCommandProcessor.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ZWaveCommandProcessor.java
@@ -112,6 +112,7 @@ public abstract class ZWaveCommandProcessor {
                     DeleteSucReturnRouteMessageClass.class);
             messageMap.put(SerialMessage.SerialMessageClass.GetRoutingInfo, GetRoutingInfoMessageClass.class);
             messageMap.put(SerialMessage.SerialMessageClass.GetVersion, GetVersionMessageClass.class);
+            messageMap.put(SerialMessage.SerialMessageClass.GetRfRegion, GetRfRegionMessageClass.class);
             messageMap.put(SerialMessage.SerialMessageClass.GetSucNodeId, GetSucNodeIdMessageClass.class);
             messageMap.put(SerialMessage.SerialMessageClass.GetControllerCapabilities,
                     GetControllerCapabilitiesMessageClass.class);

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/ZWaveRegionTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/ZWaveRegionTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.zwave.internal.protocol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.zwave.internal.protocol.serialmessage.GetRfRegionMessageClass.ZWaveRegion;
+
+/**
+ * Test for {@link ZWaveRegion}
+ *
+ * @author Bob Eckhoff - Initial contribution
+ *
+ */
+@NonNullByDefault
+public class ZWaveRegionTest {
+    @Test
+    public void mapsKnownCodes() {
+        assertEquals(ZWaveRegion.EU, ZWaveRegion.fromCode(0x00));
+        assertEquals(ZWaveRegion.US, ZWaveRegion.fromCode(0x01));
+        assertEquals(ZWaveRegion.ANZ, ZWaveRegion.fromCode(0x02));
+        assertEquals(ZWaveRegion.BR, ZWaveRegion.fromCode(0x0B));
+    }
+
+    @Test
+    public void exposesLowerCaseRepositoryValues() {
+        assertEquals("europe", ZWaveRegion.EU.getLowerCaseName());
+        assertEquals("usa", ZWaveRegion.US.getLowerCaseName());
+        assertEquals("australia/new zealand", ZWaveRegion.ANZ.getLowerCaseName());
+        assertEquals("hong kong", ZWaveRegion.HK.getLowerCaseName());
+    }
+
+    @Test
+    public void fallsBackToUnknownForUnsupportedCodes() {
+        assertEquals(ZWaveRegion.UNKNOWN, ZWaveRegion.fromCode(0x7F));
+    }
+
+    @Test
+    public void doesNotExposeRepositoryNameForUnknownRegion() {
+        assertEquals(null, ZWaveRegion.UNKNOWN.getLowerCaseName());
+    }
+
+    @Test
+    public void derivesKnownRegionsFromUnambiguousLocale() {
+        assertEquals(ZWaveRegion.US, ZWaveRegion.fromLocale(Locale.US));
+        assertEquals(ZWaveRegion.US, ZWaveRegion.fromLocale(Locale.CANADA));
+        assertEquals(ZWaveRegion.US, ZWaveRegion.fromLocale(Locale.forLanguageTag("es-MX")));
+        assertEquals(ZWaveRegion.ANZ, ZWaveRegion.fromLocale(Locale.forLanguageTag("en-AU")));
+        assertEquals(ZWaveRegion.ANZ, ZWaveRegion.fromLocale(Locale.forLanguageTag("en-NZ")));
+        assertEquals(ZWaveRegion.EU, ZWaveRegion.fromLocale(Locale.GERMANY));
+        assertEquals(ZWaveRegion.EU, ZWaveRegion.fromLocale(Locale.UK));
+    }
+
+    @Test
+    public void leavesAmbiguousOrUnsupportedLocalesUnknown() {
+        assertEquals(ZWaveRegion.UNKNOWN, ZWaveRegion.fromLocale(Locale.ENGLISH));
+        assertEquals(ZWaveRegion.UNKNOWN, ZWaveRegion.fromLocale(Locale.JAPAN));
+    }
+}


### PR DESCRIPTION
Adds support for the Serial API `GetRfRegion` command and wires it into controller initialization and command processing. The controller now stores/report RF region information, including locale-based fallback mapping when the controller reports unknown, and exposes it via the new `zwave_rf_region` thing property. Includes unit tests for region code mapping, display names, locale fallback behavior, and unknown handling.

This is required to use the zwave-js firmware repository since some vendors use the region. The one issue is that 500 controllers do not report RF Region, so there is a locale-based backup for the main regions. If no region is sent the firmware returned will only be ones applicable to all regions.