### PR TITLE
Add Supervision CC handling for binary switch commands

### DIFF
--- a/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -1288,20 +1288,23 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
         }
 
         // Send all the messages
+        boolean supervisionUsed = false;
         for (ZWaveCommandClassTransactionPayload message : messages) {
+            supervisionUsed |= message.isSupervisionEncapsulated();
             controllerHandler.sendData(message);
         }
 
         // Restart the polling so we get an update on the channel shortly after this command is sent
-        if (commandPollDelay != 0) {
+        if (commandPollDelay != 0 && !supervisionUsed) {
             startPolling(commandPollDelay);
+        } else if (supervisionUsed) {
+            logger.debug("NODE {}: Command poll skipped because COMMAND_CLASS_SUPERVISION is in use", nodeId);
         }
     }
 
     @Nullable
     Command convertCommandToDataType(ChannelUID channelUID, DataType channelDataType, Command command,
             DataType dataType) {
-
         if (!(command instanceof State)) {
             logger.debug("NODE {}: Received commands datatype {} doesn't support conversion", nodeId, dataType);
             return null;
@@ -1895,7 +1898,6 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
 
     private boolean updateConfigurationParameter(Configuration configuration, int paramIndex, int paramSize,
             int paramValue) {
-
         boolean cfgUpdated = false;
 
         for (String key : configuration.keySet()) {
@@ -2018,8 +2020,7 @@ public class ZWaveThingHandler extends ConfigStatusThingHandler implements ZWave
     /**
      * Return an ISO 8601 combined date and time string for specified date/time
      *
-     * @param date
-     *            Date
+     * @param date Date
      * @return String with format "yyyy-MM-dd'T'HH:mm:ss'Z'"
      */
     private static String getISO8601StringForDate(Date date) {

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jdt.annotation.Nullable;
@@ -40,6 +41,7 @@ import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveSupervision
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveVersionCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveWakeUpCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.impl.CommandClassSecurityV1;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveDelayedPollEvent;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveNodeStatusEvent;
 import org.openhab.binding.zwave.internal.protocol.initialization.ZWaveNodeInitStage;
@@ -61,6 +63,11 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
  */
 @XStreamAlias("node")
 public class ZWaveNode {
+
+    private static final long SUPERVISION_PENDING_TIMEOUT_MS = 60_000;
+    private static final long SUPERVISION_WORKING_EXTENSION_MARGIN_MS = 5_000;
+    private static final long SUPERVISION_PENDING_MAX_LIFETIME_MS = 10 * 60_000;
+    private static final int SUPERVISION_PENDING_MAX_ENTRIES = 63;
 
     @XStreamOmitField
     private static final Logger logger = LoggerFactory.getLogger(ZWaveNode.class);
@@ -149,10 +156,14 @@ public class ZWaveNode {
     private static class PendingSupervisionCommand {
         private final ZWaveCommandClassPayload payload;
         private final int endpointId;
+        private final long createdAtMillis;
+        private long expiresAtMillis;
 
         private PendingSupervisionCommand(ZWaveCommandClassPayload payload, int endpointId) {
             this.payload = payload;
             this.endpointId = endpointId;
+            this.createdAtMillis = System.currentTimeMillis();
+            this.expiresAtMillis = this.createdAtMillis + SUPERVISION_PENDING_TIMEOUT_MS;
         }
     }
 
@@ -1150,6 +1161,7 @@ public class ZWaveNode {
     public ZWaveCommandClassTransactionPayload encapsulate(ZWaveCommandClassTransactionPayload transaction,
             int endpointId) {
         initializeSupervisionRuntimeState();
+        cleanupPendingSupervisionCommands();
 
         ZWaveMultiInstanceCommandClass multiInstanceCommandClass;
         logger.trace("NODE {}: Encapsulating message, endpoint {}", getNodeId(), endpointId);
@@ -1483,8 +1495,14 @@ public class ZWaveNode {
         return commandClass == CommandClass.COMMAND_CLASS_SWITCH_BINARY;
     }
 
-    public void handleSupervisionReport(int sessionId, int status, boolean moreUpdatesFollow, int endpoint) {
+    public void handleSupervisionReport(int sessionId, int status, int duration, boolean moreUpdatesFollow,
+            int endpoint) {
         initializeSupervisionRuntimeState();
+        cleanupPendingSupervisionCommands();
+
+        if (status == ZWaveSupervisionCommandClass.SUPERVISION_STATUS_WORKING) {
+            extendPendingSupervisionExpiry(sessionId, duration);
+        }
 
         if (moreUpdatesFollow || status == ZWaveSupervisionCommandClass.SUPERVISION_STATUS_WORKING) {
             return;
@@ -1499,6 +1517,12 @@ public class ZWaveNode {
         if (status != ZWaveSupervisionCommandClass.SUPERVISION_STATUS_SUCCESS) {
             logger.debug("NODE {}: Supervision session {} completed with non-success status 0x{}", getNodeId(),
                     sessionId, Integer.toHexString(status));
+
+            // For terminal non-success statuses we trigger a delayed poll so the UI/state can converge.
+            if (controller != null) {
+                controller.notifyEventListeners(new ZWaveDelayedPollEvent(getNodeId(), pending.endpointId, 125,
+                        TimeUnit.MILLISECONDS));
+            }
             return;
         }
 
@@ -1535,6 +1559,75 @@ public class ZWaveNode {
         if (supervisionSessionId < 1 || supervisionSessionId > 0x3F) {
             supervisionSessionId = 1;
         }
+    }
+
+    private void cleanupPendingSupervisionCommands() {
+        if (pendingSupervisionCommands == null || pendingSupervisionCommands.isEmpty()) {
+            return;
+        }
+
+        long now = System.currentTimeMillis();
+
+        // Drop timed-out pending entries to prevent stale session replays.
+        pendingSupervisionCommands.entrySet().removeIf(entry -> now > entry.getValue().expiresAtMillis);
+
+        if (pendingSupervisionCommands.size() <= SUPERVISION_PENDING_MAX_ENTRIES) {
+            return;
+        }
+
+        // Safety guard: evict oldest entries if the map still grows beyond expected bounds.
+        while (pendingSupervisionCommands.size() > SUPERVISION_PENDING_MAX_ENTRIES) {
+            Integer oldestSessionId = null;
+            long oldestTimestamp = Long.MAX_VALUE;
+
+            for (Map.Entry<Integer, PendingSupervisionCommand> entry : pendingSupervisionCommands.entrySet()) {
+                if (entry.getValue().createdAtMillis < oldestTimestamp) {
+                    oldestTimestamp = entry.getValue().createdAtMillis;
+                    oldestSessionId = entry.getKey();
+                }
+            }
+
+            if (oldestSessionId == null) {
+                break;
+            }
+            pendingSupervisionCommands.remove(oldestSessionId);
+        }
+    }
+
+    private void extendPendingSupervisionExpiry(int sessionId, int duration) {
+        PendingSupervisionCommand pending = pendingSupervisionCommands.get(sessionId);
+        if (pending == null) {
+            return;
+        }
+
+        long now = System.currentTimeMillis();
+        long durationMillis = supervisionDurationToMillis(duration);
+
+        if (durationMillis <= 0) {
+            return;
+        }
+
+        long requestedExpiry = now + durationMillis + SUPERVISION_WORKING_EXTENSION_MARGIN_MS;
+        long maxAllowedExpiry = pending.createdAtMillis + SUPERVISION_PENDING_MAX_LIFETIME_MS;
+        long newExpiry = Math.min(requestedExpiry, maxAllowedExpiry);
+
+        if (newExpiry > pending.expiresAtMillis) {
+            pending.expiresAtMillis = newExpiry;
+        }
+    }
+
+    private long supervisionDurationToMillis(int duration) {
+        if (duration >= 0x00 && duration <= 0x7F) {
+            return duration * 1_000L;
+        }
+
+        if (duration >= 0x80 && duration <= 0xFD) {
+            int minutes = duration - 0x7F;
+            return minutes * 60_000L;
+        }
+
+        // 0xFE = unknown duration, 0xFF = reserved. Keep default timeout in those cases.
+        return 0;
     }
 
     public void sendMessage(ZWaveCommandClassTransactionPayload payload) {

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -36,6 +36,7 @@ import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiComman
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiInstanceCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveNoOperationCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveSecurityCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveSupervisionCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveVersionCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveWakeUpCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.impl.CommandClassSecurityV1;
@@ -54,8 +55,9 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
 /**
  * Z-Wave node class. Represents a node in the Z-Wave network.
  *
- * @author Chris Jackson
- * @author Brian Crosby
+ * @author Chris Jackson - Initial contribution
+ * @author Brian Crosby - Contribution
+ * @author Robert Eckhoff - Added Supervision support and other improvements
  */
 @XStreamAlias("node")
 public class ZWaveNode {
@@ -136,7 +138,23 @@ public class ZWaveNode {
     private int retryCount = 0;
 
     @XStreamOmitField
+    private int supervisionSessionId = 1;
+
+    @XStreamOmitField
+    private Map<Integer, PendingSupervisionCommand> pendingSupervisionCommands;
+
+    @XStreamOmitField
     Long inclusionTimer = null;
+
+    private static class PendingSupervisionCommand {
+        private final ZWaveCommandClassPayload payload;
+        private final int endpointId;
+
+        private PendingSupervisionCommand(ZWaveCommandClassPayload payload, int endpointId) {
+            this.payload = payload;
+            this.endpointId = endpointId;
+        }
+    }
 
     /**
      * Constructor. Creates a new instance of the ZWaveNode class.
@@ -154,6 +172,8 @@ public class ZWaveNode {
 
         ZWaveEndpoint endpoint0 = new ZWaveEndpoint(0);
         endpoints.put(0, endpoint0);
+
+        initializeSupervisionRuntimeState();
     }
 
     /**
@@ -182,6 +202,8 @@ public class ZWaveNode {
         // Create the initialisation advancer and tell it we've loaded from file
         nodeInitStageAdvancer = new ZWaveNodeInitStageAdvancer(this, controller);
         nodeInitStageAdvancer.setRestoredFromConfigfile();
+
+        initializeSupervisionRuntimeState();
     }
 
     /**
@@ -1127,6 +1149,8 @@ public class ZWaveNode {
      */
     public ZWaveCommandClassTransactionPayload encapsulate(ZWaveCommandClassTransactionPayload transaction,
             int endpointId) {
+        initializeSupervisionRuntimeState();
+
         ZWaveMultiInstanceCommandClass multiInstanceCommandClass;
         logger.trace("NODE {}: Encapsulating message, endpoint {}", getNodeId(), endpointId);
 
@@ -1138,7 +1162,31 @@ public class ZWaveNode {
 
         // Encapsulation the COMMAND_CLASS_MULTI_CMD class
 
+        boolean supervisionEncapsulated = false;
+
         // Encapsulation the COMMAND_CLASS_SUPERVISION class
+        if (shouldUseSupervisionEncapsulation(transaction)) {
+            ZWaveSupervisionCommandClass supervisionCommandClass = (ZWaveSupervisionCommandClass) getOrAddCommandClass(
+                    endpoints.get(0), CommandClass.COMMAND_CLASS_SUPERVISION);
+
+            if (supervisionCommandClass == null) {
+                logger.debug("NODE {}: Failed to initialize COMMAND_CLASS_SUPERVISION encapsulation", getNodeId());
+                return null;
+            }
+
+            int sessionId = getNextSupervisionSessionId();
+            ZWaveCommandClassPayload supervisedCommand = new ZWaveCommandClassPayload(transaction.getPayloadBuffer());
+            logger.debug("NODE {}: Encapsulating message with COMMAND_CLASS_SUPERVISION (session={})", getNodeId(),
+                    sessionId);
+            transaction = supervisionCommandClass.getSupervisionGetEncapMessage(transaction, sessionId, true);
+            if (transaction == null) {
+                logger.debug("NODE {}: Failed to encapsulate supervision message", getNodeId());
+                return null;
+            }
+
+            pendingSupervisionCommands.put(sessionId, new PendingSupervisionCommand(supervisedCommand, endpointId));
+            supervisionEncapsulated = true;
+        }
 
         // Encapsulation the COMMAND_CLASS_MULTI_CHANNEL class
         if (endpointId != 0) {
@@ -1174,6 +1222,8 @@ public class ZWaveNode {
                     CommandClass.getCommandClass(transaction.getCommandClassId()));
             // Encapsulation the COMMAND_CLASS_CRC16 class if we don't utilise security
         }
+
+        transaction.setSupervisionEncapsulated(supervisionEncapsulated);
 
         return transaction;
     }
@@ -1316,6 +1366,23 @@ public class ZWaveNode {
 
         if (payload.getCommandClassId() == CommandClass.COMMAND_CLASS_SUPERVISION.getKey()) {
             logger.debug("NODE {}: Decapsulating COMMAND_CLASS_SUPERVISION", getNodeId());
+
+            if (payload.getCommandClassCommand() == ZWaveSupervisionCommandClass.SUPERVISION_GET) {
+                if (payload.getPayloadLength() < 4) {
+                    logger.debug("NODE {}: COMMAND_CLASS_SUPERVISION corrupted payload {}", getNodeId(),
+                            SerialMessage.bb2hex(payload.getPayloadBuffer()));
+                    return null;
+                }
+
+                int encapsulatedLength = payload.getPayloadByte(3);
+                if (payload.getPayloadLength() < 4 + encapsulatedLength) {
+                    logger.debug("NODE {}: COMMAND_CLASS_SUPERVISION invalid encapsulated length {} in payload {}",
+                            getNodeId(), encapsulatedLength, SerialMessage.bb2hex(payload.getPayloadBuffer()));
+                    return null;
+                }
+
+                payload = new ZWaveCommandClassPayload(payload, 4, 4 + encapsulatedLength);
+            }
         }
 
         List<ZWaveCommandClassPayload> commands = new ArrayList<ZWaveCommandClassPayload>();
@@ -1385,6 +1452,89 @@ public class ZWaveNode {
 
         // Return the list of commands we've processed
         return commands;
+    }
+
+    private synchronized int getNextSupervisionSessionId() {
+        int sessionId = supervisionSessionId;
+        supervisionSessionId++;
+        if (supervisionSessionId > 0x3F) {
+            supervisionSessionId = 1;
+        }
+
+        return sessionId;
+    }
+
+    private boolean shouldUseSupervisionEncapsulation(ZWaveCommandClassTransactionPayload transaction) {
+        if (!supportsCommandClass(CommandClass.COMMAND_CLASS_SUPERVISION)) {
+            return false;
+        }
+
+        if (transaction.getExpectedResponseCommandClass() != null) {
+            return false;
+        }
+
+        CommandClass commandClass = CommandClass.getCommandClass(transaction.getCommandClassId());
+        if (commandClass == null) {
+            return false;
+        }
+
+        // Keep supervision scope intentionally narrow for now.
+        // Only Binary Switch Set should be supervised until additional CCs are explicitly enabled.
+        return commandClass == CommandClass.COMMAND_CLASS_SWITCH_BINARY;
+    }
+
+    public void handleSupervisionReport(int sessionId, int status, boolean moreUpdatesFollow, int endpoint) {
+        initializeSupervisionRuntimeState();
+
+        if (moreUpdatesFollow || status == ZWaveSupervisionCommandClass.SUPERVISION_STATUS_WORKING) {
+            return;
+        }
+
+        PendingSupervisionCommand pending = pendingSupervisionCommands.remove(sessionId);
+        if (pending == null) {
+            logger.debug("NODE {}: Supervision report for unknown session {}", getNodeId(), sessionId);
+            return;
+        }
+
+        if (status != ZWaveSupervisionCommandClass.SUPERVISION_STATUS_SUCCESS) {
+            logger.debug("NODE {}: Supervision session {} completed with non-success status 0x{}", getNodeId(),
+                    sessionId, Integer.toHexString(status));
+            return;
+        }
+
+        ZWaveEndpoint targetEndpoint = getEndpoint(pending.endpointId);
+        if (targetEndpoint == null) {
+            logger.debug("NODE {}: Endpoint {} not found for supervised command replay", getNodeId(),
+                    pending.endpointId);
+            return;
+        }
+
+        CommandClass commandClass = CommandClass.getCommandClass(pending.payload.getCommandClassId());
+        if (commandClass == null) {
+            logger.debug("NODE {}: Unknown supervised command class 0x{}", getNodeId(),
+                    Integer.toHexString(pending.payload.getCommandClassId()));
+            return;
+        }
+
+        ZWaveCommandClass zwaveCommandClass = getOrAddCommandClass(targetEndpoint, commandClass);
+        if (zwaveCommandClass == null) {
+            return;
+        }
+
+        try {
+            zwaveCommandClass.handleApplicationCommandRequest(pending.payload, pending.endpointId);
+        } catch (ZWaveSerialMessageException e) {
+            logger.error("Exception processing supervised command replay", e);
+        }
+    }
+
+    private void initializeSupervisionRuntimeState() {
+        if (pendingSupervisionCommands == null) {
+            pendingSupervisionCommands = new ConcurrentHashMap<Integer, PendingSupervisionCommand>();
+        }
+        if (supervisionSessionId < 1 || supervisionSessionId > 0x3F) {
+            supervisionSessionId = 1;
+        }
     }
 
     public void sendMessage(ZWaveCommandClassTransactionPayload payload) {

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
@@ -537,7 +537,7 @@ public abstract class ZWaveCommandClass {
         COMMAND_CLASS_MAILBOX(0x69, null),
         COMMAND_CLASS_WINDOW_COVERING(0x6A, null),
         COMMAND_CLASS_IRRIGATION(0x6B, null),
-        COMMAND_CLASS_SUPERVISION(0x6C, null),
+        COMMAND_CLASS_SUPERVISION(0x6C, ZWaveSupervisionCommandClass.class),
         COMMAND_CLASS_HUMIDITY_CONTROL_MODE(0x6D, null),
         COMMAND_CLASS_HUMIDITY_CONTROL_OPERATING_STATE(0x6E, null),
         COMMAND_CLASS_ENTRY_CONTROL(0x6F, null),

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSupervisionCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSupervisionCommandClass.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.zwave.internal.protocol.commandclass;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.openhab.binding.zwave.internal.protocol.ZWaveCommandClassPayload;
+import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
+import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.ZWaveSerialMessageException;
+import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
+
+/**
+ * Handles the Supervision command class.
+ *
+ * @author Robert Eckhoff - Initial contribution
+ */
+@XStreamAlias("COMMAND_CLASS_SUPERVISION")
+public class ZWaveSupervisionCommandClass extends ZWaveCommandClass {
+
+    @XStreamOmitField
+    private static final Logger logger = LoggerFactory.getLogger(ZWaveSupervisionCommandClass.class);
+
+    public static final int SUPERVISION_GET = 0x01;
+    public static final int SUPERVISION_REPORT = 0x02;
+    public static final int SUPERVISION_STATUS_NO_SUPPORT = 0x00;
+    public static final int SUPERVISION_STATUS_WORKING = 0x01;
+    public static final int SUPERVISION_STATUS_FAIL = 0x02;
+    public static final int SUPERVISION_STATUS_SUCCESS = 0xFF;
+
+    private static final int REQUEST_UPDATES_BIT = 0x80;
+    private static final int MORE_UPDATES_FOLLOW_BIT = 0x40;
+
+    public ZWaveSupervisionCommandClass(ZWaveNode node, ZWaveController controller, ZWaveEndpoint endpoint) {
+        super(node, controller, endpoint);
+        this.versionMax = 2;
+    }
+
+    @Override
+    public CommandClass getCommandClass() {
+        return CommandClass.COMMAND_CLASS_SUPERVISION;
+    }
+
+    public ZWaveCommandClassTransactionPayload getSupervisionGetEncapMessage(
+            ZWaveCommandClassTransactionPayload transactionPayload, int sessionId, boolean requestStatusUpdates) {
+        ByteArrayOutputStream newPayload = new ByteArrayOutputStream();
+        newPayload.write(getCommandClass().getKey());
+        newPayload.write(SUPERVISION_GET);
+        newPayload.write((requestStatusUpdates ? REQUEST_UPDATES_BIT : 0) | (sessionId & 0x3F));
+        newPayload.write(transactionPayload.getPayloadLength());
+
+        try {
+            newPayload.write(transactionPayload.getPayloadBuffer());
+            ZWaveCommandClassTransactionPayload supervisionTransaction = new ZWaveCommandClassTransactionPayload(
+                    transactionPayload.getNodeId(), newPayload.toByteArray(), transactionPayload.getPriority(),
+                    CommandClass.COMMAND_CLASS_SUPERVISION, SUPERVISION_REPORT);
+
+            supervisionTransaction.setRequiresResponse(transactionPayload.getRequiresResponse());
+            supervisionTransaction.setMaxAttempts(transactionPayload.getMaxAttempts());
+            if (transactionPayload.getRequiresSecurity()) {
+                supervisionTransaction.setRequiresSecurity();
+            }
+
+            return supervisionTransaction;
+        } catch (IOException e) {
+            logger.debug("NODE {}: Error encapsulating supervision message", getNode().getNodeId(), e);
+        }
+
+        return null;
+    }
+
+    @ZWaveResponseHandler(id = SUPERVISION_REPORT, name = "SUPERVISION_REPORT")
+    public void handleSupervisionReport(ZWaveCommandClassPayload payload, int endpoint)
+            throws ZWaveSerialMessageException {
+        if (payload.getPayloadLength() < 4) {
+            logger.debug("NODE {}: Supervision report payload too short", getNode().getNodeId());
+            return;
+        }
+
+        int properties = payload.getPayloadByte(2);
+        boolean moreUpdatesFollow = (properties & MORE_UPDATES_FOLLOW_BIT) != 0;
+        int sessionId = properties & 0x3F;
+        int status = payload.getPayloadByte(3);
+        int duration = payload.getPayloadLength() > 4 ? payload.getPayloadByte(4) : 0;
+
+        logger.debug(
+                "NODE {}: Supervision report endpoint={}, session={}, status=0x{}, moreUpdatesFollow={}, duration={}",
+                getNode().getNodeId(), endpoint, sessionId, Integer.toHexString(status), moreUpdatesFollow, duration);
+
+        getNode().handleSupervisionReport(sessionId, status, moreUpdatesFollow, endpoint);
+    }
+}

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSupervisionCommandClass.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSupervisionCommandClass.java
@@ -104,6 +104,6 @@ public class ZWaveSupervisionCommandClass extends ZWaveCommandClass {
                 "NODE {}: Supervision report endpoint={}, session={}, status=0x{}, moreUpdatesFollow={}, duration={}",
                 getNode().getNodeId(), endpoint, sessionId, Integer.toHexString(status), moreUpdatesFollow, duration);
 
-        getNode().handleSupervisionReport(sessionId, status, moreUpdatesFollow, endpoint);
+        getNode().handleSupervisionReport(sessionId, status, duration, moreUpdatesFollow, endpoint);
     }
 }

--- a/src/main/java/org/openhab/binding/zwave/internal/protocol/transaction/ZWaveCommandClassTransactionPayload.java
+++ b/src/main/java/org/openhab/binding/zwave/internal/protocol/transaction/ZWaveCommandClassTransactionPayload.java
@@ -35,6 +35,7 @@ public class ZWaveCommandClassTransactionPayload extends ZWaveCommandClassPayloa
 
     private boolean requiresSecurity = false;
     private boolean requiresResponse = true;
+    private boolean supervisionEncapsulated = false;
 
     /**
      *
@@ -156,5 +157,13 @@ public class ZWaveCommandClassTransactionPayload extends ZWaveCommandClassPayloa
 
     public boolean getRequiresResponse() {
         return requiresResponse;
+    }
+
+    public void setSupervisionEncapsulated(boolean supervisionEncapsulated) {
+        this.supervisionEncapsulated = supervisionEncapsulated;
+    }
+
+    public boolean isSupervisionEncapsulated() {
+        return supervisionEncapsulated;
     }
 }

--- a/src/test/java/org/openhab/binding/zwave/handler/ZWaveThingHandlerTest.java
+++ b/src/test/java/org/openhab/binding/zwave/handler/ZWaveThingHandlerTest.java
@@ -22,12 +22,14 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.openhab.binding.zwave.ZWaveBindingConstants;
+import org.openhab.binding.zwave.internal.converter.ZWaveCommandClassConverter;
 import org.openhab.binding.zwave.internal.protocol.ZWaveAssociationGroup;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
@@ -41,6 +43,7 @@ import org.openhab.core.config.core.status.ConfigStatusMessage;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StopMoveType;
+import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingUID;
@@ -315,5 +318,61 @@ public class ZWaveThingHandlerTest {
         assertEquals("val3", properties.get("arg3"));
         assertTrue(properties.containsKey("arg4"));
         assertNull(properties.get("arg4"));
+    }
+
+    @Test
+    public void testHandleCommandSkipsPollWhenSupervisionEncapsulationIsUsed() {
+        ThingType thingType = ThingTypeBuilder.instance("bindingId", "thingTypeId", "label").build();
+        Thing thing = ThingBuilder.create(thingType.getUID(), new ThingUID(thingType.getUID(), "thingId"))
+                .withConfiguration(new Configuration()).build();
+        ZWaveThingHandler sut = new ZWaveThingHandlerForTest(thing);
+
+        ZWaveControllerHandler controllerHandler = Mockito.mock(ZWaveControllerHandler.class);
+        ZWaveNode node = Mockito.mock(ZWaveNode.class);
+        ZWaveThingChannel channel = Mockito.mock(ZWaveThingChannel.class);
+        ZWaveCommandClassConverter converter = Mockito.mock(ZWaveCommandClassConverter.class);
+        ScheduledExecutorService scheduler = Mockito.mock(ScheduledExecutorService.class);
+
+        ChannelUID channelUID = new ChannelUID("zwave:device:controller:node5:switch_binary");
+        Mockito.when(channel.getUID()).thenReturn(channelUID);
+        Mockito.when(channel.getDataType()).thenReturn(ZWaveThingChannel.DataType.OnOffType);
+        Mockito.when(channel.getConverter()).thenReturn(converter);
+
+        ZWaveCommandClassTransactionPayload supervisedMessage = new ZWaveCommandClassTransactionPayload(5,
+                new byte[] { 0x25, 0x01, (byte) 0xFF }, null, null, null);
+        supervisedMessage.setSupervisionEncapsulated(true);
+        Mockito.when(converter.receiveCommand(ArgumentMatchers.any(), ArgumentMatchers.eq(node),
+                ArgumentMatchers.eq(OnOffType.ON))).thenReturn(List.of(supervisedMessage));
+
+        Mockito.when(controllerHandler.getNode(5)).thenReturn(node);
+
+        setFieldInHierarchy(sut, "controllerHandler", controllerHandler);
+        setFieldInHierarchy(sut, "nodeId", 5);
+        setFieldInHierarchy(sut, "thingChannelsCmd", List.of(channel));
+        setFieldInHierarchy(sut, "commandPollDelay", 1500L);
+        setFieldInHierarchy(sut, "scheduler", scheduler);
+
+        sut.handleCommand(channelUID, OnOffType.ON);
+
+        Mockito.verify(controllerHandler).sendData(supervisedMessage);
+        Mockito.verifyNoInteractions(scheduler);
+    }
+
+    private void setFieldInHierarchy(Object target, String fieldName, Object value) {
+        Class<?> current = target.getClass();
+        while (current != null) {
+            try {
+                Field field = current.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (NoSuchFieldException e) {
+                current = current.getSuperclass();
+            } catch (IllegalAccessException e) {
+                fail("Unable to set field " + fieldName);
+            }
+        }
+
+        fail("Field not found: " + fieldName);
     }
 }

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/ZWaveNodeTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/ZWaveNodeTest.java
@@ -18,9 +18,16 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAssociationCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveBinarySwitchCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiAssociationCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiInstanceCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveSupervisionCommandClass;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
 import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
 
 /**
@@ -88,5 +95,69 @@ public class ZWaveNodeTest {
         List<ZWaveCommandClassPayload> response = processCommand(new byte[] { 0x60, 0x0D, 0x01 });
 
         assertNull(response);
+    }
+
+    @Test
+    public void testSupervisionSuccessReplaysSwitchSetAsValueEvent() {
+        ZWaveController controller = Mockito.mock(ZWaveController.class);
+        ZWaveNode node = new ZWaveNode(1, 2, controller);
+
+        ArgumentCaptor<ZWaveEvent> eventCaptor = ArgumentCaptor.forClass(ZWaveEvent.class);
+        Mockito.doNothing().when(controller).notifyEventListeners(eventCaptor.capture());
+
+        ZWaveBinarySwitchCommandClass switchClass = new ZWaveBinarySwitchCommandClass(node, controller, null);
+        ZWaveSupervisionCommandClass supervisionClass = new ZWaveSupervisionCommandClass(node, controller, null);
+        node.addCommandClass(switchClass);
+        node.addCommandClass(supervisionClass);
+
+        ZWaveCommandClassTransactionPayload setTransaction = switchClass.setValueMessage(0xFF);
+        ZWaveCommandClassTransactionPayload supervisedTransaction = node.encapsulate(setTransaction, 0);
+        assertNotNull(supervisedTransaction);
+
+        int sessionId = supervisedTransaction.getPayloadByte(2) & 0x3F;
+        byte[] supervisionSuccess = new byte[] { 0x6C, 0x02, (byte) (sessionId & 0x3F), (byte) 0xFF, 0x00 };
+
+        List<ZWaveCommandClassPayload> response = node.processCommand(new ZWaveCommandClassPayload(supervisionSuccess));
+        assertNotNull(response);
+
+        List<ZWaveEvent> events = eventCaptor.getAllValues();
+        assertEquals(1, events.size());
+        assertTrue(events.get(0) instanceof ZWaveCommandClassValueEvent);
+
+        ZWaveCommandClassValueEvent valueEvent = (ZWaveCommandClassValueEvent) events.get(0);
+        assertEquals(CommandClass.COMMAND_CLASS_SWITCH_BINARY, valueEvent.getCommandClass());
+        assertEquals(0xFF, valueEvent.getValue());
+    }
+
+    @Test
+    public void testSupervisionWorkingAndMoreUpdatesDoNotReplaySwitchSet() {
+        ZWaveController controller = Mockito.mock(ZWaveController.class);
+        ZWaveNode node = new ZWaveNode(1, 2, controller);
+
+        ArgumentCaptor<ZWaveEvent> eventCaptor = ArgumentCaptor.forClass(ZWaveEvent.class);
+        Mockito.doNothing().when(controller).notifyEventListeners(eventCaptor.capture());
+
+        ZWaveBinarySwitchCommandClass switchClass = new ZWaveBinarySwitchCommandClass(node, controller, null);
+        ZWaveSupervisionCommandClass supervisionClass = new ZWaveSupervisionCommandClass(node, controller, null);
+        node.addCommandClass(switchClass);
+        node.addCommandClass(supervisionClass);
+
+        ZWaveCommandClassTransactionPayload setTransaction = switchClass.setValueMessage(0xFF);
+        ZWaveCommandClassTransactionPayload supervisedTransaction = node.encapsulate(setTransaction, 0);
+        assertNotNull(supervisedTransaction);
+
+        int sessionId = supervisedTransaction.getPayloadByte(2) & 0x3F;
+
+        byte[] supervisionWorking = new byte[] { 0x6C, 0x02, (byte) (sessionId & 0x3F), 0x01, 0x00 };
+        List<ZWaveCommandClassPayload> responseWorking = node.processCommand(new ZWaveCommandClassPayload(supervisionWorking));
+        assertNotNull(responseWorking);
+        assertTrue(eventCaptor.getAllValues().isEmpty());
+
+        byte[] supervisionMoreUpdates = new byte[] { 0x6C, 0x02, (byte) (0x40 | (sessionId & 0x3F)), (byte) 0xFF,
+                0x00 };
+        List<ZWaveCommandClassPayload> responseMoreUpdates = node
+                .processCommand(new ZWaveCommandClassPayload(supervisionMoreUpdates));
+        assertNotNull(responseMoreUpdates);
+        assertTrue(eventCaptor.getAllValues().isEmpty());
     }
 }

--- a/src/test/java/org/openhab/binding/zwave/internal/protocol/ZWaveNodeTest.java
+++ b/src/test/java/org/openhab/binding/zwave/internal/protocol/ZWaveNodeTest.java
@@ -14,8 +14,10 @@ package org.openhab.binding.zwave.internal.protocol;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -27,6 +29,7 @@ import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiAssoci
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiInstanceCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveSupervisionCommandClass;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveDelayedPollEvent;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
 import org.openhab.binding.zwave.internal.protocol.transaction.ZWaveCommandClassTransactionPayload;
 
@@ -159,5 +162,68 @@ public class ZWaveNodeTest {
                 .processCommand(new ZWaveCommandClassPayload(supervisionMoreUpdates));
         assertNotNull(responseMoreUpdates);
         assertTrue(eventCaptor.getAllValues().isEmpty());
+    }
+
+    @Test
+    public void testSupervisionTerminalFailTriggersDelayedPollFallback() {
+        ZWaveController controller = Mockito.mock(ZWaveController.class);
+        ZWaveNode node = new ZWaveNode(1, 2, controller);
+
+        ArgumentCaptor<ZWaveEvent> eventCaptor = ArgumentCaptor.forClass(ZWaveEvent.class);
+        Mockito.doNothing().when(controller).notifyEventListeners(eventCaptor.capture());
+
+        ZWaveBinarySwitchCommandClass switchClass = new ZWaveBinarySwitchCommandClass(node, controller, null);
+        ZWaveSupervisionCommandClass supervisionClass = new ZWaveSupervisionCommandClass(node, controller, null);
+        node.addCommandClass(switchClass);
+        node.addCommandClass(supervisionClass);
+
+        ZWaveCommandClassTransactionPayload setTransaction = switchClass.setValueMessage(0xFF);
+        ZWaveCommandClassTransactionPayload supervisedTransaction = node.encapsulate(setTransaction, 0);
+        assertNotNull(supervisedTransaction);
+
+        int sessionId = supervisedTransaction.getPayloadByte(2) & 0x3F;
+        byte[] supervisionFail = new byte[] { 0x6C, 0x02, (byte) (sessionId & 0x3F), 0x02, 0x00 };
+
+        List<ZWaveCommandClassPayload> response = node.processCommand(new ZWaveCommandClassPayload(supervisionFail));
+        assertNotNull(response);
+
+        List<ZWaveEvent> events = eventCaptor.getAllValues();
+        assertEquals(1, events.size());
+        assertTrue(events.get(0) instanceof ZWaveDelayedPollEvent);
+    }
+
+    @Test
+    public void testSupervisionWorkingDurationExtendsPendingExpiry() throws Exception {
+        ZWaveController controller = Mockito.mock(ZWaveController.class);
+        ZWaveNode node = new ZWaveNode(1, 2, controller);
+
+        ZWaveBinarySwitchCommandClass switchClass = new ZWaveBinarySwitchCommandClass(node, controller, null);
+        ZWaveSupervisionCommandClass supervisionClass = new ZWaveSupervisionCommandClass(node, controller, null);
+        node.addCommandClass(switchClass);
+        node.addCommandClass(supervisionClass);
+
+        ZWaveCommandClassTransactionPayload setTransaction = switchClass.setValueMessage(0xFF);
+        ZWaveCommandClassTransactionPayload supervisedTransaction = node.encapsulate(setTransaction, 0);
+        assertNotNull(supervisedTransaction);
+
+        int sessionId = supervisedTransaction.getPayloadByte(2) & 0x3F;
+
+        Field pendingField = ZWaveNode.class.getDeclaredField("pendingSupervisionCommands");
+        pendingField.setAccessible(true);
+        Map<Integer, Object> pendingMap = (Map<Integer, Object>) pendingField.get(node);
+        Object pending = pendingMap.get(sessionId);
+        assertNotNull(pending);
+
+        Field expiresField = pending.getClass().getDeclaredField("expiresAtMillis");
+        expiresField.setAccessible(true);
+        long expiresBefore = (long) expiresField.get(pending);
+
+        // 0x81 means about 2 minutes in Z-Wave duration format.
+        byte[] supervisionWorking = new byte[] { 0x6C, 0x02, (byte) (sessionId & 0x3F), 0x01, (byte) 0x81 };
+        List<ZWaveCommandClassPayload> response = node.processCommand(new ZWaveCommandClassPayload(supervisionWorking));
+        assertNotNull(response);
+
+        long expiresAfter = (long) expiresField.get(pending);
+        assertTrue(expiresAfter > expiresBefore);
     }
 }


### PR DESCRIPTION
Implement COMMAND_CLASS_SUPERVISION support by wiring a new Supervision command class, registering it in the command class map, and adding node-level session tracking for supervised transactions. Binary Switch Set commands are now selectively encapsulated and replayed as value events on successful supervision reports, while command polling is skipped when supervision is used; tests cover supervision replay behavior and poll suppression.